### PR TITLE
Restore window order on reload

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -55,16 +55,23 @@ fn restore_workspaces(manager: &mut Manager, old_manager: &Manager) {
 
 /// Copy windows state.
 fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
-    for window in &mut manager.windows {
-        if let Some(old) = old_manager
+    let mut ordered = vec![];
+
+    for old in &old_manager.windows {
+        if let Some((index, window)) = manager
             .windows
-            .iter()
-            .find(|w| w.handle == window.handle)
+            .iter_mut()
+            .enumerate()
+            .find(|w| w.1.handle == old.handle)
         {
             window.set_floating(old.floating());
             window.set_floating_offsets(old.get_floating_offsets());
             window.normal = old.normal;
             window.tags = old.tags.clone();
+            ordered.push(window.clone());
+            manager.windows.remove(index);
         }
     }
+    // manager.windows.clear();
+    manager.windows.append(&mut ordered);
 }


### PR DESCRIPTION
This restores the original window order when reloading, in as fast a way I can think of (let me know if anyone can find ways of speeding it up). This will causes conflicts with #259, as the addition to remember margin multiplier won't be added, but this will be an easy conflict to fix. 