### PR TITLE
Do not move Dock on the top of the stack

### DIFF
--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -49,8 +49,10 @@ pub fn created(manager: &mut Manager, mut window: Window) -> bool {
     }
 
     //new windows should be on the top of the stack
-    let act = DisplayAction::MoveToTop(window.handle.clone());
-    manager.actions.push_back(act);
+    if window.type_ != WindowType::Dock {
+        let act = DisplayAction::MoveToTop(window.handle.clone());
+        manager.actions.push_back(act);
+    }
 
     focus_handler::focus_window(manager, &window, window.x() + 1, window.y() + 1);
 

--- a/src/utils/state_socket.rs
+++ b/src/utils/state_socket.rs
@@ -81,7 +81,7 @@ impl StateSocket {
     pub fn write_manager_state(&mut self, manager: &Manager) -> Result<()> {
         let state: ManagerState = manager.into();
         let mut json = serde_json::to_string(&state)?;
-        json.push_str("\n");
+        json.push('\n');
         let mut lc = self.last_state.lock().unwrap();
         if json != *lc {
             if let Ok(server) = &self.server {


### PR DESCRIPTION
I guess moving Dock window to the top race with polybar re-stacking tray window: https://github.com/polybar/polybar/blob/1dc8d2f30e248d2ca186d7dcf2972c5111dc3fa2/src/x11/tray_manager.cpp#L581

I have no experience working with X, but in my case, it fixed the issue.

Fixes #138.