### PR TITLE
Removed giant if block in xatom module and replaced it with match statement

### DIFF
--- a/src/display_servers/xlib_display_server/xatom.rs
+++ b/src/display_servers/xlib_display_server/xatom.rs
@@ -90,99 +90,39 @@ impl XAtom {
     }
 
     pub fn get_name(&self, atom: xlib::Atom) -> &str {
-        if atom == self.WMProtocols {
-            return "WM_PROTOCOLS";
+        match atom {
+            self.WMProtocols => "WM_PROTOCOLS",
+            self.WMDelete => "WM_DELETE_WINDOW",
+            self.WMState => "WM_STATE",
+            self.WMTakeFocus => "WM_TAKE_FOCUS",
+            self.NetActiveWindow => "_NET_ACTIVE_WINDOW",
+            self.NetSupported => "_NET_SUPPORTED",
+            self.NetWMName => "_NET_WM_NAME",
+            self.NetWMState => "_NET_WM_STATE",
+            self.NetWMStateModal => "NetWMStateModal",
+            self.NetWMStateSticky => "NetWMStateSticky",
+            self.NetWMStateMaximizedVert => "NetWMStateMaximizedVert",
+            self.NetWMStateMaximizedHorz => "NetWMStateMaximizedHorz",
+            self.NetWMStateShaded => "NetWMStateShaded",
+            self.NetWMStateSkipTaskbar => "NetWMStateSkipTaskbar",
+            self.NetWMStateSkipPager => "NetWMStateSkipPager",
+            self.NetWMStateHidden => "NetWMStateHidden",
+            self.NetWMStateFullscreen => "NetWMStateFullscreen",
+            self.NetWMStateAbove => "NetWMStateAbove",
+            self.NetWMStateBelow => "NetWMStateBelow",
+            self.NetWMWindowType => "_NET_WM_WINDOW_TYPE",
+            self.NetWMWindowTypeDialog => "_NET_WM_WINDOW_TYPE_DIALOG",
+            self.NetWMWindowTypeDock => "_NET_WM_WINDOW_TYPE_DOCK",
+            self.NetClientList => "_NET_CLIENT_LIST",
+            self.NetDesktopViewport => "_NET_DESKTOP_VIEWPORT",
+            self.NetNumberOfDesktops => "_NET_NUMBER_OF_DESKTOPS",
+            self.NetCurrentDesktop => "_NET_CURRENT_DESKTOP",
+            self.NetDesktopNames => "_NET_DESKTOP_NAMES",
+            self.NetWMDesktop => "_NET_WM_DESKTOP",
+            self.NetWMStrutPartial => "_NET_WM_STRUT_PARTIAL",
+            self.NetWMStrut => "_NET_WM_STRUT",
+            _ => "(UNKNOWN)"
         }
-        if atom == self.WMDelete {
-            return "WM_DELETE_WINDOW";
-        }
-        if atom == self.WMState {
-            return "WM_STATE";
-        }
-        if atom == self.WMTakeFocus {
-            return "WM_TAKE_FOCUS";
-        }
-        if atom == self.NetActiveWindow {
-            return "_NET_ACTIVE_WINDOW";
-        }
-        if atom == self.NetSupported {
-            return "_NET_SUPPORTED";
-        }
-        if atom == self.NetWMName {
-            return "_NET_WM_NAME";
-        }
-        if atom == self.NetWMState {
-            return "_NET_WM_STATE";
-        }
-
-        if atom == self.NetWMStateModal {
-            return "NetWMStateModal";
-        }
-        if atom == self.NetWMStateSticky {
-            return "NetWMStateSticky";
-        }
-        if atom == self.NetWMStateMaximizedVert {
-            return "NetWMStateMaximizedVert";
-        }
-        if atom == self.NetWMStateMaximizedHorz {
-            return "NetWMStateMaximizedHorz";
-        }
-        if atom == self.NetWMStateShaded {
-            return "NetWMStateShaded";
-        }
-        if atom == self.NetWMStateSkipTaskbar {
-            return "NetWMStateSkipTaskbar";
-        }
-        if atom == self.NetWMStateSkipPager {
-            return "NetWMStateSkipPager";
-        }
-        if atom == self.NetWMStateHidden {
-            return "NetWMStateHidden";
-        }
-        if atom == self.NetWMStateFullscreen {
-            return "NetWMStateFullscreen";
-        }
-        if atom == self.NetWMStateAbove {
-            return "NetWMStateAbove";
-        }
-        if atom == self.NetWMStateBelow {
-            return "NetWMStateBelow";
-        }
-
-        if atom == self.NetWMWindowType {
-            return "_NET_WM_WINDOW_TYPE";
-        }
-        if atom == self.NetWMWindowTypeDialog {
-            return "_NET_WM_WINDOW_TYPE_DIALOG";
-        }
-        if atom == self.NetWMWindowTypeDock {
-            return "_NET_WM_WINDOW_TYPE_DOCK";
-        }
-        if atom == self.NetClientList {
-            return "_NET_CLIENT_LIST";
-        }
-        if atom == self.NetDesktopViewport {
-            return "_NET_DESKTOP_VIEWPORT";
-        }
-        if atom == self.NetNumberOfDesktops {
-            return "_NET_NUMBER_OF_DESKTOPS";
-        }
-        if atom == self.NetCurrentDesktop {
-            return "_NET_CURRENT_DESKTOP";
-        }
-        if atom == self.NetDesktopNames {
-            return "_NET_DESKTOP_NAMES";
-        }
-        if atom == self.NetWMDesktop {
-            return "_NET_WM_DESKTOP";
-        }
-        if atom == self.NetWMStrutPartial {
-            return "_NET_WM_STRUT_PARTIAL";
-        }
-        if atom == self.NetWMStrut {
-            return "_NET_WM_STRUT";
-        }
-        "(UNKNOWN)"
     }
 
     pub fn new(xlib: &xlib::Xlib, dpy: *mut xlib::Display) -> XAtom {


### PR DESCRIPTION
Just ran across this if block when looking at x server related modules for reference for another project and saw this massive if block and thought it would be a harmless pr if I changed it to a match, so that the wm doesn't have to go through all those checks for checking the atom.