### PR TITLE
Manually create more consistent behaviour in reorder_vec and added method cycle_vec to provide better behaviour to monocle and similar layouts

### DIFF
--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -120,10 +120,15 @@ fn template_handler(
 
     let mut output = template.render(&globals).unwrap();
     output = str::replace(&output, "\r", "");
-    if !newline {
+    // We use newline rather than !newline to avoid negative logic,
+    // but note the difference between print! and println!. Trying to skip println!
+    // will result in theme degradation, as in #263.
+    if newline {
+        print!("{}", output);
+    } else {
         output = str::replace(&output, "\n", "");
+        println!("{}", output);
     }
-    print!("{}", output);
     Ok(())
 }
 

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -229,7 +229,7 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;
@@ -375,7 +375,7 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -229,13 +229,13 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;
                         }
                     };
-                    helpers::reorder_vec(&mut to_reorder, is_handle, -1);
+                    helpers::cycle_vec(&mut to_reorder, -1);
                     manager.windows.append(&mut to_reorder);
                     let act = DisplayAction::MoveMouseOver(new_handle);
                     manager.actions.push_back(act);
@@ -279,13 +279,13 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;
                         }
                     };
-                    helpers::reorder_vec(&mut to_reorder, is_handle, 1);
+                    helpers::cycle_vec(&mut to_reorder, 1);
                     manager.windows.append(&mut to_reorder);
                     let act = DisplayAction::MoveMouseOver(new_handle);
                     manager.actions.push_back(act);
@@ -375,13 +375,13 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;
                         }
                     };
-                    helpers::reorder_vec(&mut to_reorder, is_handle, -1);
+                    helpers::cycle_vec(&mut to_reorder, -1);
                     manager.windows.append(&mut to_reorder);
                     let act = DisplayAction::MoveMouseOver(new_handle);
                     manager.actions.push_back(act);
@@ -425,13 +425,13 @@ pub fn process(
                     let mut to_reorder =
                         helpers::vec_extract(&mut manager.windows, for_active_workspace);
                     let is_handle = |x: &Window| -> bool { x.handle == handle };
-                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+                    let new_handle = match helpers::relative_find(&to_reorder, is_handle, -1) {
                         Some(h) => h.handle.clone(),
                         _ => {
                             return false;
                         }
                     };
-                    helpers::reorder_vec(&mut to_reorder, is_handle, 1);
+                    helpers::cycle_vec(&mut to_reorder, 1);
                     manager.windows.append(&mut to_reorder);
                     let act = DisplayAction::MoveMouseOver(new_handle);
                     manager.actions.push_back(act);

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -63,32 +63,34 @@ where
     //Manually handle edge cases to allow more consistent behaviour
     if new_index < 0 {
         new_index += len;
-        let mut i = index as i32 - 1;
-        while i != new_index - 1 {
-            let i_plus = i + 1;
-            if i < 0 {
-                i += len;
-            }
-            list[i_plus as usize] = list[i as usize].clone();
-            i -= 1;
-        }
-        list[new_index as usize] = item;
+        manual_reorder(list, len, index as i32, item, new_index, -1);
     } else if new_index >= len {
         new_index -= len;
-        let mut i = index as i32 + 1;
-        while i != new_index + 1 {
-            let i_minus = i - 1;
-            if i >= len {
-                i -= len;
-            }
-            list[i_minus as usize] = list[i as usize].clone();
-            i += 1;
-        }
-        list[new_index as usize] = item;
+        manual_reorder(list, len, index as i32, item, new_index, 1);
     } else {
         list.remove(index);
         list.insert(new_index as usize, item);
     }
+}
+
+fn manual_reorder<T>(list: &mut Vec<T>, len: i32, index: i32, item: T, new_index: i32, val: i32)
+where
+    T: Clone,
+{
+    let mut i = index + val;
+    let mut i_alt = index;
+    while i != new_index + val {
+        if i < 0 {
+            i += len;
+        }
+        if i >= len {
+            i -= len;
+        }
+        list[i_alt as usize] = list[i as usize].clone();
+        i_alt = i;
+        i += val;
+    }
+    list[new_index as usize] = item;
 }
 
 pub fn relative_find<T, F>(list: &[T], test: F, shift: i32) -> Option<&T>

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -28,6 +28,24 @@ where
     removed
 }
 
+pub fn cycle_vec<T>(list: &mut Vec<T>, shift: i32)
+where
+    T: Clone,
+{
+    let temp_list = list.clone();
+    let len = list.len() as i32;
+    for (index, item) in temp_list.iter().enumerate() {
+        let mut new_index = index as i32 + shift;
+        if new_index < 0 {
+            new_index += len;
+        }
+        if new_index >= len {
+            new_index -= len;
+        }
+        list[new_index as usize] = item.clone();
+    }
+}
+
 //shifts a object left or right in an Vec by a given amount
 pub fn reorder_vec<T, F>(list: &mut Vec<T>, test: F, shift: i32)
 where

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -41,15 +41,36 @@ where
             return;
         }
     };
-    list.remove(index);
     let mut new_index = index as i32 + shift;
+    //Manually handle edge cases to allow more consistent behaviour
     if new_index < 0 {
-        new_index += len
+        new_index += len;
+        let mut i = index as i32 - 1;
+        while i != new_index - 1 {
+            let i_plus = i + 1;
+            if i < 0 {
+                i += len;
+            }
+            list[i_plus as usize] = list[i as usize].clone();
+            i -= 1;
+        }
+        list[new_index as usize] = item;
+    } else if new_index >= len {
+        new_index -= len;
+        let mut i = index as i32 + 1;
+        while i != new_index + 1 {
+            let i_minus = i - 1;
+            if i >= len {
+                i -= len;
+            }
+            list[i_minus as usize] = list[i as usize].clone();
+            i += 1;
+        }
+        list[new_index as usize] = item;
+    } else {
+        list.remove(index);
+        list.insert(new_index as usize, item);
     }
-    if new_index >= len {
-        new_index -= len
-    }
-    list.insert(new_index as usize, item);
 }
 
 pub fn relative_find<T, F>(list: &[T], test: F, shift: i32) -> Option<&T>


### PR DESCRIPTION
Manually controlling the behave around the ends of the list allows for the behaviour to be the same and switch items in the middle of the list. No 100% if this is the best code (let me know and I will update it). This further breaks the window cycling in monocle layout, thinking about creating a custom method to handling the reordering differently where the focus is always on the head and doesn't follow the window through.