### PR TITLE
test suite fix

### DIFF
--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -175,7 +175,7 @@ pub fn update_current_tags(manager: &mut Manager) {
     }
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -281,7 +281,7 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None);
-        window.tag("2".to_owned());
+        window.tag("2");
         focus_window(&mut manager, &window, 0, 0);
         let actual = manager.focused_tag().unwrap();
         assert_eq!("2", actual);
@@ -294,7 +294,7 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         screen_create_handler::process(&mut manager, Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None);
-        window.tag("2".to_owned());
+        window.tag("2");
         focus_window(&mut manager, &window, 0, 0);
         let actual = manager.focused_workspace().unwrap().id.clone();
         let expected = manager.workspaces[1].id.clone();

--- a/src/handlers/goto_tag_handler.rs
+++ b/src/handlers/goto_tag_handler.rs
@@ -23,7 +23,7 @@ pub fn process(manager: &mut Manager, tag_num: usize) -> bool {
     true
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/handlers/screen_create_handler.rs
+++ b/src/handlers/screen_create_handler.rs
@@ -23,7 +23,7 @@ pub fn process(manager: &mut Manager, screen: Screen) -> bool {
     false
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -39,9 +39,9 @@ mod tests {
     #[test]
     fn should_be_able_to_add_screens_with_perexisting_tags() {
         let mut manager = Manager::default();
-        manager.tags.push("web".to_owned());
-        manager.tags.push("console".to_owned());
-        manager.tags.push("code".to_owned());
+        manager.tags.push(TagModel::new("web"));
+        manager.tags.push(TagModel::new("console"));
+        manager.tags.push(TagModel::new("code"));
         process(&mut manager, Screen::default());
         process(&mut manager, Screen::default());
         assert!(manager.workspaces[0].has_tag("web"));

--- a/src/models/dock_area.rs
+++ b/src/models/dock_area.rs
@@ -101,7 +101,7 @@ impl DockArea {
     }
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -263,27 +263,24 @@ impl Window {
     }
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn should_be_able_to_tag_a_window() {
         let mut subject = Window::new(WindowHandle::MockHandle(1), None);
-        subject.tag("test".to_string());
-        assert!(
-            subject.has_tag("test".to_string()),
-            "was unable to tag the window"
-        );
+        subject.tag("test");
+        assert!(subject.has_tag("test"), "was unable to tag the window");
     }
 
     #[test]
     fn should_be_able_to_untag_a_window() {
         let mut subject = Window::new(WindowHandle::MockHandle(1), None);
-        subject.tag("test".to_string());
-        subject.untag("test".to_string());
+        subject.tag("test");
+        subject.untag("test");
         assert!(
-            subject.has_tag("test".to_string()) == false,
+            subject.has_tag("test") == false,
             "was unable to untag the window"
         );
     }


### PR DESCRIPTION
- fix a type preventing test suites from being run on `cargo test`. `[#cfg(tests)] becomes `[cfg(test)]`
- fix tests that stopped working after recent changes to tags