### PR TITLE
Spawn windows on parent terminal's workspace

### DIFF
--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -30,7 +30,8 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                     Ok(attr) if attr.override_redirect > 0 => None,
                     Ok(_attr) => {
                         let name = xw.get_window_name(event.window);
-                        let mut w = Window::new(handle, name);
+                        let pid = xw.get_cardinal_prop_value(event.window, xw.atoms.NetWMPid);
+                        let mut w = Window::new(handle, name, pid);
                         let trans = xw.get_transient_for(event.window);
 
                         if let Some(hint) = xw.get_hint_sizing_as_xyhw(event.window) {

--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -201,7 +201,8 @@ impl XlibDisplayServer {
                 };
                 if managed {
                     let name = self.xw.get_window_name(handle);
-                    let w = Window::new(WindowHandle::XlibHandle(handle), name);
+                    let pid = self.xw.get_cardinal_prop_value(handle, self.xw.atoms.NetWMPid);
+                    let w = Window::new(WindowHandle::XlibHandle(handle), name, pid);
                     all.push(w);
                 }
             }),

--- a/src/display_servers/xlib_display_server/xatom.rs
+++ b/src/display_servers/xlib_display_server/xatom.rs
@@ -48,6 +48,8 @@ pub struct XAtom {
     pub NetWMDesktop: xlib::Atom,
     pub NetWMStrutPartial: xlib::Atom, //net version - Reserve Screen Space
     pub NetWMStrut: xlib::Atom,        //old version
+
+    pub NetWMPid: xlib::Atom,
 }
 
 impl XAtom {
@@ -86,6 +88,7 @@ impl XAtom {
             self.NetWMDesktop,
             self.NetWMStrutPartial,
             self.NetWMStrut,
+            self.NetWMPid,
         ]
     }
 
@@ -182,6 +185,9 @@ impl XAtom {
         if atom == self.NetWMStrut {
             return "_NET_WM_STRUT";
         }
+        if atom == self.NetWMPid {
+            return "_NET_WM_PID"
+        }
         "(UNKNOWN)"
     }
 
@@ -227,6 +233,8 @@ impl XAtom {
             NetWMDesktop: from(xlib, dpy, "_NET_WM_DESKTOP"),
             NetWMStrutPartial: from(xlib, dpy, "_NET_WM_STRUT_PARTIAL"),
             NetWMStrut: from(xlib, dpy, "_NET_WM_STRUT"),
+
+            NetWMPid: from(xlib, dpy, "_NET_WM_PID"),
         }
     }
 }

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -15,7 +15,7 @@ use crate::models::XYHWChange;
 use crate::utils::xkeysym_lookup::ModMask;
 use crate::DisplayEvent;
 use std::ffi::CString;
-use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong};
+use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_void};
 use std::ptr;
 use std::slice;
 use x11_dl::xlib;
@@ -244,6 +244,41 @@ impl XWrap {
         Ok(attrs)
     }
 
+    pub fn get_cardinal_prop_value(
+        &self,
+        window: xlib::Window,
+        prop: xlib::Atom
+    ) -> Option<u32> {
+        let mut format_return: i32 = 0;
+        let mut nitems_return: c_ulong = 0;
+        let mut bytes_after: c_ulong = 0;
+        let mut type_return: xlib::Atom = 0;
+        let mut prop_return: *mut c_uchar = ptr::null_mut();
+        unsafe {
+            let status = (self.xlib.XGetWindowProperty)(
+                self.display,
+                window,
+                prop,
+                0,
+                1,
+                xlib::False,
+                xlib::XA_CARDINAL,
+                // Can these be null?
+                &mut type_return,
+                &mut format_return,
+                &mut nitems_return,
+                &mut bytes_after,
+                &mut prop_return,
+            );
+            if status == i32::from(xlib::Success) && !prop_return.is_null() {
+                let val = *(prop_return as *const u32);
+                (self.xlib.XFree)(prop_return as *mut c_void);
+                return Some(val);
+            }
+            None
+        }
+    }
+
     pub fn get_atom_prop_value(
         &self,
         window: xlib::Window,
@@ -271,6 +306,7 @@ impl XWrap {
             if status == i32::from(xlib::Success) && !prop_return.is_null() {
                 #[allow(clippy::cast_lossless, clippy::cast_ptr_alignment)]
                 let atom = *(prop_return as *const xlib::Atom);
+                (self.xlib.XFree)(prop_return as *mut c_void);
                 return Some(atom);
             }
             None

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -207,8 +207,8 @@ mod tests {
     fn focusing_a_window_should_make_it_active() {
         let mut manager = Manager::default();
         screen_create_handler::process(&mut manager, Screen::default());
-        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(1), None));
-        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(2), None));
+        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(1), None, None));
+        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(2), None, None));
         let expected = manager.windows[0].clone();
         focus_window(&mut manager, &expected, 0, 0);
         let actual = manager.focused_window().unwrap().handle.clone();
