### PR TITLE
Add more specific margin capabilities

### DIFF
--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -1,4 +1,5 @@
 use crate::errors::Result;
+use crate::models::Margins;
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use std::fs;
@@ -7,8 +8,8 @@ use std::path::Path;
 #[serde(default)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ThemeSetting {
-    pub border_width: u32,
-    pub margin: u32,
+    pub border_width: i32,
+    pub margin: Margins,
     pub default_border_color: String,
     pub floating_border_color: String,
     pub focused_border_color: String,
@@ -32,7 +33,7 @@ impl Default for ThemeSetting {
     fn default() -> Self {
         ThemeSetting {
             border_width: 1,
-            margin: 10,
+            margin: Margins::Int(10),
             default_border_color: "#000000".to_owned(),
             floating_border_color: "#000000".to_owned(),
             focused_border_color: "#FF0000".to_owned(),
@@ -70,7 +71,7 @@ on_new_window = 'echo Hello World'
             config,
             ThemeSetting {
                 border_width: 0,
-                margin: 5,
+                margin: Margins::Int(5),
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -95,7 +95,7 @@ impl Layout {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{BBox, WindowHandle};
+    use crate::models::{BBox, Margins, WindowHandle};
 
     #[test]
     fn should_fullscreen_a_single_window() {
@@ -114,7 +114,7 @@ mod tests {
         ws.update_avoided_areas();
         let mut w = Window::new(WindowHandle::MockHandle(1), None);
         w.border = 0;
-        w.margin = 0;
+        w.margin = Margins::Int(0);
         let mut windows = vec![&mut w];
         let mut windows_filters = windows.iter_mut().filter(|_f| true).collect();
         even_horizontal::update(&ws, &mut windows_filters);

--- a/src/models/margins.rs
+++ b/src/models/margins.rs
@@ -5,20 +5,20 @@ use serde::{Deserialize, Serialize};
 pub enum Margins {
     Int(u32),
     Vec(Vec<u32>),
-} // format: 0=> top 1=> bottom 2=> left 3=> right
+} // format: [top, right, bottom, left] as per HTML
 
 impl Margins {
    pub fn left(self) -> i32 {
-       self.into_vec()[1] as i32
+       self.into_vec()[3] as i32
    }
    pub fn right(self) -> i32 {
-       self.into_vec()[3] as i32
+       self.into_vec()[1] as i32
    }
    pub fn top(self) -> i32 {
        self.into_vec()[0] as i32
    }
    pub fn bottom(self) -> i32 {
-       self.into_vec()[0] as i32
+       self.into_vec()[2] as i32
    }
 
     pub fn into_vec(self) -> Vec<u32> {

--- a/src/models/margins.rs
+++ b/src/models/margins.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum Margins {
+    Int(u32),
+    Vec(Vec<u32>),
+} // format: 0=> top 1=> bottom 2=> left 3=> right
+
+impl Margins {
+   pub fn left(self) -> i32 {
+       self.into_vec()[1] as i32
+   }
+   pub fn right(self) -> i32 {
+       self.into_vec()[3] as i32
+   }
+   pub fn top(self) -> i32 {
+       self.into_vec()[0] as i32
+   }
+   pub fn bottom(self) -> i32 {
+       self.into_vec()[0] as i32
+   }
+
+    pub fn into_vec(self) -> Vec<u32> {
+        match self {
+            Self::Vec(v) => match v.len() {
+                1 => vec![v[0], v[0], v[0], v[0]],
+                2 => vec![v[0], v[0], v[1], v[1]],
+                3 => vec![v[0], v[1], v[2], v[2]],
+                4 => v,
+                0 => {
+                    log::error!("Empty margin or border array");
+                    vec![10, 10, 10, 10] //assume 5 px borders for now
+                }
+                _ => {
+                    log::error!("Too many entries in margin or border array");
+                    vec![v[0], v[1], v[2], v[3]] //assume later entries are invalid
+                }
+            },
+            Self::Int(x) => vec![x, x, x, x],
+        }
+    }
+}

--- a/src/models/margins.rs
+++ b/src/models/margins.rs
@@ -8,18 +8,18 @@ pub enum Margins {
 } // format: [top, right, bottom, left] as per HTML
 
 impl Margins {
-   pub fn left(self) -> i32 {
-       self.into_vec()[3] as i32
-   }
-   pub fn right(self) -> i32 {
-       self.into_vec()[1] as i32
-   }
-   pub fn top(self) -> i32 {
-       self.into_vec()[0] as i32
-   }
-   pub fn bottom(self) -> i32 {
-       self.into_vec()[2] as i32
-   }
+    pub fn left(self) -> i32 {
+        self.into_vec()[3] as i32
+    }
+    pub fn right(self) -> i32 {
+        self.into_vec()[1] as i32
+    }
+    pub fn top(self) -> i32 {
+        self.into_vec()[0] as i32
+    }
+    pub fn bottom(self) -> i32 {
+        self.into_vec()[2] as i32
+    }
 
     pub fn into_vec(self) -> Vec<u32> {
         match self {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 mod dock_area;
 mod manager;
+mod margins;
 mod mode;
 mod screen;
 mod tag;
@@ -16,6 +17,7 @@ use crate::layouts;
 
 pub use dock_area::DockArea;
 pub use manager::Manager;
+pub use margins::Margins;
 pub use mode::Mode;
 pub use screen::{BBox, Screen};
 pub use window::Window;

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -4,6 +4,7 @@ use crate::config::ThemeSetting;
 use crate::models::TagId;
 use crate::models::XYHWBuilder;
 use crate::models::XYHW;
+use crate::models::Margins;
 use serde::{Deserialize, Serialize};
 use x11_dl::xlib;
 
@@ -28,7 +29,7 @@ pub struct Window {
     pub type_: WindowType,
     pub tags: Vec<TagId>,
     pub border: i32,
-    pub margin: i32,
+    pub margin: Margins,
     states: Vec<WindowState>,
     pub normal: XYHW,
     pub start_loc: Option<XYHW>,
@@ -48,7 +49,7 @@ impl Window {
             type_: WindowType::Normal,
             tags: Vec::new(),
             border: 1,
-            margin: 10,
+            margin: Margins::Int(10),
             states: vec![],
             normal: XYHWBuilder::default().into(),
             floating: None,
@@ -59,10 +60,10 @@ impl Window {
 
     pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
         if self.type_ == WindowType::Normal {
-            self.margin = theme.margin as i32;
-            self.border = theme.border_width as i32;
+            self.margin = theme.margin.clone();
+            self.border = theme.border_width;
         } else {
-            self.margin = 0;
+            self.margin = Margins::Int(0);
             self.border = 0;
         }
     }
@@ -147,9 +148,9 @@ impl Window {
             value = self.normal.w();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            value = relative.w() - (self.margin * 2) - (self.border * 2);
+            value = relative.w() - (self.margin.clone().left() + self.margin.clone().right()) - (self.border * 2);
         } else {
-            value = self.normal.w() - (self.margin * 2) - (self.border * 2);
+            value = self.normal.w() - (self.margin.clone().left() + self.margin.clone().right()) - (self.border * 2);
         }
         if value < 100 && self.type_ != WindowType::Dock {
             value = 100
@@ -162,9 +163,9 @@ impl Window {
             value = self.normal.h();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            value = relative.h() - (self.margin * 2) - (self.border * 2);
+            value = relative.h() - (self.margin.clone().top() + self.margin.clone().bottom()) - (self.border * 2);
         } else {
-            value = self.normal.h() - (self.margin * 2) - (self.border * 2);
+            value = self.normal.h() - (self.margin.clone().top() + self.margin.clone().bottom()) - (self.border * 2);
         }
         if value < 100 && self.type_ != WindowType::Dock {
             value = 100
@@ -193,9 +194,9 @@ impl Window {
         }
         if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            relative.x() + self.margin
+            relative.x() + self.margin.clone().left()
         } else {
-            self.normal.x() + self.margin
+            self.normal.x() + self.margin.clone().left()
         }
     }
 
@@ -205,9 +206,9 @@ impl Window {
         }
         if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            relative.y() + self.margin
+            relative.y() + self.margin.clone().bottom()
         } else {
-            self.normal.y() + self.margin
+            self.normal.y() + self.margin.clone().bottom()
         }
     }
 

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -1,10 +1,10 @@
 use super::WindowState;
 use super::WindowType;
 use crate::config::ThemeSetting;
+use crate::models::Margins;
 use crate::models::TagId;
 use crate::models::XYHWBuilder;
 use crate::models::XYHW;
-use crate::models::Margins;
 use serde::{Deserialize, Serialize};
 use x11_dl::xlib;
 
@@ -148,9 +148,13 @@ impl Window {
             value = self.normal.w();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            value = relative.w() - (self.margin.clone().left() + self.margin.clone().right()) - (self.border * 2);
+            value = relative.w()
+                - (self.margin.clone().left() + self.margin.clone().right())
+                - (self.border * 2);
         } else {
-            value = self.normal.w() - (self.margin.clone().left() + self.margin.clone().right()) - (self.border * 2);
+            value = self.normal.w()
+                - (self.margin.clone().left() + self.margin.clone().right())
+                - (self.border * 2);
         }
         if value < 100 && self.type_ != WindowType::Dock {
             value = 100
@@ -163,9 +167,13 @@ impl Window {
             value = self.normal.h();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap();
-            value = relative.h() - (self.margin.clone().top() + self.margin.clone().bottom()) - (self.border * 2);
+            value = relative.h()
+                - (self.margin.clone().top() + self.margin.clone().bottom())
+                - (self.border * 2);
         } else {
-            value = self.normal.h() - (self.margin.clone().top() + self.margin.clone().bottom()) - (self.border * 2);
+            value = self.normal.h()
+                - (self.margin.clone().top() + self.margin.clone().bottom())
+                - (self.border * 2);
         }
         if value < 100 && self.type_ != WindowType::Dock {
             value = 100

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -2,7 +2,7 @@ use super::Window;
 use super::WindowHandle;
 use super::WindowState;
 use super::WindowType;
-use crate::models::XYHWChange;
+use crate::models::{Margins,XYHWChange};
 
 type MaybeWindowHandle = Option<WindowHandle>;
 type MaybeName = Option<String>;
@@ -82,7 +82,7 @@ impl WindowChange {
             window.type_ = type_.clone();
             if window.type_ == WindowType::Dock {
                 window.border = 0;
-                window.margin = 0;
+                window.margin = Margins::Int(0);
             }
         }
         if let Some(states) = self.states {

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -2,7 +2,7 @@ use super::Window;
 use super::WindowHandle;
 use super::WindowState;
 use super::WindowType;
-use crate::models::{Margins,XYHWChange};
+use crate::models::{Margins, XYHWChange};
 
 type MaybeWindowHandle = Option<WindowHandle>;
 type MaybeName = Option<String>;


### PR DESCRIPTION
Good evening,

This PR adds functionality to the margins as per #194. I went with the HTML format of [top, right, bottom, left] and [top/bottom, left/right]. To change the margins, edit _~/.config/leftwm/themes/current/theme.toml_ from:
```toml
border_width = 4
margin = 10
```
to:
```toml
border_width = 4
margin = [10, 10]
```

I intended to apply this to borders as well, but it does not appear that this is possible due to an upstream requirement of a singular integer to define borders, but it may be possible. 