### PR TITLE
New Command: master toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Mod + W => switch the desktops for each screen. Desktops [1][2] changes to [2][1
 Mod + Shift + W => move window to the other desktop
 Mod + (⬆️⬇️) => Focus the different windows in the current workspace
 Mod + Shift + (⬆️⬇️) => Move the different windows in the current workspace
+Mod + Enter => Move selected window to the top of the stack in the current workspace
 Mod + Ctrl + (⬆️⬇️) => Switch between different layouts
 Mod + Shift + (⬅➡) => Switch between different workspaces
 Mod + Shift + Enter => open a terminal

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,6 +10,7 @@ pub enum Command {
     GotoTag,
     MoveWindowUp,
     MoveWindowDown,
+    MoveWindowMaster,
     FocusNextTag,
     FocusPreviousTag,
     FocusWindowUp,

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,7 +10,7 @@ pub enum Command {
     GotoTag,
     MoveWindowUp,
     MoveWindowDown,
-    MoveWindowMaster,
+    MoveWindowTop,
     FocusNextTag,
     FocusPreviousTag,
     FocusWindowUp,

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,12 @@ impl Default for Config {
                 key: "Down".to_owned(),
             },
             Keybind {
+                command: Command::MoveWindowTop,
+                value: None,
+                modifier: vec!["modkey".to_owned()],
+                key: "Return".to_owned(),
+            },
+            Keybind {
                 command: Command::FocusWindowUp,
                 value: None,
                 modifier: vec!["modkey".to_owned()],

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -205,7 +205,13 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
                 }
             };
             list.remove(index);
-            let mut new_index = 0;
+            let mut new_index: i32;
+            match index {
+                0 => new_index = 1,
+                _ => {
+                    new_index = 0;
+                }
+            }
             if new_index < 0 {
                 new_index += len
             }
@@ -213,6 +219,7 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
                 new_index -= len
             }
             list.insert(new_index as usize, item);
+
             // set first in line
             manager.windows.append(&mut to_reorder);
             let act = DisplayAction::MoveMouseOver(handle);

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -175,7 +175,8 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             manager.actions.push_back(act);
             true
         }
-
+        // Moves the selected window at index 0 of the window list.
+        // If the selected window is already at index 0, it is sent to index 1.
         Command::MoveWindowTop => {
             let handle = match manager.focused_window() {
                 Some(h) => h.handle.clone(),

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -222,8 +222,11 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
 
             // set first in line
             manager.windows.append(&mut to_reorder);
-            let act = DisplayAction::MoveMouseOver(handle);
-            manager.actions.push_back(act);
+            // focus follows the window only if it was not on the master
+            if index > 0 {
+                let act = DisplayAction::MoveMouseOver(handle);
+                manager.actions.push_back(act);
+            }
             true
         }
 

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -176,7 +176,7 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             true
         }
 
-        Command::MoveWindowMaster => {
+        Command::MoveWindowTop => {
             let handle = match manager.focused_window() {
                 Some(h) => h.handle.clone(),
                 _ => {
@@ -194,8 +194,6 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             };
             let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
             let is_handle = |x: &Window| -> bool { x.handle == handle };
-            // helpers::reorder_vec(&mut to_reorder, is_handle, -3);
-            // set first in line
             let list = &mut to_reorder;
             let len = list.len() as i32;
             let (index, item) = match list.iter().enumerate().find(|&x| is_handle(&x.1)) {
@@ -220,9 +218,8 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             }
             list.insert(new_index as usize, item);
 
-            // set first in line
             manager.windows.append(&mut to_reorder);
-            // focus follows the window only if it was not on the master
+            // focus follows the window if it was not already on top of the stack
             if index > 0 {
                 let act = DisplayAction::MoveMouseOver(handle);
                 manager.actions.push_back(act);

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -176,6 +176,50 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             true
         }
 
+        Command::MoveWindowMaster => {
+            let handle = match manager.focused_window() {
+                Some(h) => h.handle.clone(),
+                _ => {
+                    return false;
+                }
+            };
+            let tags = match manager.focused_workspace() {
+                Some(w) => w.tags.clone(),
+                _ => {
+                    return false;
+                }
+            };
+            let for_active_workspace = |x: &Window| -> bool {
+                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
+            };
+            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+            let is_handle = |x: &Window| -> bool { x.handle == handle };
+            // helpers::reorder_vec(&mut to_reorder, is_handle, -3);
+            // set first in line
+            let list = &mut to_reorder;
+            let len = list.len() as i32;
+            let (index, item) = match list.iter().enumerate().find(|&x| is_handle(&x.1)) {
+                Some(x) => (x.0, x.1.clone()),
+                None => {
+                    return false;
+                }
+            };
+            list.remove(index);
+            let mut new_index = 0;
+            if new_index < 0 {
+                new_index += len
+            }
+            if new_index >= len {
+                new_index -= len
+            }
+            list.insert(new_index as usize, item);
+            // set first in line
+            manager.windows.append(&mut to_reorder);
+            let act = DisplayAction::MoveMouseOver(handle);
+            manager.actions.push_back(act);
+            true
+        }
+
         Command::FocusWindowUp => {
             let handle = match manager.focused_window() {
                 Some(h) => h.handle.clone(),

--- a/src/utils/command_pipe.rs
+++ b/src/utils/command_pipe.rs
@@ -104,6 +104,8 @@ fn parse_command(s: String) -> std::result::Result<ExternalCommand, ()> {
         return Ok(ExternalCommand::MoveWindowDown);
     } else if s.starts_with("FocusWindowUp") {
         return Ok(ExternalCommand::FocusWindowUp);
+    } else if s.starts_with("MoveWindowTop") {
+        return Ok(ExternalCommand::MoveWindowTop);
     } else if s.starts_with("FocusWindowDown") {
         return Ok(ExternalCommand::FocusWindowDown);
     } else if s.starts_with("FocusNextTag") {
@@ -194,6 +196,7 @@ pub enum ExternalCommand {
     MoveWindowToLastWorkspace,
     MoveWindowUp,
     MoveWindowDown,
+    MoveWindowTop,
     FocusWindowUp,
     FocusWindowDown,
     FocusNextTag,


### PR DESCRIPTION
This pull request adds a command that sends the current active window to the top of the stack. However, if the window is already on top of the stack, it sends it to second position.

By default, this would be mapped to `mod+enter`.