### PR TITLE
Leftwm-check

### DIFF
--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -1,0 +1,55 @@
+use clap::{App,Arg};
+use leftwm::errors::Result;
+use xdg::BaseDirectories;
+use leftwm::config::Config;
+use std::fs;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let matches = App::new("LeftWM Check")
+        .author("Lex Childs <lex.childs@gmail.com>")
+        .version("0.2.7")
+        .about("checks syntax of the configuration file")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use. Uses first in PATH otherwise.")
+                .required(false)
+                .index(1),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .help("Outputs received configuration file."),
+        )
+        .get_matches();
+
+    let config_file = matches.value_of("INPUT");
+    let verbose = matches.occurrences_of("verbose") >= 1;
+
+    dbg!(config_file);
+//    use leftwm::config::*;
+
+pub fn load_from_file() -> Result<Config> {
+    let path = BaseDirectories::with_prefix("leftwm")?;
+    let config_filename = path.place_config_file("config.toml")?;
+    if Path::new(&config_filename).exists() {
+        let contents = fs::read_to_string(config_filename)?;
+        Ok(toml::from_str(&contents)?)
+    } else {
+        Err(leftwm::errors::LeftError::from(std::io::Error::new(std::io::ErrorKind::Other, "Configuration not found in path")))    
+}
+}
+   
+    match load_from_file(){
+        Ok(config) => {println!("Configuration loaded successfully");
+            if verbose {
+              dbg!(config);
+            }             
+        }
+        Err(e) => {println!("Configuration failed. Reason: {:?}", e);}
+    }    
+
+    Ok(())
+}

--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 async fn main() -> Result<()> {
     let matches = App::new("LeftWM Check")
         .author("Lex Childs <lex.childs@gmail.com>")
-        .version("0.2.7")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("checks syntax of the configuration file")
         .arg(
             Arg::with_name("INPUT")

--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -1,9 +1,9 @@
-use clap::{App,Arg};
-use leftwm::errors::Result;
-use xdg::BaseDirectories;
+use clap::{App, Arg};
 use leftwm::config::Config;
+use leftwm::errors::Result;
 use std::fs;
 use std::path::Path;
+use xdg::BaseDirectories;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -29,27 +29,33 @@ async fn main() -> Result<()> {
     let verbose = matches.occurrences_of("verbose") >= 1;
 
     dbg!(config_file);
-//    use leftwm::config::*;
+    //    use leftwm::config::*;
 
-pub fn load_from_file() -> Result<Config> {
-    let path = BaseDirectories::with_prefix("leftwm")?;
-    let config_filename = path.place_config_file("config.toml")?;
-    if Path::new(&config_filename).exists() {
-        let contents = fs::read_to_string(config_filename)?;
-        Ok(toml::from_str(&contents)?)
-    } else {
-        Err(leftwm::errors::LeftError::from(std::io::Error::new(std::io::ErrorKind::Other, "Configuration not found in path")))    
-}
-}
-   
-    match load_from_file(){
-        Ok(config) => {println!("Configuration loaded successfully");
-            if verbose {
-              dbg!(config);
-            }             
+    pub fn load_from_file() -> Result<Config> {
+        let path = BaseDirectories::with_prefix("leftwm")?;
+        let config_filename = path.place_config_file("config.toml")?;
+        if Path::new(&config_filename).exists() {
+            let contents = fs::read_to_string(config_filename)?;
+            Ok(toml::from_str(&contents)?)
+        } else {
+            Err(leftwm::errors::LeftError::from(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Configuration not found in path",
+            )))
         }
-        Err(e) => {println!("Configuration failed. Reason: {:?}", e);}
-    }    
+    }
+
+    match load_from_file() {
+        Ok(config) => {
+            println!("Configuration loaded successfully");
+            if verbose {
+                dbg!(config);
+            }
+        }
+        Err(e) => {
+            println!("Configuration failed. Reason: {:?}", e);
+        }
+    }
 
     Ok(())
 }

--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -11,7 +11,7 @@ use xdg::BaseDirectories;
 async fn main() -> Result<()> {
     let matches = App::new("LeftWM State")
         .author("Lex Childs <lex.childs@gmail.com>")
-        .version("0.2.7")
+        .version(env!("CARGO_PKG_VERSION"))
         .about("prints out the current state of LeftWM")
         .arg(
             Arg::with_name("template")


### PR DESCRIPTION
Good morning,

Per #168, and kind of #27, I think it would be helpful to have a binary that I have called cargo-check.  As currently implemented, it will tell you if your configuration is right or give a TOML error if it is wrong. I think it could be expanded to:

1. verify whether a theme is installed properly (verify theme config is correct)
2. perhaps only be compiled as an optional feature for debugging purposes
3. propose suggestions for fixing the config.toml file
4. read config.toml files from other locations to check them as well (although Clap currently says it will take input, it won't)

Any thoughts? As it is written now, it is a bit messy in output. I found it helpful in developing a solution to #32 that I intend to finish soon.

Best, 
Mautamu