@@ -219,7 +219,7 @@ mod tests {
     fn focusing_the_same_window_shouldnt_add_to_the_history() {
         let mut manager = Manager::default();
         screen_create_handler::process(&mut manager, Screen::default());
-        let window = Window::new(WindowHandle::MockHandle(1), None);
+        let window = Window::new(WindowHandle::MockHandle(1), None, None);
         window_handler::created(&mut manager, window.clone());
         focus_window(&mut manager, &window, 0, 0);
         let start_length = manager.focused_workspace_history.len();
@@ -280,7 +280,7 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
-        let mut window = Window::new(WindowHandle::MockHandle(1), None);
+        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2".to_owned());
         focus_window(&mut manager, &window, 0, 0);
         let actual = manager.focused_tag().unwrap();
@@ -293,7 +293,7 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
-        let mut window = Window::new(WindowHandle::MockHandle(1), None);
+        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2".to_owned());
         focus_window(&mut manager, &window, 0, 0);
         let actual = manager.focused_workspace().unwrap().id.clone();

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -107,7 +107,7 @@ mod tests {
         ws.xyhw.set_minh(600);
         ws.xyhw.set_minw(800);
         ws.update_avoided_areas();
-        let mut w = Window::new(WindowHandle::MockHandle(1), None);
+        let mut w = Window::new(WindowHandle::MockHandle(1), None, None);
         w.border = 0;
         w.margin = 0;
         let mut windows = vec![&mut w];

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -33,10 +33,11 @@ pub struct Window {
     pub normal: XYHW,
     pub start_loc: Option<XYHW>,
     pub strut: Option<XYHW>,
+    pub pid: Option<u32>,
 }
 
 impl Window {
-    pub fn new(h: WindowHandle, name: Option<String>) -> Window {
+    pub fn new(h: WindowHandle, name: Option<String>, pid: Option<u32>) -> Window {
         Window {
             handle: h,
             transient: None,
@@ -54,6 +55,7 @@ impl Window {
             floating: None,
             start_loc: None,
             strut: None,
+            pid,
         }
     }
 
@@ -260,7 +262,7 @@ mod tests {
 
     #[test]
     fn should_be_able_to_tag_a_window() {
-        let mut subject = Window::new(WindowHandle::MockHandle(1), None);
+        let mut subject = Window::new(WindowHandle::MockHandle(1), None, None);
         subject.tag("test".to_string());
         assert!(
             subject.has_tag("test".to_string()),
@@ -270,7 +272,7 @@ mod tests {
 
     #[test]
     fn should_be_able_to_untag_a_window() {
-        let mut subject = Window::new(WindowHandle::MockHandle(1), None);
+        let mut subject = Window::new(WindowHandle::MockHandle(1), None, None);
         subject.tag("test".to_string());
         subject.untag("test".to_string());
         assert!(

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -198,7 +198,7 @@ mod tests {
             },
             vec![],
         );
-        let w = Window::new(WindowHandle::MockHandle(1), None);
+        let w = Window::new(WindowHandle::MockHandle(1), None, None);
         assert!(
             !subject.is_displaying(&w),
             "workspace incorrectly owns window"
@@ -218,7 +218,7 @@ mod tests {
         );
         let tag = crate::models::TagModel::new("test");
         subject.show_tag(tag);
-        let mut w = Window::new(WindowHandle::MockHandle(1), None);
+        let mut w = Window::new(WindowHandle::MockHandle(1), None, None);
         w.tag("test");
         assert!(subject.is_displaying(&w), "workspace should include window");
     }


### PR DESCRIPTION
I made this change for myself to ease development of apps that spawn windows - this way `cargo watch -x run` puts the window on the screen with the terminal that is building it instead of on the screen with my editor(s).

I'm curious whether or not this (or something similar) is of enough interest to get merged. If not that's perfectly understandable, it's a pretty specific feature.

The way it decides whether or not a window is a terminal right now is just checking against the name of a specific terminal... and probably shouldn't be merged. I suspect it's a problem that can't be solved generally, many popular terminal emulators are actually spawning all their windows from the same process - so I don't think we would be able to determine which window is actually responsible for spawning a process. On the other hand, we could at least make the names of the "terminal" processes configurable, and we might even be able to do something like detect processes with a single window and an open tty...