### PR TITLE
monocle Layout

### DIFF
--- a/src/layouts/main_and_horizontal_stack.rs
+++ b/src/layouts/main_and_horizontal_stack.rs
@@ -1,0 +1,39 @@
+use crate::models::Window;
+use crate::models::Workspace;
+
+/// Layout which splits the workspace into two columns, gives one window all of the left column,
+/// and divides the right column among all the other windows.
+pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
+    let window_count = windows.len();
+    if window_count == 0 {
+        return;
+    }
+
+    let height = match window_count {
+        1 => workspace.height() as i32,
+        _ => (workspace.height() as f32 / 100.0 * workspace.main_width()).floor() as i32,
+    };
+
+    //build build the main window.
+    let mut iter = windows.iter_mut();
+    {
+        if let Some(first) = iter.next() {
+            first.set_width(workspace.width());
+            first.set_height(height);
+            first.set_x(workspace.x());
+            first.set_y(workspace.y());
+        }
+    }
+
+    //stack all the others
+    let width_f = workspace.width() as f32 / (window_count - 1) as f32;
+    let width = width_f.floor() as i32;
+    let mut x = 0;
+    for w in iter {
+        w.set_height(workspace.height() - height);
+        w.set_width(width);
+        w.set_x(workspace.x() + x);
+        w.set_y(workspace.y() + height);
+        x += width;
+    }
+}

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -7,11 +7,13 @@ mod even_horizontal;
 mod even_vertical;
 mod fibonacci;
 mod grid_horizontal;
