### PR TITLE
Update to focus system to watch for missed EnterEvents

### DIFF
--- a/src/display_event.rs
+++ b/src/display_event.rs
@@ -8,11 +8,12 @@ pub enum DisplayEvent {
     Movement(WindowHandle, i32, i32),
     KeyCombo(ModMask, XKeysym),
     MouseCombo(ModMask, Button, WindowHandle),
-    WindowCreate(Window),
+    WindowCreate(Window, i32, i32),
     WindowChange(WindowChange),
     WindowDestroy(WindowHandle),
-    FocusedWindow(WindowHandle, i32, i32),
-    FocusedAt(i32, i32), //request to focus whatever is located at this point
+    MouseEnteredWindow(WindowHandle),
+    VerifyFocusedAt(i32, i32), //Request focus validation at this point
+    MoveFocusTo(i32, i32),     //Focus the nearest window to this point
     MoveWindow(WindowHandle, u64, i32, i32),
     ResizeWindow(WindowHandle, u64, i32, i32),
     ScreenCreate(Screen),

--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -52,7 +52,8 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                         }
                         w.type_ = xw.get_window_type(event.window);
 
-                        Some(DisplayEvent::WindowCreate(w))
+                        let cursor = xw.get_cursor_point().ok()?;
+                        Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1))
                     }
                     Err(_) => None,
                 }
@@ -105,7 +106,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                     Mode::NormalMode => {}
                 };
                 let event = xlib::XEnterWindowEvent::from(raw_event);
-                //println!("EnterNotify {:?}", event);
+                //log::trace!("EnterNotify {:?}", event);
                 let crossing = xlib::XCrossingEvent::from(raw_event);
                 if (crossing.mode != xlib::NotifyNormal || crossing.detail == xlib::NotifyInferior)
                     && crossing.window != xw.get_default_root()
@@ -113,9 +114,9 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                     return None;
                 }
                 let h = WindowHandle::XlibHandle(event.window);
-                let mouse_loc = xw.get_pointer_location();
-
-                mouse_loc.map(|loc| DisplayEvent::FocusedWindow(h, loc.0, loc.1))
+                //let mouse_loc = xw.get_pointer_location();
+                //mouse_loc.map(|loc| )
+                Some(DisplayEvent::MouseEnteredWindow(h))
             }
 
             xlib::PropertyNotify => {
@@ -138,7 +139,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
 
             xlib::MotionNotify => {
                 let event = xlib::XMotionEvent::from(raw_event);
-                //println!("MotionNotify {:?}", event);
+                //log::trace!("XMotionEvent {:?}", event);
                 let event_h = WindowHandle::XlibHandle(event.window);
                 let offset_x = event.x_root - xw.mode_origin.0;
                 let offset_y = event.y_root - xw.mode_origin.1;

--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -83,7 +83,9 @@ impl DisplayServer for XlibDisplayServer {
             }
         });
 
