### PR TITLE
resize windows with keybinding

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -22,4 +22,6 @@ pub enum Command {
     MouseMoveWindow,
     NextLayout,
     PreviousLayout,
+    IncreaseMainWidth,
+    DecreaseMainWidth,
 }

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -362,6 +362,29 @@ pub fn process(manager: &mut Manager, command: Command, val: Option<String>) -> 
             manager.hard_reload();
             false
         }
+
+        Command::IncreaseMainWidth if val.is_none() => false,
+        Command::IncreaseMainWidth => {
+            let workspace = manager.focused_workspace_mut();
+            if workspace.is_none() {
+                return false;
+            }
+            let workspace = workspace.unwrap();
+            let delta: u8 = (&val.unwrap()).parse().unwrap();
+            workspace.increase_main_width(delta);
+            true
+        }
+        Command::DecreaseMainWidth if val.is_none() => false,
+        Command::DecreaseMainWidth => {
+            let workspace = manager.focused_workspace_mut();
+            if workspace.is_none() {
+                return false;
+            }
+            let workspace = workspace.unwrap();
+            let delta: u8 = (&val.unwrap()).parse().unwrap();
+            workspace.decrease_main_width(delta);
+            true
+        }
     }
 }
 

--- a/src/layouts/main_and_vert_stack.rs
+++ b/src/layouts/main_and_vert_stack.rs
@@ -11,7 +11,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
 
     let width = match window_count {
         1 => workspace.width() as i32,
-        _ => (workspace.width() as f32 / 2.0).floor() as i32,
+        _ => (workspace.width() as f32 / 100.0 * workspace.main_width()).floor() as i32,
     };
 
     //build build the main window.
@@ -31,7 +31,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
     let mut y = 0;
     for w in iter {
         w.set_height(height);
-        w.set_width(width);
+        w.set_width(workspace.width() - width);
         w.set_x(workspace.x() + width);
         w.set_y(workspace.y() + y);
         y += height;

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -16,6 +16,7 @@ pub struct Workspace {
     pub tags: Vec<Tag>,
     pub avoid: Vec<XYHW>,
     pub xyhw: XYHW,
+    pub main_width_percentage: u8,
     xyhw_avoided: XYHW,
 }
 
@@ -45,6 +46,7 @@ impl Workspace {
             layout: Layout::default(),
             tags: vec![],
             avoid: vec![],
+            main_width_percentage: 50,
 
             xyhw: XYHWBuilder {
                 h: bbox.height,
@@ -136,6 +138,23 @@ impl Workspace {
     }
     pub fn width(&self) -> i32 {
         self.xyhw_avoided.w()
+    }
+
+    pub fn increase_main_width(&mut self, delta: u8) {
+        self.main_width_percentage += delta;
+        if self.main_width_percentage > 100 {
+            self.main_width_percentage = 100
+        }
+    }
+    pub fn decrease_main_width(&mut self, delta: u8) {
+        if self.main_width_percentage > delta {
+            self.main_width_percentage -= delta;
+        } else {
+            self.main_width_percentage = 0;
+        }
+    }
+    pub fn main_width(&self) -> f32 {
+        self.main_width_percentage as f32
     }
 
     pub fn center_halfed(&self) -> XYHW {


### PR DESCRIPTION
this is my implementation to resize the main window using keybindings like in many other WMs as presented by @cjwyett in issue #144 (but only for the `main_and_vert_stack` layout for now)

although it does work as intended for me the PR is only meant as an idea as this is my first time modifying rust code and I probably violated many rust and/or leftwm concepts here and i'm not sure how the testing usually works with rust/leftwm

as a result of this code new keybindings can be used to change the size of the main window (for the one layout it was implemented for). The value represents width change as a percentage:

*[config.toml]*:
```
[[keybind]]
command = "IncreaseMainWidth"
value = "5"
modifier = ["modkey"]
key = "l"

[[keybind]]
command = "DecreaseMainWidth"
value = "5"
modifier = ["modkey"]
key = "h"
```