### PR TITLE
Fix position of seconds in basic_polybar date-alt

### DIFF
--- a/themes/basic_polybar/polybar.config
+++ b/themes/basic_polybar/polybar.config
@@ -80,7 +80,7 @@ module-margin-right = 2
 font-0 = misc fixed:pixelsize=10;1
 font-1 = unifont:fontformat=truetype:size=8:antialias=false;0
 font-2 = wuncon siji:pixelsize=10;1
-modules-center = 
+modules-center =
 modules-right = filesystem xbacklight pulseaudio xkeyboard memory cpu wlan eth battery temperature date powermenu
 tray-position = right
 tray-padding = 2
@@ -285,7 +285,7 @@ format-disconnected =
 [module/date]
 type = internal/date
 date =    %%{F#99}%m/%d/%Y%%{F-}  %%{F#fff}%I:%M %p%{F-}
-date-alt = %%{F#fff}%A, %B %d, %Y  %%{F#fff}%I:%M %p%{F#666}%%{F#fba922}%S%%{F-}
+date-alt = %%{F#fff}%A, %B %d, %Y  %%{F#fff}%I:%M:%{F#666}%%{F#fba922}%S%%{F-} %p
 ;interval = 5
 ;date =
 ;date-alt = " %Y-%m-%d"


### PR DESCRIPTION
Fixes issue where seconds in basic polybar config, shown upon click of
time, was erroneously placed after the AM/PM instead of after the
minutes.

Fixes #240 