### PR TITLE
Bump versions on outdated packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,12 +214,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "3.0.1"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
@@ -229,7 +230,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.5",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.0",
  "winapi",
 ]
 
@@ -431,7 +443,7 @@ version = "0.2.7"
 dependencies = [
  "chrono",
  "clap",
- "dirs 3.0.1",
+ "dirs-next",
  "futures",
  "libc",
  "liquid",
@@ -869,6 +881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.2",
+ "redox_syscall 0.2.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,7 +1148,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs 2.0.2",
+ "dirs",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,12 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80115a2dfde04491e181c2440a39e4be26e52d9ca4e92bed213f65b94e0b8db1"
-
-[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,9 +306,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -393,17 +387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
 dependencies = [
  "either",
 ]
@@ -426,6 +409,15 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "kstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1167388385b43067bd74f967def6c93b969284f14f41e2ab6035b715d9343215"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "lazy_static"
@@ -481,84 +473,60 @@ dependencies = [
 
 [[package]]
 name = "liquid"
-version = "0.19.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cf7f28965f50ff06e2e9f26162f6d944b71f976506a7a01a6308ddebd36155"
+checksum = "3ebeca3e471d40ca4816a8f77cb2e89590275d9ba74da4acb37b267f6250b358"
 dependencies = [
- "chrono",
- "deunicode",
  "doc-comment",
- "itertools",
- "lazy_static",
- "liquid-compiler",
+ "kstring",
+ "liquid-core",
  "liquid-derive",
- "liquid-error",
- "liquid-interpreter",
- "liquid-value",
- "regex",
+ "liquid-lib",
  "serde",
- "unicode-segmentation",
- "url",
 ]
 
 [[package]]
-name = "liquid-compiler"
-version = "0.19.0"
+name = "liquid-core"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd195c00674a2dc811b07969358c97c0639db4a73bc61514db48609d110356f"
+checksum = "719573721a84bb8383be7e4f48337c78fcc2048778f780090d5ee5b6e0d6c66f"
 dependencies = [
+ "anymap",
+ "chrono",
  "itertools",
- "liquid-error",
- "liquid-interpreter",
- "liquid-value",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
  "pest",
  "pest_derive",
+ "serde",
 ]
 
 [[package]]
 name = "liquid-derive"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0faadd0dd1a7cf38390316c36a9a741949462750f9833b794ac6d7de145218"
+checksum = "d5ed0397fd0b3bd70965471955f4ff83d69515c6d58e09f735efd10f2084e7f1"
 dependencies = [
- "liquid-compiler",
- "liquid-error",
- "liquid-interpreter",
- "liquid-value",
- "proc-macro2 0.4.30",
+ "proc-macro2",
  "proc-quote",
- "syn 0.15.44",
+ "syn",
 ]
 
 [[package]]
-name = "liquid-error"
-version = "0.19.0"
+name = "liquid-lib"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5c0851812322e87dcf67c2d7e520c3efd8651bd44eb8d0c0246e6dfb94d481"
-
-[[package]]
-name = "liquid-interpreter"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998e0411b8cb6210bb0729ccbb15abd2a1c8ef7e318c97511ae5a741c817c63e"
-dependencies = [
- "anymap",
- "itertools",
- "liquid-error",
- "liquid-value",
-]
-
-[[package]]
-name = "liquid-value"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f56016187fb289186fccf44a9ae840f7b9ba35a04fd611e591aed2a1f53c265"
+checksum = "a4780544c8d62eb1881dffddfd82ffe23990a18cc952de27b570b910214543ac"
 dependencies = [
  "chrono",
  "itertools",
- "liquid-error",
- "num-traits",
- "serde",
+ "kstring",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -584,12 +552,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maybe-uninit"
@@ -715,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
@@ -746,9 +708,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -800,53 +762,35 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "proc-quote"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa612543f23fda013e1e6ce30b5285a9d313c6e582e57b4ceca74eb5b85685b5"
+checksum = "06ea4226882439d07839be9c7f683e13d6d69d9c2fe960d61f637d1e2fa4c081"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 0.4.30",
+ "proc-macro2",
  "proc-quote-impl",
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "proc-quote-impl"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f785f0f8cd00b7945efc3f3bdf8205eb06af5aacec598d83e67f41dc8d101fda"
+checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 0.4.30",
- "quote 0.6.13",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -855,7 +799,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -990,9 +934,9 @@ version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1147,24 +1091,13 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "unicode-xid 0.2.1",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1227,21 +1160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
 name = "tokio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,9 +1185,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.8",
- "syn 1.0.60",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1294,24 +1212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,26 +1225,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna",
- "matches",
- "percent-encoding",
-]
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libsystemd-sys"
@@ -563,11 +563,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -969,29 +969,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.120"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1d807cf71129b05ce36914e1dbb6fbfbdecaf686301cb457f4fa967f9f5b6"
+checksum = "c76d88c965d3c60da712ef89ba2bca3fd118ed6dead726a9b7153eaddd7a56b1"
 dependencies = [
  "atty",
  "chrono",
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
@@ -1200,11 +1200,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1235,9 +1235,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca04cec6ff2474c638057b65798f60ac183e5e79d3448bb7163d36a39cff6ec"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1255,13 +1255,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",
- "syn 1.0.58",
+ "syn 1.0.60",
 ]
 
 [[package]]
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,15 +628,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "void",
 ]
 
 [[package]]
@@ -1352,12 +1351,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,7 +439,7 @@ version = "0.2.7"
 dependencies = [
  "chrono",
  "clap",
- "dirs",
+ "dirs 3.0.1",
  "futures",
  "libc",
  "liquid",
@@ -1185,7 +1194,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 signal-hook = "0.1.15"
-nix = "0.17.0"
+nix = "0.19.1"
 x11-dl = "2.18.4"
 xdg = "2.2.0"
 toml = "0.5.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.8"
 dirs = "3.0.1"
 tokio = { version = "1", features = ["full"] }
 clap = "2.33.0"
-liquid = "0.19.0"
+liquid = "0.21.5"
 chrono = "0.4.10"
 futures = "0.3"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "leftwm"
 path = "src/lib.rs"
 
 [dependencies]
-signal-hook = "0.1.15"
+signal-hook = "0.3.4"
 nix = "0.19.1"
 x11-dl = "2.18.4"
 xdg = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.44"
 log = "0.4.8"
-dirs = "2.0.2"
+dirs = "3.0.1"
 tokio = { version = "1", features = ["full"] }
 clap = "2.33.0"
 liquid = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.44"
 log = "0.4.8"
-dirs = "3.0.1"
+dirs-next = "2.0.0"
 tokio = { version = "1", features = ["full"] }
 clap = "2.33.0"
 liquid = "0.21.5"

--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
 
     if let Some(template_file) = template_file {
         let template_str = fs::read_to_string(template_file).await?;
-        let template = liquid::ParserBuilder::with_liquid()
+        let template = liquid::ParserBuilder::with_stdlib()
             .build()
             .unwrap()
             .parse(&template_str)
@@ -99,24 +99,24 @@ fn template_handler(
     let globals = match ws_num {
         Some(ws_num) => {
             let json = serde_json::to_string(&display.workspaces[ws_num])?;
-            let workspace: liquid::value::Object = serde_json::from_str(&json)?;
-            let mut globals = liquid::value::Object::new();
+            let workspace: liquid::model::Object = serde_json::from_str(&json)?;
+            let mut globals = liquid::model::Object::new();
             globals.insert(
                 "window_title".into(),
-                liquid::value::Value::scalar(display.window_title),
+                liquid::model::value::Value::scalar(display.window_title),
             );
-            globals.insert("workspace".into(), liquid::value::Value::Object(workspace));
+            globals.insert("workspace".into(), liquid::model::value::Value::Object(workspace));
             //liquid only does time in utc. BUG: https://github.com/cobalt-org/liquid-rust/issues/332
             //as a workaround we are setting a time locally
             globals.insert(
                 "localtime".into(),
-                liquid::value::Value::scalar(get_localtime()),
+                liquid::model::value::Value::scalar(get_localtime()),
             );
             globals
         }
         None => {
             let json = serde_json::to_string(&display)?;
-            let globals: liquid::value::Object = serde_json::from_str(&json)?;
+            let globals: liquid::model::Object = serde_json::from_str(&json)?;
             globals
         }
     };

--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -105,7 +105,10 @@ fn template_handler(
                 "window_title".into(),
                 liquid::model::value::Value::scalar(display.window_title),
             );
-            globals.insert("workspace".into(), liquid::model::value::Value::Object(workspace));
+            globals.insert(
+                "workspace".into(),
+                liquid::model::value::Value::Object(workspace),
+            );
             //liquid only does time in utc. BUG: https://github.com/cobalt-org/liquid-rust/issues/332
             //as a workaround we are setting a time locally
             globals.insert(

--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -2,7 +2,7 @@ use crate::errors::Result;
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 #[serde(default)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -17,12 +17,12 @@ pub struct ThemeSetting {
 }
 
 impl ThemeSetting {
-    pub fn load(path: &PathBuf) -> ThemeSetting {
+    pub fn load(path: &Path) -> ThemeSetting {
         load_theme_file(path).unwrap_or_default()
     }
 }
 
-fn load_theme_file(path: &PathBuf) -> Result<ThemeSetting> {
+fn load_theme_file(path: &Path) -> Result<ThemeSetting> {
     let contents = fs::read_to_string(path)?;
     let from_file: ThemeSetting = toml::from_str(&contents)?;
     Ok(from_file)

--- a/src/utils/child_process.rs
+++ b/src/utils/child_process.rs
@@ -141,6 +141,6 @@ impl Extend<Child> for Children {
 /// Register the `SIGCHLD` signal handler. Once the signal is received,
 /// the flag will be set true. User needs to manually clear the flag.
 pub fn register_child_hook(flag: Arc<AtomicBool>) {
-    let _ = signal_hook::flag::register(signal_hook::SIGCHLD, flag)
+    let _ = signal_hook::flag::register(signal_hook::consts::signal::SIGCHLD, flag)
         .map_err(|err| log::error!("Cannot register SIGCHLD signal handler: {:?}", err));
 }

--- a/src/utils/child_process.rs
+++ b/src/utils/child_process.rs
@@ -22,7 +22,7 @@ impl Nanny {
     }
 
     pub fn autostart(&self) -> Children {
-        dirs::home_dir()
+        dirs_next::home_dir()
             .map(|mut path| {
                 path.push(".config");
                 path.push("autostart");
@@ -56,7 +56,7 @@ impl Nanny {
     }
 }
 
-fn boot_desktop_file(path: &PathBuf) -> std::io::Result<Child> {
+fn boot_desktop_file(path: &Path) -> std::io::Result<Child> {
     let args = format!( "`grep '^Exec' {:?} | tail -1 | sed 's/^Exec=//' | sed 's/%.//' | sed 's/^\"//g' | sed 's/\" *$//g'`", path );
     Command::new("sh").arg("-c").arg(args).spawn()
 }

--- a/src/utils/command_pipe.rs
+++ b/src/utils/command_pipe.rs
@@ -71,7 +71,7 @@ impl CommandPipe {
     }
 }
 
-async fn read_from_pipe(queue: &Queue, pipe_file: &PathBuf) -> Option<()> {
+async fn read_from_pipe(queue: &Queue, pipe_file: &Path) -> Option<()> {
     let file = fs::File::open(pipe_file).await.ok()?;
     let mut lines = BufReader::new(file).lines();
 


### PR DESCRIPTION
Good afternoon,

This PR updates the following:

- dirs
- nix
- signal-hook
- liquid

Additionally, `cargo audit` notes the following:
```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 239 security advisories (from /home/mautamu/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (140 crate dependencies)
     Success No vulnerable packages found

warning: 1 warning found

Crate:  dirs
Title:  dirs is unmaintained, use dirs-next instead
Date:   2020-10-16
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 2.0.2

Crate:  dirs
Title:  dirs is unmaintained, use dirs-next instead
Date:   2020-10-16
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 3.0.1

Crate:  term
Title:  term is looking for a new maintainer
Date:   2018-11-19
URL:    https://rustsec.org/advisories/RUSTSEC-2018-0015
Dependency tree:
term 0.6.1
└── slog-term 2.7.0
    ├── slog-envlogger 2.2.0
    │   └── leftwm 0.2.7
    └── leftwm 0.2.7

warning: 1 warning found!
```

Should we also update `dirs` to `dirs-next`?

Best,
Mautamu