+mod main_and_horizontal_stack;
 mod main_and_vert_stack;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum Layout {
     MainAndVertStack,
+    MainAndHorizontalStack,
     GridHorizontal,
     EvenHorizontal,
     EvenVertical,
@@ -28,6 +30,7 @@ impl Default for Layout {
 
 const LAYOUTS: &[&str] = &[
     "MainAndVertStack",
+    "MainAndHorizontalStack",
     "GridHorizontal",
     "EvenHorizontal",
     "EvenVertical",
@@ -39,6 +42,7 @@ impl From<&str> for Layout {
     fn from(s: &str) -> Self {
         match s {
             "MainAndVertStack" => Self::MainAndVertStack,
+            "MainAndHorizontalStack" => Self::MainAndHorizontalStack,
             "GridHorizontal" => Self::GridHorizontal,
             "EvenHorizontal" => Self::EvenHorizontal,
             "EvenVertical" => Self::EvenVertical,
@@ -54,6 +58,7 @@ impl Layout {
     pub fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         match self {
             Self::MainAndVertStack => main_and_vert_stack::update(workspace, windows),
+            Self::MainAndHorizontalStack => main_and_horizontal_stack::update(workspace, windows),
             Self::GridHorizontal => grid_horizontal::update(workspace, windows),
             Self::EvenHorizontal => even_horizontal::update(workspace, windows),
             Self::EvenVertical => even_vertical::update(workspace, windows),

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -9,9 +9,11 @@ mod fibonacci;
 mod grid_horizontal;
 mod main_and_horizontal_stack;
 mod main_and_vert_stack;
+mod monocle;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum Layout {
+    Monocle,
     MainAndVertStack,
     MainAndHorizontalStack,
     GridHorizontal,
@@ -29,6 +31,7 @@ impl Default for Layout {
 }
 
 const LAYOUTS: &[&str] = &[
+    "Monocle",
     "MainAndVertStack",
     "MainAndHorizontalStack",
     "GridHorizontal",
@@ -41,6 +44,7 @@ const LAYOUTS: &[&str] = &[
 impl From<&str> for Layout {
     fn from(s: &str) -> Self {
         match s {
+            "Monocle" => Self::Monocle,
             "MainAndVertStack" => Self::MainAndVertStack,
             "MainAndHorizontalStack" => Self::MainAndHorizontalStack,
             "GridHorizontal" => Self::GridHorizontal,
@@ -48,7 +52,7 @@ impl From<&str> for Layout {
             "EvenVertical" => Self::EvenVertical,
             "Fibonacci" => Self::Fibonacci,
             "CenterMain" => Self::CenterMain,
-            _ => Self::MainAndVertStack,
+            _ => Self::Monocle,
         }
     }
 }
@@ -57,6 +61,7 @@ impl From<&str> for Layout {
 impl Layout {
     pub fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         match self {
+            Self::Monocle => monocle::update(workspace, windows),
             Self::MainAndVertStack => main_and_vert_stack::update(workspace, windows),
             Self::MainAndHorizontalStack => main_and_horizontal_stack::update(workspace, windows),
             Self::GridHorizontal => grid_horizontal::update(workspace, windows),

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -13,7 +13,6 @@ mod monocle;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum Layout {
-    Monocle,
     MainAndVertStack,
     MainAndHorizontalStack,
     GridHorizontal,
@@ -21,6 +20,7 @@ pub enum Layout {
     EvenVertical,
     Fibonacci,
     CenterMain,
+    Monocle,
 }
 
 impl Default for Layout {
@@ -31,7 +31,6 @@ impl Default for Layout {
 }
 
 const LAYOUTS: &[&str] = &[
-    "Monocle",
     "MainAndVertStack",
     "MainAndHorizontalStack",
     "GridHorizontal",
@@ -39,12 +38,12 @@ const LAYOUTS: &[&str] = &[
     "EvenVertical",
     "Fibonacci",
     "CenterMain",
+    "Monocle",
 ];
 
 impl From<&str> for Layout {
     fn from(s: &str) -> Self {
         match s {
-            "Monocle" => Self::Monocle,
             "MainAndVertStack" => Self::MainAndVertStack,
             "MainAndHorizontalStack" => Self::MainAndHorizontalStack,
             "GridHorizontal" => Self::GridHorizontal,
@@ -52,7 +51,8 @@ impl From<&str> for Layout {
             "EvenVertical" => Self::EvenVertical,
             "Fibonacci" => Self::Fibonacci,
             "CenterMain" => Self::CenterMain,
-            _ => Self::Monocle,
+            "Monocle" => Self::Monocle,
+            _ => Self::MainAndVertStack,
         }
     }
 }
@@ -61,7 +61,6 @@ impl From<&str> for Layout {
 impl Layout {
     pub fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         match self {
-            Self::Monocle => monocle::update(workspace, windows),
             Self::MainAndVertStack => main_and_vert_stack::update(workspace, windows),
             Self::MainAndHorizontalStack => main_and_horizontal_stack::update(workspace, windows),
             Self::GridHorizontal => grid_horizontal::update(workspace, windows),
@@ -69,6 +68,7 @@ impl Layout {
             Self::EvenVertical => even_vertical::update(workspace, windows),
             Self::Fibonacci => fibonacci::update(workspace, windows),
             Self::CenterMain => center_main::update(workspace, windows),
+            Self::Monocle => monocle::update(workspace, windows),
         }
     }
 

--- a/src/layouts/monocle.rs
+++ b/src/layouts/monocle.rs
@@ -1,0 +1,15 @@
+use crate::models::Window;
+use crate::models::Workspace;
+
+/// Layout which gives only one window with the full desktop realestate. A monocle mode.
+pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
+    let height = workspace.height() as i32;
+    let mut y = 0;
+    for w in windows.iter_mut() {
+        w.set_height(height);
+        w.set_width(workspace.width());
+        w.set_x(workspace.x());
+        w.set_y(workspace.y() + y);
+        y += height;
+    }
+}

--- a/src/layouts/monocle.rs
+++ b/src/layouts/monocle.rs
@@ -22,7 +22,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
             // monoclestate.push(WindowState::Above);
             // monoclestate.push(WindowState::MaximizedVert);
             // monoclestate.push(WindowState::MaximizedHorz);
-            monowin.margin = 0;
+            // monowin.margin = 0;
             monowin.set_height(workspace.height());
             monowin.set_width(workspace.width());
             monowin.set_x(workspace.x());
@@ -38,6 +38,10 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         if window_count > 1 {
             for w in iter {
                 w.set_visible(false); //window state Hide
+                w.set_height(workspace.height());
+                w.set_width(workspace.width());
+                w.set_x(workspace.x());
+                w.set_y(workspace.y());
             }
         }
     }

--- a/src/layouts/monocle.rs
+++ b/src/layouts/monocle.rs
@@ -10,38 +10,30 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
         return;
     }
 
-    let mut iter = windows.iter_mut(); 
+    let mut iter = windows.iter_mut();
 
-       //maximize primary window
-        
+    //maximize primary window
     {
         if let Some(monowin) = iter.next() {
-            // let mut monoclestate: Vec<WindowState> = Vec::new();
-
-            //Above, MaximizedVert, MaximizedHorz
-            // monoclestate.push(WindowState::Above);
-            // monoclestate.push(WindowState::MaximizedVert);
-            // monoclestate.push(WindowState::MaximizedHorz);
-            // monowin.margin = 0;
             monowin.set_height(workspace.height());
             monowin.set_width(workspace.width());
             monowin.set_x(workspace.x());
             monowin.set_y(workspace.y());
 
-            // monowin.set_states(monoclestate.to_vec());
             monowin.set_visible(true);
         }
     }
-        
-        //hide all other windows
-     {
+
+    //hide all other windows
+    {
         if window_count > 1 {
             for w in iter {
-                w.set_visible(false); //window state Hide
                 w.set_height(workspace.height());
                 w.set_width(workspace.width());
                 w.set_x(workspace.x());
                 w.set_y(workspace.y());
+
+                w.set_visible(false);
             }
         }
     }

--- a/src/layouts/monocle.rs
+++ b/src/layouts/monocle.rs
@@ -1,15 +1,44 @@
 use crate::models::Window;
 use crate::models::Workspace;
+// use crate::models::WindowState;
 
 /// Layout which gives only one window with the full desktop realestate. A monocle mode.
 pub fn update(workspace: &Workspace, windows: &mut Vec<&mut &mut Window>) {
-    let height = workspace.height() as i32;
-    let mut y = 0;
-    for w in windows.iter_mut() {
-        w.set_height(height);
-        w.set_width(workspace.width());
-        w.set_x(workspace.x());
-        w.set_y(workspace.y() + y);
-        y += height;
+    let window_count = windows.len();
+
+    if window_count == 0 {
+        return;
+    }
+
+    let mut iter = windows.iter_mut(); 
+
+       //maximize primary window
+        
+    {
+        if let Some(monowin) = iter.next() {
+            // let mut monoclestate: Vec<WindowState> = Vec::new();
+
+            //Above, MaximizedVert, MaximizedHorz
+            // monoclestate.push(WindowState::Above);
+            // monoclestate.push(WindowState::MaximizedVert);
+            // monoclestate.push(WindowState::MaximizedHorz);
+            monowin.margin = 0;
+            monowin.set_height(workspace.height());
+            monowin.set_width(workspace.width());
+            monowin.set_x(workspace.x());
+            monowin.set_y(workspace.y());
+
+            // monowin.set_states(monoclestate.to_vec());
+            monowin.set_visible(true);
+        }
+    }
+        
+        //hide all other windows
+     {
+        if window_count > 1 {
+            for w in iter {
+                w.set_visible(false); //window state Hide
+            }
+        }
     }
 }


### PR DESCRIPTION
As proposed in #174 here is my attempt to add a simple Monocle Layout, which sets the primary window to full screen and hides any others. The windows can be cycled through with MoveWindow commands.

In a hacky way it get rid of the margin, but I am not sure how to handle properly to return to the theme margin again in other layouts, yet.

Also it would be possibly nice to have a monocle specific margin, like doule or tripple the theme margin. Maybe have a "monocle-factor" value in the theme.toml? 