### PR TITLE
main & horizontal stack layout

### DIFF
--- a/src/layouts/main_and_horizontal_stack.rs
+++ b/src/layouts/main_and_horizontal_stack.rs
@@ -1,0 +1,39 @@
+use crate::models::Window;
+use crate::models::Workspace;
+
+/// Layout which splits the workspace into two columns, gives one window all of the left column,
+/// and divides the right column among all the other windows.
+pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
+    let window_count = windows.len();
+    if window_count == 0 {
+        return;
+    }
+
+    let height = match window_count {
+        1 => workspace.height() as i32,
+        _ => (workspace.height() as f32 / 100.0 * workspace.main_width()).floor() as i32,
+    };
+
+    //build build the main window.
+    let mut iter = windows.iter_mut();
+    {
+        if let Some(first) = iter.next() {
+            first.set_width(workspace.width());
+            first.set_height(height);
+            first.set_x(workspace.x());
+            first.set_y(workspace.y());
+        }
+    }
+
+    //stack all the others
+    let width_f = workspace.width() as f32 / (window_count - 1) as f32;
+    let width = width_f.floor() as i32;
+    let mut x = 0;
+    for w in iter {
+        w.set_height(workspace.height() - height);
+        w.set_width(width);
+        w.set_x(workspace.x() + x);
+        w.set_y(workspace.y() + height);
+        x += width;
+    }
+}

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -7,8 +7,8 @@ mod even_horizontal;
 mod even_vertical;
 mod fibonacci;
 mod grid_horizontal;
-mod main_and_vert_stack;
 mod main_and_horizontal_stack;
+mod main_and_vert_stack;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum Layout {

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -8,10 +8,12 @@ mod even_vertical;
 mod fibonacci;
 mod grid_horizontal;
 mod main_and_vert_stack;
+mod main_and_horizontal_stack;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum Layout {
     MainAndVertStack,
+    MainAndHorizontalStack,
     GridHorizontal,
     EvenHorizontal,
     EvenVertical,
@@ -28,6 +30,7 @@ impl Default for Layout {
 
 const LAYOUTS: &[&str] = &[
     "MainAndVertStack",
+    "MainAndHorizontalStack",
     "GridHorizontal",
     "EvenHorizontal",
     "EvenVertical",
@@ -39,6 +42,7 @@ impl From<&str> for Layout {
     fn from(s: &str) -> Self {
         match s {
             "MainAndVertStack" => Self::MainAndVertStack,
+            "MainAndHorizontalStack" => Self::MainAndHorizontalStack,
             "GridHorizontal" => Self::GridHorizontal,
             "EvenHorizontal" => Self::EvenHorizontal,
             "EvenVertical" => Self::EvenVertical,
@@ -54,6 +58,7 @@ impl Layout {
     pub fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         match self {
             Self::MainAndVertStack => main_and_vert_stack::update(workspace, windows),
+            Self::MainAndHorizontalStack => main_and_horizontal_stack::update(workspace, windows),
             Self::GridHorizontal => grid_horizontal::update(workspace, windows),
             Self::EvenHorizontal => even_horizontal::update(workspace, windows),
             Self::EvenVertical => even_vertical::update(workspace, windows),


### PR DESCRIPTION
Adds a new layout, similar to the "bstack" layout in this [dwm patch](https://dwm.suckless.org/patches/bottomstack/).

The code is more or less a complete copy to `src/layouts/main_and_vert_stack.rs`, except a few changes here and there, so should work fine.

I have tested on my laptop.