### PR TITLE
Fix #89: close window leaving zombies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,9 +457,11 @@ dependencies = [
  "futures",
  "liquid",
  "log",
+ "nix",
  "serde",
  "serde_derive",
  "serde_json",
+ "signal-hook",
  "slog",
  "slog-async",
  "slog-envlogger",
@@ -669,6 +677,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -1029,6 +1050,26 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+dependencies = [
+ "arc-swap",
+ "libc",
 ]
 
 [[package]]
@@ -1476,6 +1517,12 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ name = "leftwm"
 path = "src/lib.rs"
 
 [dependencies]
+signal-hook = "0.1.15"
+nix = "0.17.0"
 x11-dl = "2.18.4"
 xdg = "2.2.0"
 toml = "0.5.5"

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -35,7 +35,8 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
                 .arg(&val.unwrap())
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
-                .spawn();
+                .spawn()
+                .map(|child| manager.children.insert(child));
             false
         }
 
@@ -272,8 +273,7 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
         Command::SoftReload => {
             manager.soft_reload();
             false
-
-        },
+        }
         Command::HardReload => {
             manager.hard_reload();
             false

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -61,7 +61,8 @@ pub fn created(manager: &mut Manager, mut window: Window) -> bool {
             .arg(&cmd)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .spawn();
+            .spawn()
+            .map(|child| manager.children.insert(child));
     }
 
     true

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -1,4 +1,3 @@
-use crate::state;
 use crate::config::ThemeSetting;
 use crate::display_action::DisplayAction;
 use crate::models::Mode;
@@ -6,10 +5,13 @@ use crate::models::Screen;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use crate::models::Workspace;
+use crate::state;
+use crate::utils::child_process::Children;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::sync::{atomic::AtomicBool, Arc};
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug)]
 pub struct Manager {
     pub screens: Vec<Screen>,
     pub windows: Vec<Window>,
@@ -21,6 +23,10 @@ pub struct Manager {
     pub focused_window_history: VecDeque<WindowHandle>,
     pub focused_tag_history: VecDeque<String>,
     pub actions: VecDeque<DisplayAction>,
+    #[serde(skip)]
+    pub children: Children,
+    #[serde(skip)]
+    pub reap_requested: Arc<AtomicBool>,
     #[serde(skip)]
     pub reload_requested: bool,
 }

--- a/src/utils/child_process.rs
+++ b/src/utils/child_process.rs
@@ -1,9 +1,12 @@
 use crate::errors::Result;
 use dirs;
+use std::collections::HashMap;
 use std::fs;
 use std::io;
+use std::iter::{Extend, FromIterator};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::{atomic::AtomicBool, Arc};
 use xdg::BaseDirectories;
 
 pub struct Nanny {}
@@ -13,12 +16,13 @@ impl Default for Nanny {
         Self::new()
     }
 }
