### PR TITLE
Show which tags has windows in leftwm-state

### DIFF
--- a/src/models/dto.rs
+++ b/src/models/dto.rs
@@ -112,8 +112,14 @@ impl From<&Manager> for ManagerState {
         let working_tags = manager
             .tags
             .iter()
-            .filter(|tag| manager.windows.iter().any(|w| w.has_tag(tag.to_string())))
-            .map(|tag| tag.clone())
+            .filter(|tag| {
+                manager
+                    .windows
+                    .iter()
+                    .filter(|w| !(w.is_fullscreen() || w.floating()))
+                    .any(|w| w.has_tag(tag.to_string()))
+            })
+            .cloned()
             .collect();
         for ws in &manager.workspaces {
             viewports.push(Viewport {


### PR DESCRIPTION
### Description
Xmonad differentiates between tags that are not visible and tags that are not visible _and_ have windows. This is useful info to communicate to a status bar, so that the user doesn't forget about windows hanging around in hidden tags. For instance:

![image](https://user-images.githubusercontent.com/46683255/100174989-d7e1b980-2ecd-11eb-9251-846b2df2b59e.png)

where **[3]** is a tag in the current workspace, **1** is a tag in another visible workspace (another monitor in this case) and **2** is a tag that it is not visible but has windows in it. The rest are not visible and are empty of windows.
<details><summary> Using this template </summary>

```vue
{% for tag in workspace.tags %}
{% if tag.mine %}
%{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
%{F#D19A66}%{B#455A64} [ {{tag.name}} ] %{B-}%{F-}
%{A}
{% elsif tag.visible  %}
%{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
%{B#282A36}%{F#D19A66}   {{tag.name}}   %{B-}%{F-}
%{A}
{% elsif tag.busy %}
%{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
%{B#282A36}%{F#f7f7f7}   {{tag.name}}   %{B-}%{F-}
%{A}
{% else tag.visible  %}
%{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
%{F#546e7a}   {{tag.name}}   %{F-}
%{A}
{% endif %}
{% endfor %}
%{c}

{{ window_title }}
```
</details>

### Implementation
- Add a `working_tags: Vec<String>` field to `ManagerState` that contains the name of tags that are busy.
- Add a `busy: bool` field to `TagsForWorkspace`, true if tag has windows and determined based on the introduced`ManagerState.working_tags`.