### PR TITLE
Avoid zombie child processes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ chrono = "0.4.10"
 futures = "0.1.29"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 nix = "0.15"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ liquid = "0.19.0"
 chrono = "0.4.10"
 futures = "0.1.29"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
+nix = "0.15"

--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -7,12 +7,16 @@ use leftwm::*;
 use log::*;
 use std::panic;
 use std::sync::Once;
+use nix::sys::signal::{self, SigHandler, Signal};
 
 fn get_events<T: DisplayServer>(ds: &mut T) -> Vec<DisplayEvent> {
     ds.get_next_events()
 }
 
 fn main() {
+    // Avoid zombies, by ignoring SIGCHLD
+    unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigIgn) }.unwrap();
+
     match Logger::with_env_or_str("leftwm-worker=info, leftwm=info")
         .log_to_file()
         .directory("/tmp/leftwm")

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -5,11 +5,13 @@ use std::process::Command;
 use nix::sys::signal::{self, SigHandler, Signal};
 
 fn main() {
-    // Avoid zombies, by ignoring SIGCHLD
-    unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigIgn) }.unwrap();
     if let Ok(booter) = std::env::current_exe() {
+        // Avoid zombies, by ignoring SIGCHLD
+        unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigIgn) }.unwrap();
         //boot everything in ~/.config/autostart
         Nanny::new().autostart();
+        // Restore default handler before leftwm-worker handover
+        unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigDfl) }.unwrap();
 
         //Fix for JAVA apps so they repaint correctly
         env::set_var("_JAVA_AWT_WM_NONREPARENTING", "1");

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -2,8 +2,11 @@ extern crate leftwm;
 use leftwm::child_process::Nanny;
 use std::env;
 use std::process::Command;
+use nix::sys::signal::{self, SigHandler, Signal};
 
 fn main() {
+    // Avoid zombies, by ignoring SIGCHLD
+    unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigIgn) }.unwrap();
     if let Ok(booter) = std::env::current_exe() {
         //boot everything in ~/.config/autostart
         Nanny::new().autostart();


### PR DESCRIPTION
We have two processes that `Command::new` but do not take care of waiting
for child processes. We can either call wait or let the kernel know that
we don't care by ignoring `SIGCHLD`. If we don't do this, any child
process will turn into a zombie that will consume resources and litter
the process tree.

The solution uses `nix::sys::signal` unconditionally, since leftwm is
an X11 wm, and it's reasonable to assume a suitable `nix::sys`
environment.