+
 impl Nanny {
     pub fn new() -> Nanny {
         Nanny {}
     }
 
-    pub fn autostart(&self) {
+    pub fn autostart(&self) -> Children {
         dirs::home_dir()
             .and_then(|mut path| {
                 path.push(".config");
@@ -26,15 +30,16 @@ impl Nanny {
                 Some(path)
             })
             .and_then(|path| list_desktop_files(&path).ok())
-            .and_then(|files| {
-                files.iter().for_each(|file| {
-                    let _ = boot_desktop_file(&file);
-                });
-                Some(files)
-            });
+            .map(|files| {
+                files
+                    .iter()
+                    .filter_map(|file| boot_desktop_file(&file).ok())
+                    .collect::<Children>()
+            })
+            .unwrap_or_default()
     }
 
-    pub fn boot_current_theme(&self) -> Result<()> {
+    pub fn boot_current_theme(&self) -> Result<Option<Child>> {
         let mut path = BaseDirectories::with_prefix("leftwm")?.create_config_directory("")?;
         path.push("themes");
         path.push("current");
@@ -43,13 +48,16 @@ impl Nanny {
             Command::new(&path)
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
-                .spawn()?;
+                .spawn()
+                .map(Some)
+                .map_err(|e| e.into())
+        } else {
+            Ok(None)
         }
-        Ok(())
     }
 }
 
-fn boot_desktop_file(path: &PathBuf) -> std::result::Result<std::process::Child, std::io::Error> {
+fn boot_desktop_file(path: &PathBuf) -> std::io::Result<Child> {
     let args = format!( "`grep '^Exec' {:?} | tail -1 | sed 's/^Exec=//' | sed 's/%.//' | sed 's/^\"//g' | sed 's/\" *$//g'`", path );
     Command::new("sh").arg("-c").arg(args).spawn()
 }
@@ -71,4 +79,69 @@ fn list_desktop_files(dir: &Path) -> io::Result<Vec<PathBuf>> {
         }
     }
     Ok(list)
+}
+
+/// A struct managing children processes.
+///
+/// The `reap` method could be called at any place the user wants to.
+/// `register_child_hook` provides a hook that sets a flag. User may use the
+/// flag to do a epoch-based reaping.
+#[derive(Debug, Default)]
+pub struct Children {
+    inner: HashMap<u32, Child>,
+}
+
+impl Children {
+    pub fn new() -> Children {
+        Default::default()
+    }
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+    /// Insert a `Child` in the `Children`.
+    /// If this `Children` did not have this value present, true is returned.
+    /// If this `Children` did have this value present, false is returned.
+    pub fn insert(&mut self, child: Child) -> bool {
+        // Not possible to have duplication!
+        self.inner.insert(child.id(), child).is_none()
+    }
+    /// Merge another `Children` into this `Children`.
+    pub fn merge(&mut self, reaper: Children) {
+        self.inner.extend(reaper.inner.into_iter())
+    }
+    /// Try reaping all the children processes managed by this struct.
+    pub fn reap(&mut self) {
+        // The `try_wait` needs `child` to be `mut`, but only `HashMap::retain`
+        // allows modifying the value. Here `id` is not needed.
+        self.inner
+            .retain(|_, child| child.try_wait().map_or(true, |ret| ret.is_none()))
+    }
+}
+
+impl FromIterator<Child> for Children {
+    fn from_iter<T: IntoIterator<Item = Child>>(iter: T) -> Self {
+        Self {
+            inner: iter
+                .into_iter()
+                .map(|child| (child.id(), child))
+                .collect::<HashMap<_, _>>(),
+        }
+    }
+}
+
+impl Extend<Child> for Children {
+    fn extend<T: IntoIterator<Item = Child>>(&mut self, iter: T) {
+        self.inner
+            .extend(iter.into_iter().map(|child| (child.id(), child)))
+    }
+}
+
+/// Register the `SIGCHLD` signal handler. Once the signal is received,
+/// the flag will be set true. User needs to manually clear the flag.
+pub fn register_child_hook(flag: Arc<AtomicBool>) {
+    let _ = signal_hook::flag::register(signal_hook::SIGCHLD, flag)
+        .map_err(|err| log::error!("Cannot register SIGCHLD signal handler: {:?}", err));
 }


### PR DESCRIPTION
Collect all `Child`s in to a `Children` struct and use `SIGCHLD` signal handler. Reap zombies in every `event_loop` epoch.

Before this commit, `ps auxf` gives:
```
leftwm
 \_ [dropbox] <defunct>
 \_ /usr/bin/leftwm-worker
     \_ [up] <defunct>
     \_ [alacritty] <defunct>
     \_ [alacritty] <defunct>
     \_ [alacritty] <defunct>
     \_ [rofi] <defunct>
```
After this commit, it's like:
```
leftwm
 \_ /usr/bin/leftwm-worker
     \_ alacritty
         \_ ...
```