-        for _ in 0..self.xw.queue_len() {
+        let event_in_queue = self.xw.queue_len();
+
+        for _ in 0..event_in_queue {
             let xlib_event = self.xw.get_next_event();
             let event = XEvent(&self.xw, xlib_event).into();
             if let Some(e) = event {
@@ -127,13 +129,26 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.window_take_focus(w);
                 None
             }
-            DisplayAction::FocusWindowUnderCursor => {
-                let cursor = self.xw.get_cursor_point().ok()?;
-                Some(DisplayEvent::FocusedAt(cursor.0, cursor.1))
-            }
             DisplayAction::SetWindowOrder(wins) => {
-                self.xw.restack(wins);
+                // get all the windows are aren't managing.
+                // They should be in front of our windows.
+                let unmanged: Vec<WindowHandle> = self
+                    .xw
+                    .get_all_windows()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter(|&x| *x != self.root)
+                    .map(|x| WindowHandle::XlibHandle(*x))
+                    .filter(|h| !wins.contains(&h))
+                    .collect();
+                let all: Vec<WindowHandle> = unmanged.iter().chain(wins.iter()).cloned().collect();
+                self.xw.restack(all);
                 None
+            }
+            DisplayAction::FocusWindowUnderCursor => {
+                let point = self.xw.get_cursor_point().ok()?;
+                let evt = DisplayEvent::MoveFocusTo(point.0, point.1);
+                Some(evt)
             }
             DisplayAction::StartMovingWindow(w) => {
                 self.xw.set_mode(Mode::MovingWindow(w));
@@ -188,11 +203,21 @@ impl XlibDisplayServer {
 
         // tell manager about existing windows
         self.find_all_windows().into_iter().for_each(|w| {
-            let e = DisplayEvent::WindowCreate(w);
+            let cursor = self.xw.get_cursor_point().ok().unwrap_or_default();
+            let e = DisplayEvent::WindowCreate(w, cursor.0, cursor.1);
             events.push(e);
         });
 
         events
+    }
+
+    pub fn verify_focused_window(&mut self) -> Vec<DisplayEvent> {
+        self.verify_focused_window_work().unwrap_or_default()
+    }
+
+    fn verify_focused_window_work(&mut self) -> Option<Vec<DisplayEvent>> {
+        let point = self.xw.get_cursor_point().ok()?;
+        Some(vec![DisplayEvent::VerifyFocusedAt(point.0, point.1)])
     }
 
     fn find_all_windows(&self) -> Vec<Window> {

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -1111,33 +1111,6 @@ impl XWrap {
         }
     }
 
-    pub fn get_pointer_location(&self) -> Option<(i32, i32)> {
-        let mut root: xlib::Window = 0;
-        let mut window: xlib::Window = 0;
-        let mut root_x: c_int = 0;
-        let mut root_y: c_int = 0;
-        let mut win_x: c_int = 0;
-        let mut win_y: c_int = 0;
-        let mut state: c_uint = 0;
-        unsafe {
-            let success = (self.xlib.XQueryPointer)(
-                self.display,
-                self.root,
-                &mut root,
-                &mut window,
-                &mut root_x,
-                &mut root_y,
-                &mut win_x,
-                &mut win_y,
-                &mut state,
-            );
-            if success > 0 {
-                return Some((root_x, root_y));
-            }
-        }
-        None
-    }
-
     pub fn get_wmhints(&self, window: xlib::Window) -> Option<xlib::XWMHints> {
         unsafe {
             let hints_ptr: *const xlib::XWMHints = (self.xlib.XGetWMHints)(self.display, window);
@@ -1353,8 +1326,8 @@ impl XWrap {
         if self.mode == Mode::NormalMode && mode != Mode::NormalMode {
             self.mode = mode.clone();
             //safe this point as the start of the move/resize
-            if let Some(loc) = self.get_pointer_location() {
-                self.mode_origin = loc;
+            if let Ok(loc) = self.get_cursor_point() {
+                self.mode_origin = loc
             }
             unsafe {
                 let cursor = match mode {

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -33,10 +33,6 @@ pub fn process(
                 manager.actions.push_back(act);
                 manager.sort_windows();
             }
-
-            //make sure focus is re-computed
-            let act = DisplayAction::FocusWindowUnderCursor;
-            manager.actions.push_back(act);
             true
         }
 
@@ -482,7 +478,7 @@ pub fn process(
                 .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
             {
                 let window = window.clone();
-                focus_handler::focus_window(manager, &window, &window.x() + 1, &window.y() + 1);
+                focus_handler::move_cursor_over(manager, &window);
                 let act = DisplayAction::MoveMouseOver(window.handle);
                 manager.actions.push_back(act);
             }
@@ -520,7 +516,7 @@ pub fn process(
                 .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
             {
                 let window = window.clone();
-                focus_handler::focus_window(manager, &window, &window.x() + 1, &window.y() + 1);
+                focus_handler::move_cursor_over(manager, &window);
                 let act = DisplayAction::MoveMouseOver(window.handle);
                 manager.actions.push_back(act);
             }

--- a/src/handlers/display_event_handler.rs
+++ b/src/handlers/display_event_handler.rs
@@ -16,15 +16,19 @@ impl DisplayEventHandler {
     pub fn process(&self, manager: &mut Manager, event: DisplayEvent) -> bool {
         let update_needed = match event {
             DisplayEvent::ScreenCreate(s) => screen_create_handler::process(manager, s),
-            DisplayEvent::WindowCreate(w) => window_handler::created(manager, w),
+            DisplayEvent::WindowCreate(w, x, y) => window_handler::created(manager, w, x, y),
             DisplayEvent::WindowChange(w) => window_handler::changed(manager, w),
 
-            DisplayEvent::FocusedWindow(handle, x, y) => {
-                focus_handler::focus_window_by_handle(manager, &handle, x, y)
+            //The window has been focused, do we want to do anything about it?
+            DisplayEvent::MouseEnteredWindow(handle) => {
+                return focus_handler::focus_window(manager, &handle)
             }
 
-            //request to focus whatever is at this point
-            DisplayEvent::FocusedAt(x, y) => focus_handler::move_focus_to_point(manager, x, y),
+            DisplayEvent::MoveFocusTo(x, y) => focus_handler::move_focus_to_point(manager, x, y),
+
+            //This is a request to validate focus. Double check that we are focused the correct
+            //thing under this point.
+            DisplayEvent::VerifyFocusedAt(x, y) => focus_handler::validate_focus_at(manager, x, y),
 
             DisplayEvent::WindowDestroy(handle) => {
                 window_handler::destroyed(manager, &handle);

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -2,11 +2,25 @@ use super::*;
 use crate::display_action::DisplayAction;
 
 /// Marks a workspace as the focused workspace.
+//NOTE: should only be called externally from this file
 pub fn focus_workspace(manager: &mut Manager, workspace: &Workspace) -> bool {
-    //no new history for if no change
+    if focus_workspace_work(manager, workspace.id).is_some() {
+        //make sure this workspaces tag is focused
+        workspace.tags.iter().for_each(|t| {
+            focus_tag_work(manager, t);
+        });
+        // create an action to inform the DM
+        update_current_tags(manager);
+        return true;
+    }
+    false
+}
+
+fn focus_workspace_work(manager: &mut Manager, workspace_id: i32) -> Option<()> {
+    //no new history if no change
     if let Some(fws) = manager.focused_workspace() {
-        if fws.id == workspace.id {
-            return false;
+        if fws.id == workspace_id {
+            return None;
         }
     }
     //clean old ones
@@ -15,101 +29,61 @@ pub fn focus_workspace(manager: &mut Manager, workspace: &Workspace) -> bool {
     }
     //add this focus to the history
     for (index, ws) in manager.workspaces.iter().enumerate() {
-        if ws.id == workspace.id {
+        if ws.id == workspace_id {
             manager.focused_workspace_history.push_front(index);
         }
     }
-    //make sure this workspaces tag is focused
-    workspace.tags.iter().for_each(|t| {
-        focus_tag(manager, t);
-    });
+    Some(())
+}
 
-    // create an action to inform the DM
-    update_current_tags(manager);
+/// Create a DisplayAction to cause this window to become focused  
+pub fn focus_window(manager: &mut Manager, handle: &WindowHandle) -> bool {
+    let window = match focus_window_by_handle_work(manager, handle) {
+        Some(w) => w,
+        None => return false,
+    };
+
+    let mut tags = vec![];
+    let mut workspace_id: Option<i32> = None;
+    //make sure the focused window's workspace is focused
+    for ws in &manager.workspaces {
+        if ws.is_displaying(&window) {
+            tags = ws.tags.clone();
+            workspace_id = Some(ws.id);
+            break;
+        }
+    }
+    if let Some(workspace_id) = workspace_id {
+        let _ = focus_workspace_work(manager, workspace_id);
+    }
+
+    //make sure the focused window's tag is focused
+    for tag in &tags {
+        if window.has_tag(tag) {
+            let _ = focus_tag_work(manager, tag);
+            break;
+        }
+    }
     true
 }
 
-/// Marks a window as the focused window.
-pub fn focus_window_by_handle(
-    manager: &mut Manager,
-    handle: &WindowHandle,
-    x: i32,
-    y: i32,
-) -> bool {
-    let found: Option<Window> = manager
-        .windows
-        .iter()
-        .find(|w| &w.handle == handle)
-        .cloned();
-    if let Some(found) = found {
-        return focus_window(manager, &found, x, y);
-    }
-    false
-}
-
-pub fn focus_window(manager: &mut Manager, window: &Window, x: i32, y: i32) -> bool {
-    let result = _focus_window_work(manager, window);
-    if !result {
-        return false;
-    }
-
-    // if the x,y mouse location is inside the to workspace for this window, it needs to be focused
-    // this is so the focus of the window gets passed to the underlying workspace
-    if !window.tags.is_empty() {
-        let main_tag = window.tags[0].clone();
-        let to_focus: Vec<Workspace> = manager
-            .workspaces
-            .iter()
-            .filter(|w| w.has_tag(&main_tag))
-            .cloned()
-            .collect();
-        to_focus.iter().for_each(|w| {
-            if w.contains_point(x, y) {
-                focus_workspace(manager, &w);
-            }
-        });
-    }
-    result
-}
-
-pub fn move_focus_to_point(manager: &mut Manager, x: i32, y: i32) -> bool {
-    let found: Option<Window> = manager
-        .windows
-        .iter()
-        .find(|w| w.visible() && w.contains_point(x, y))
-        .cloned();
-
-    match found {
-        Some(found) => return focus_window(manager, &found, x, y),
-        None => {
-            //backup plan, move focus first window in workspace
-            if let Some(handle) = first_window_in_current_workspace(manager) {
-                return focus_window_by_handle(manager, &handle, x, y);
-            }
-        }
-    }
-    false
-}
-
-fn first_window_in_current_workspace(manager: &Manager) -> Option<WindowHandle> {
-    let tag = manager.focused_workspace()?.tags.get(0)?;
-    let window = manager
-        .windows
-        .iter()
-        .find(|w| w.visible() && w.has_tag(tag))?;
-    Some(window.handle.clone())
-}
-
-fn _focus_window_work(manager: &mut Manager, window: &Window) -> bool {
+fn focus_window_by_handle_work(manager: &mut Manager, handle: &WindowHandle) -> Option<Window> {
     //Docks don't want to get focus. If they do weird things happen. They don't get events...
-    if window.type_ == WindowType::Dock {
-        return false;
+    //Do the focus, Add the action to the list of action
+    let found: &Window = manager.windows.iter().find(|w| &w.handle == handle)?;
+    if found.type_ == WindowType::Dock {
+        return None;
     }
+    //NOTE: we are intentionally creating the focus event even if we thing this window
+    //is already in focus. This is to force the DM to update its knowledge of the focused window
+    let act = DisplayAction::WindowTakeFocus(found.clone());
+    manager.actions.push_back(act);
 
-    //no new history for if no change
+    //no new history if no change
     if let Some(fw) = manager.focused_window() {
-        if fw.handle == window.handle {
-            return false;
+        if &fw.handle == handle {
+            //NOTE: we still made the action so return some
+            return Some(found.clone());
         }
     }
     //clean old ones
@@ -117,13 +91,78 @@ fn _focus_window_work(manager: &mut Manager, window: &Window) -> bool {
         manager.focused_window_history.pop_back();
     }
     //add this focus to the history
-    manager
-        .focused_window_history
-        .push_front(window.handle.clone());
-    // inform the window it will be taking focus
-    let act = DisplayAction::WindowTakeFocus(window.clone());
+    manager.focused_window_history.push_front(handle.clone());
+
+    Some(found.clone())
+}
+
+pub fn move_cursor_over(manager: &mut Manager, window: &Window) {
+    let act = DisplayAction::MoveMouseOver(window.handle.clone());
     manager.actions.push_back(act);
-    true
+}
+
+pub fn validate_focus_at(manager: &mut Manager, x: i32, y: i32) -> bool {
+    let current = match manager.focused_window() {
+        Some(w) => w,
+        None => return false,
+    };
+    //only look at windows we can focus
+    let found: Option<Window> = manager
+        .windows
+        .iter()
+        .filter(|x| !x.never_focus && x.type_ != WindowType::Dock && x.visible())
+        .find(|w| w.contains_point(x, y))
+        .cloned();
+    match found {
+        Some(window) => {
+            //only do the focus if we need to
+            let handle = window.handle;
+            if current.handle == handle {
+                return false;
+            }
+            focus_window(manager, &handle)
+        }
+        None => false,
+    }
+}
+
+pub fn move_focus_to_point(manager: &mut Manager, x: i32, y: i32) -> bool {
+    let found: Option<Window> = manager
+        .windows
+        .iter()
+        .filter(|x| !x.never_focus && x.type_ != WindowType::Dock && x.visible())
+        .find(|w| w.contains_point(x, y))
+        .cloned();
+    match found {
+        Some(found) => focus_window(manager, &found.handle),
+        None => {
+            //backup plan, move focus first window in workspace
+            focus_closest_window(manager, x, y)
+        }
+    }
+}
+
+fn focus_closest_window(manager: &mut Manager, x: i32, y: i32) -> bool {
+    let mut dists: Vec<(i32, &Window)> = manager
+        .windows
+        .iter()
+        .filter(|x| !x.never_focus && x.type_ != WindowType::Dock && x.visible())
+        .map(|w| (distance(w, x, y), w))
+        .collect();
+    dists.sort_by(|a, b| (a.0).cmp(&b.0));
+    if let Some(first) = dists.get(0) {
+        let handle = first.1.handle.clone();
+        return focus_window(manager, &handle);
+    }
+    false
+}
+
+fn distance(window: &Window, x: i32, y: i32) -> i32 {
+    // √((x_2-x_1)²+(y_2-y_1)²)
+    let (wx, wy) = window.calculated_xyhw().center();
+    let xs = ((wx - x) * (wx - x)) as f64;
+    let ys = ((wy - y) * (wy - y)) as f64;
+    (xs + ys).sqrt().abs().floor() as i32
 }
 
 pub fn focus_workspace_under_cursor(manager: &mut Manager, x: i32, y: i32) -> bool {
@@ -149,22 +188,12 @@ pub fn focus_workspace_under_cursor(manager: &mut Manager, x: i32, y: i32) -> bo
     false
 }
 
-/*
- * marks a tag as the focused tag
- */
+/// marks a tag as the focused tag
+//NOTE: should only be called externally from this file
 pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
-    //no new history for if no change
-    if let Some(t) = manager.focused_tag(0) {
-        if t == tag {
-            return false;
-        }
+    if focus_tag_work(manager, tag).is_none() {
+        return false;
     }
-    //clean old ones
-    while manager.focused_tag_history.len() > 10 {
-        manager.focused_tag_history.pop_back();
-    }
-    //add this focus to the history
-    manager.focused_tag_history.push_front(tag.to_string());
     // check each workspace, if its displaying this tag it should be focused too
     let to_focus: Vec<Workspace> = manager
         .workspaces
@@ -173,25 +202,31 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
         .cloned()
         .collect();
     to_focus.iter().for_each(|w| {
-        focus_workspace(manager, &w);
+        focus_workspace_work(manager, w.id);
     });
+    //make sure the focused window is on this workspace
+    let act = DisplayAction::FocusWindowUnderCursor;
+    manager.actions.push_back(act);
+    true
+}
 
-    //check the currently focused window.
-    //if it isn't under this tag, move focus to a window with this tag
-    if let Some(fw) = manager.focused_window() {
-        if !fw.has_tag(tag) {
-            let win = manager
-                .windows
-                .iter()
-                .find(|win| win.has_tag(tag))
-                .map(Window::clone);
-            if let Some(win) = win {
-                let _ = _focus_window_work(manager, &win);
-            }
+fn focus_tag_work(manager: &mut Manager, tag: &str) -> Option<()> {
+    //no new history if no change
+    if let Some(t) = manager.focused_tag(0) {
+        if t == tag {
+            return None;
         }
     }
 
-    true
+    //clean old ones
+    while manager.focused_tag_history.len() > 10 {
+        manager.focused_tag_history.pop_back();
+    }
+
+    //add this focus to the history
+    manager.focused_tag_history.push_front(tag.to_string());
+
+    Some(())
 }
 
 /// Create an action to inform the DM of the new current tags.
@@ -238,10 +273,20 @@ mod tests {
     fn focusing_a_window_should_make_it_active() {
         let mut manager = Manager::default();
         screen_create_handler::process(&mut manager, Screen::default());
-        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(1), None));
-        window_handler::created(&mut manager, Window::new(WindowHandle::MockHandle(2), None));
+        window_handler::created(
+            &mut manager,
+            Window::new(WindowHandle::MockHandle(1), None),
+            -1,
+            -1,
+        );
+        window_handler::created(
+            &mut manager,
+            Window::new(WindowHandle::MockHandle(2), None),
+            -1,
+            -1,
+        );
         let expected = manager.windows[0].clone();
-        focus_window(&mut manager, &expected, 0, 0);
+        focus_window(&mut manager, &expected.handle);
         let actual = manager.focused_window().unwrap().handle.clone();
         assert_eq!(expected.handle, actual);
     }
@@ -251,11 +296,11 @@ mod tests {
         let mut manager = Manager::default();
         screen_create_handler::process(&mut manager, Screen::default());
         let window = Window::new(WindowHandle::MockHandle(1), None);
-        window_handler::created(&mut manager, window.clone());
-        focus_window(&mut manager, &window, 0, 0);
+        window_handler::created(&mut manager, window.clone(), -1, -1);
+        focus_window(&mut manager, &window.handle);
         let start_length = manager.focused_workspace_history.len();
-        window_handler::created(&mut manager, window.clone());
-        focus_window(&mut manager, &window, 0, 0);
+        window_handler::created(&mut manager, window.clone(), -1, -1);
+        focus_window(&mut manager, &window.handle);
         let end_length = manager.focused_workspace_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
@@ -313,7 +358,8 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None);
         window.tag("2");
-        focus_window(&mut manager, &window, 0, 0);
+        manager.windows.push(window.clone());
+        focus_window(&mut manager, &window.handle);
         let actual = manager.focused_tag(0).unwrap();
         assert_eq!("2", actual);
     }
@@ -326,7 +372,8 @@ mod tests {
         screen_create_handler::process(&mut manager, Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None);
         window.tag("2");
-        focus_window(&mut manager, &window, 0, 0);
+        manager.windows.push(window.clone());
+        focus_window(&mut manager, &window.handle);
         let actual = manager.focused_workspace().unwrap().id;
         let expected = manager.workspaces[1].id;
         assert_eq!(expected, actual);


### PR DESCRIPTION
Every so often xlib fails to send us Window EnterNotify events. This means we don't get notified that the cursor has moved over a window. That means focus is left in the previous window not the new window we just moused over. This Update its to address this issue. 
