### PR TITLE
Add a GridHorizontal layout, which splits the workspace into an even NxN grid (or as close as it can get)

### DIFF
--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -25,6 +25,7 @@ impl Clone for Box<Layout> {
 pub fn get_all_layouts() -> VecDeque<Box<Layout>> {
     let mut layouts = VecDeque::new();
     layouts.push_back(Box::new(MainAndVertStack) as Box<Layout>);
+    layouts.push_back(Box::new(GridHorizontal) as Box<Layout>);
     layouts.push_back(Box::new(EvenHorizontal) as Box<Layout>);
     layouts.push_back(Box::new(EvenVertical) as Box<Layout>);
     layouts
@@ -103,6 +104,54 @@ impl Layout for MainAndVertStack {
             w.set_x(workspace.x() + width);
             w.set_y(workspace.y() + y);
             y += height;
+        }
+    }
+}
+
+/// Layout which splits the workspace into N columns, and then splits each column into rows.
+/// Example arrangement (4 windows):
+/// ```
+/// +---+---+
+/// |   |   |
+/// +---+---+
+/// |   |   |
+/// +---+---+
+/// ```
+/// or with 8 windows:
+/// ```
+/// +---+---+---+
+/// |   |   |   |
+/// |   +---+---+
+/// +---+   |   |
+/// |   +---+---+
+/// |   |   |   |
+/// +---+---+---+
+/// ```
+#[derive(Clone, Debug)]
+pub struct GridHorizontal;
+impl Layout for GridHorizontal {
+    fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
+        let window_count = windows.len() as i32;
+
+        // choose the number of columns so that we get close to an even NxN grid.
+        let num_cols = (window_count as f32).sqrt().ceil() as i32;
+
+        let mut iter = windows.iter_mut().enumerate().peekable();
+        for col in 0..num_cols {
+            let remaining_windows = window_count - iter.peek().unwrap().0 as i32;
+            let remaining_columns = num_cols - col;
+            let num_rows_in_this_col = remaining_windows / remaining_columns;
+
+            let win_height = workspace.height() / num_rows_in_this_col;
+            let win_width = workspace.width() / num_cols;
+
+            for row in 0..num_rows_in_this_col {
+                let (_idx, win) = iter.next().unwrap();
+                win.set_height(win_height);
+                win.set_width(win_width);
+                win.set_x(workspace.x() + win_width * col);
+                win.set_y(workspace.y() + win_height * row);
+            }
         }
     }
 }

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -24,14 +24,15 @@ impl Clone for Box<Layout> {
 
 pub fn get_all_layouts() -> VecDeque<Box<Layout>> {
     let mut layouts = VecDeque::new();
-    layouts.push_back(Box::new(MainAndVertStack {}) as Box<Layout>);
-    layouts.push_back(Box::new(EvenHorizontal {}) as Box<Layout>);
-    layouts.push_back(Box::new(EvenVertical {}) as Box<Layout>);
+    layouts.push_back(Box::new(MainAndVertStack) as Box<Layout>);
+    layouts.push_back(Box::new(EvenHorizontal) as Box<Layout>);
+    layouts.push_back(Box::new(EvenVertical) as Box<Layout>);
     layouts
 }
 
+/// Layout which gives each window full height, but splits the workspace width among them all.
 #[derive(Clone, Debug)]
-pub struct EvenHorizontal {}
+pub struct EvenHorizontal;
 impl Layout for EvenHorizontal {
     fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         let width_f = workspace.width() as f32 / windows.len() as f32;
@@ -47,8 +48,9 @@ impl Layout for EvenHorizontal {
     }
 }
 
+/// Layout which gives each window full width, but splits the workspace height among them all.
 #[derive(Clone, Debug)]
-pub struct EvenVertical {}
+pub struct EvenVertical;
 impl Layout for EvenVertical {
     fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         let height_f = workspace.height() as f32 / windows.len() as f32;
@@ -64,8 +66,10 @@ impl Layout for EvenVertical {
     }
 }
 
+/// Layout which splits the workspace into two columns, gives one window all of the left column,
+/// and divides the right column among all the other windows.
 #[derive(Clone, Debug)]
-pub struct MainAndVertStack {}
+pub struct MainAndVertStack;
 impl Layout for MainAndVertStack {
     fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         let window_count = windows.len();


### PR DESCRIPTION
I find this particularly useful when editing many files. It gives each window in the workspace the same width by arranging them into a number of columns, and then splits each column into so many rows.

Here's what it looks like with 5 windows:
![leftwm-5-windows](https://user-images.githubusercontent.com/1210751/69389990-8da67680-0c82-11ea-9ef4-578f521451da.png)

And with 9 windows:
![leftwm-9-windows](https://user-images.githubusercontent.com/1210751/69389999-939c5780-0c82-11ea-8e82-55c8a2e89acf.png)

I also added some documentation & changed the other Layout structs to use a simpler syntax (no braces). I kept those style changes in their own commit though so that it should be easy to not merge them if you don't like it.

------
Thanks for making this window manager! I started using it just a few hours ago and I'm really loving how intuitive the default bindings are and how easy it is to get started with.