### PR TITLE
Refactor large functions into smaller ones

### DIFF
--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -19,62 +19,14 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
 
         match raw_event.get_type() {
             // new window is created
-            xlib::MapRequest => {
-                let event = xlib::XMapRequestEvent::from(raw_event);
-                //println!("MapRequest {:?}", event);
-                let handle = WindowHandle::XlibHandle(event.window);
-                //first subscribe to window events so we don't miss any
-                xw.subscribe_to_window_events(&handle);
-
-                match xw.get_window_attrs(event.window) {
-                    Ok(attr) if attr.override_redirect > 0 => None,
-                    Ok(_attr) => {
-                        let name = xw.get_window_name(event.window);
-                        let mut w = Window::new(handle, name);
-                        let trans = xw.get_transient_for(event.window);
-
-                        if let Some(hint) = xw.get_hint_sizing_as_xyhw(event.window) {
-                            hint.update_window_floating(&mut w);
-                            w.set_requested(hint)
-                        }
-
-                        w.set_states(xw.get_window_states(event.window));
-
-                        if w.floating() {
-                            if let Ok(geo) = xw.get_window_geometry(event.window) {
-                                log::debug!("geo: {geo:?}", geo = geo);
-                                geo.update_window_floating(&mut w);
-                            }
-                        }
-
-                        if let Some(trans) = trans {
-                            w.transient = Some(WindowHandle::XlibHandle(trans));
-                        }
-                        w.type_ = xw.get_window_type(event.window);
-
-                        let cursor = xw.get_cursor_point().ok()?;
-                        Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1))
-                    }
-                    Err(_) => None,
-                }
-            }
+            xlib::MapRequest => from_map_request(raw_event, xw),
 
             // window is deleted
-            xlib::UnmapNotify => {
-                let event = xlib::XUnmapEvent::from(raw_event);
-                //println!("UnmapNotify {:?}", event);
-                if event.send_event == xlib::False {
-                    None
-                } else {
-                    let h = WindowHandle::XlibHandle(event.window);
-                    Some(DisplayEvent::WindowDestroy(h))
-                }
-            }
+            xlib::UnmapNotify => from_unmap_event(raw_event),
 
             // window is deleted
             xlib::DestroyNotify => {
                 let event = xlib::XDestroyWindowEvent::from(raw_event);
-                //println!("DestroyNotify {:?}", event);
                 let h = WindowHandle::XlibHandle(event.window);
                 Some(DisplayEvent::WindowDestroy(h))
             }
@@ -85,128 +37,139 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                     Mode::Normal => {}
                 };
                 let event = xlib::XClientMessageEvent::from(raw_event);
-                //println!("ClientMessage {:?}", event);
                 event_translate_client_message::from_event(xw, event)
             }
 
             xlib::ButtonPress => {
                 let event = xlib::XButtonPressedEvent::from(raw_event);
-                //println!("ButtonPress {:?}", event);
                 let h = WindowHandle::XlibHandle(event.window);
                 Some(DisplayEvent::MouseCombo(event.state, event.button, h))
             }
-            xlib::ButtonRelease => {
-                //println!("ButtonRelease");
-                Some(DisplayEvent::ChangeToNormalMode)
-            }
+            xlib::ButtonRelease => Some(DisplayEvent::ChangeToNormalMode),
 
-            xlib::EnterNotify => {
-                match &xw.mode {
-                    Mode::MovingWindow(_) | Mode::ResizingWindow(_) => return None,
-                    Mode::Normal => {}
-                };
-                let event = xlib::XEnterWindowEvent::from(raw_event);
-                //log::trace!("EnterNotify {:?}", event);
-                let crossing = xlib::XCrossingEvent::from(raw_event);
-                if (crossing.mode != xlib::NotifyNormal || crossing.detail == xlib::NotifyInferior)
-                    && crossing.window != xw.get_default_root()
-                {
-                    return None;
-                }
-                let h = WindowHandle::XlibHandle(event.window);
-                //let mouse_loc = xw.get_pointer_location();
-                //mouse_loc.map(|loc| )
-                Some(DisplayEvent::MouseEnteredWindow(h))
-            }
+            xlib::EnterNotify => from_enter_notify(xw, raw_event),
 
             xlib::PropertyNotify => {
                 match &xw.mode {
                     Mode::MovingWindow(_) | Mode::ResizingWindow(_) => return None,
                     Mode::Normal => {}
                 };
-
                 let event = xlib::XPropertyEvent::from(raw_event);
-                //println!("PropertyNotify {:?}", event);
                 event_translate_property_notify::from_event(xw, event)
             }
 
             xlib::KeyPress => {
                 let event = xlib::XKeyEvent::from(raw_event);
-                //println!("KeyPress {:?}", event);
                 let sym = xw.keycode_to_keysym(event.keycode);
                 Some(DisplayEvent::KeyCombo(event.state, sym))
             }
 
-            xlib::MotionNotify => {
-                let event = xlib::XMotionEvent::from(raw_event);
-                //log::trace!("XMotionEvent {:?}", event);
-                let event_h = WindowHandle::XlibHandle(event.window);
-                let offset_x = event.x_root - xw.mode_origin.0;
-                let offset_y = event.y_root - xw.mode_origin.1;
-                match &xw.mode {
-                    Mode::Normal => {
-                        Some(DisplayEvent::Movement(event_h, event.x_root, event.y_root))
-                    }
-                    Mode::MovingWindow(h) => {
-                        Some(DisplayEvent::MoveWindow(*h, event.time, offset_x, offset_y))
-                    }
-                    Mode::ResizingWindow(h) => {
-                        Some(DisplayEvent::ResizeWindow(
-                            *h, event.time, offset_x, offset_y,
-                        ))
-                        //h, w
-                    }
-                }
-            }
-            xlib::FocusIn => {
-                //let event = xlib::XFocusChangeEvent::from(raw_event);
-                //println!("FocusIn {:?}", event);
-                None
-            }
+            xlib::MotionNotify => Some(from_motion_notify(raw_event, xw)),
 
-            xlib::ConfigureRequest => {
-                match &xw.mode {
-                    Mode::MovingWindow(_) | Mode::ResizingWindow(_) => return None,
-                    Mode::Normal => {}
-                };
-                let event = xlib::XConfigureRequestEvent::from(raw_event);
-                let window_type = xw.get_window_type(event.window);
+            xlib::ConfigureRequest => from_configure_request(xw, raw_event),
 
-                if window_type == WindowType::Normal {
-                    None
-                } else {
-                    let handle = WindowHandle::XlibHandle(event.window);
-                    let mut change = WindowChange::new(handle);
-                    let xyhw = XyhwChange {
-                        w: Some(event.width),
-                        h: Some(event.height),
-                        x: Some(event.x),
-                        y: Some(event.y),
-                        ..XyhwChange::default()
-                    };
-                    change.floating = Some(xyhw);
-                    if window_type == WindowType::Dock {
-                        if let Some(dock_area) = xw.get_window_strut_array(event.window) {
-                            let dems = xw.screens_area_dimensions();
-                            if let Some(strut_xywh) = dock_area.as_xyhw(dems.0, dems.1) {
-                                change.strut = Some(strut_xywh.into())
-                            }
-                        }
-                    }
-                    Some(DisplayEvent::WindowChange(change))
-                }
-                /*
-                 ConfigureRequest XConfigureRequestEvent { type_: 23, serial: 1157, send_event: 0,
-                 display: 0x5604f8d70a00, parent: 414, window: 62914566, x: 0, y: 0,
-                 width: 450, height: 215, border_width: 0, above: 0, detail: 0, value_mask: 12 }
-                */
-            }
+            _other => None,
+        }
+    }
+}
 
-            _other => {
-                //println!("Xevent Other {:?}", _other);
-                //log::warn!("Xevent Other {:?}", _other);
-                None
+fn from_map_request(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent> {
+    let event = xlib::XMapRequestEvent::from(raw_event);
+    let handle = WindowHandle::XlibHandle(event.window);
+    xw.subscribe_to_window_events(&handle);
+    //check that the window isn't requesting to be unmanaged
+    let attr = xw.get_window_attrs(event.window).ok()?;
+    if attr.override_redirect > 0 {
+        return None;
+    }
+    //build the new window, and fill in info about it from xlib
+    let name = xw.get_window_name(event.window);
+    let mut w = Window::new(handle, name);
+    let trans = xw.get_transient_for(event.window);
+    if let Some(hint) = xw.get_hint_sizing_as_xyhw(event.window) {
+        hint.update_window_floating(&mut w);
+        w.set_requested(hint)
+    }
+    w.set_states(xw.get_window_states(event.window));
+    if w.floating() {
+        if let Ok(geo) = xw.get_window_geometry(event.window) {
+            log::debug!("geo: {geo:?}", geo = geo);
+            geo.update_window_floating(&mut w);
+        }
+    }
+    if let Some(trans) = trans {
+        w.transient = Some(WindowHandle::XlibHandle(trans));
+    }
+    w.type_ = xw.get_window_type(event.window);
+    let cursor = xw.get_cursor_point().unwrap_or_default();
+    Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1))
+}
+
+fn from_unmap_event(raw_event: xlib::XEvent) -> Option<DisplayEvent> {
+    let event = xlib::XUnmapEvent::from(raw_event);
+    if event.send_event == xlib::False {
+        None
+    } else {
+        let h = WindowHandle::XlibHandle(event.window);
+        Some(DisplayEvent::WindowDestroy(h))
+    }
+}
+
+fn from_enter_notify(xw: &XWrap, raw_event: xlib::XEvent) -> Option<DisplayEvent> {
+    match &xw.mode {
+        Mode::MovingWindow(_) | Mode::ResizingWindow(_) => return None,
+        Mode::Normal => {}
+    };
+    let event = xlib::XEnterWindowEvent::from(raw_event);
+    let crossing = xlib::XCrossingEvent::from(raw_event);
+    if (crossing.mode != xlib::NotifyNormal || crossing.detail == xlib::NotifyInferior)
+        && crossing.window != xw.get_default_root()
+    {
+        return None;
+    }
+    let h = WindowHandle::XlibHandle(event.window);
+    Some(DisplayEvent::MouseEnteredWindow(h))
+}
+
+fn from_motion_notify(raw_event: xlib::XEvent, xw: &XWrap) -> DisplayEvent {
+    let event = xlib::XMotionEvent::from(raw_event);
+    let event_h = WindowHandle::XlibHandle(event.window);
+    let offset_x = event.x_root - xw.mode_origin.0;
+    let offset_y = event.y_root - xw.mode_origin.1;
+    match &xw.mode {
+        Mode::Normal => DisplayEvent::Movement(event_h, event.x_root, event.y_root),
+        Mode::MovingWindow(h) => DisplayEvent::MoveWindow(*h, event.time, offset_x, offset_y),
+        Mode::ResizingWindow(h) => DisplayEvent::ResizeWindow(*h, event.time, offset_x, offset_y),
+    }
+}
+
+fn from_configure_request(xw: &XWrap, raw_event: xlib::XEvent) -> Option<DisplayEvent> {
+    match &xw.mode {
+        Mode::MovingWindow(_) | Mode::ResizingWindow(_) => return None,
+        Mode::Normal => {}
+    };
+    let event = xlib::XConfigureRequestEvent::from(raw_event);
+    let window_type = xw.get_window_type(event.window);
+    if window_type == WindowType::Normal {
+        return None;
+    }
+    let handle = WindowHandle::XlibHandle(event.window);
+    let mut change = WindowChange::new(handle);
+    let xyhw = XyhwChange {
+        w: Some(event.width),
+        h: Some(event.height),
+        x: Some(event.x),
+        y: Some(event.y),
+        ..XyhwChange::default()
+    };
+    change.floating = Some(xyhw);
+    if window_type == WindowType::Dock {
+        if let Some(dock_area) = xw.get_window_strut_array(event.window) {
+            let dems = xw.screens_area_dimensions();
+            if let Some(strut_xywh) = dock_area.as_xyhw(dems.0, dems.1) {
+                change.strut = Some(strut_xywh.into())
             }
         }
     }
+    Some(DisplayEvent::WindowChange(change))
 }

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -19,457 +19,43 @@ pub fn process(
     val: Option<String>,
 ) -> bool {
     match command {
-        Command::MoveToTag if val.is_none() => false,
-        Command::MoveToTag if !is_num(&val) => false,
-        Command::MoveToTag if to_num(&val) > manager.tags.len() => false,
-        Command::MoveToTag if to_num(&val) < 1 => false,
-        Command::MoveToTag => {
-            let tag_num = to_num(&val);
-            let tag = manager.tags[tag_num - 1].clone();
-            if let Some(window) = manager.focused_window_mut() {
-                window.clear_tags();
-                window.set_floating(false);
-                window.tag(&tag.id);
-                let act = DisplayAction::SetWindowTags(window.handle, tag.id.clone());
-                manager.actions.push_back(act);
-                manager.sort_windows();
-            }
-            true
-        }
-
-        Command::GotoTag if val.is_none() => false,
-        Command::GotoTag if !is_num(&val) => false,
-        Command::GotoTag => {
-            let current_tag = manager.tag_index(&manager.focused_tag(0).unwrap_or_default());
-            let previous_tag = manager.tag_index(&manager.focused_tag(1).unwrap_or_default());
-            let input_tag = to_num(&val);
-            let mut destination_tag = input_tag;
-
-            if !config.disable_current_tag_swap {
-                destination_tag = match (current_tag, previous_tag, input_tag) {
-                    (Some(curr_tag), Some(prev_tag), inp_tag) if curr_tag + 1 == inp_tag => {
-                        prev_tag + 1
-                    } // if current tag is the same as the destination tag, go to the previous tag instead
-                    (_, _, _) => input_tag, // go to the input tag tag
-                };
-            }
-            goto_tag_handler::process(manager, destination_tag)
-        }
-
-        Command::FocusNextTag => {
-            let current = manager.focused_tag(0);
-            let current = current.unwrap();
-            let mut index = match manager.tags.iter().position(|x| x.id == current) {
-                Some(x) => x + 1,
-                None => {
-                    return false;
-                }
-            };
-
-            index += 1;
-
-            if index > manager.tags.len() {
-                index = 1;
-            }
-
-            goto_tag_handler::process(manager, index)
-        }
-
-        Command::FocusPreviousTag => {
-            let current = manager.focused_tag(0);
-            let current = current.unwrap();
-            let mut index = match manager.tags.iter().position(|x| x.id == current) {
-                Some(x) => x + 1,
-                None => {
-                    return false;
-                }
-            };
-
-            index -= 1;
-            if index < 1 {
-                index = manager.tags.len();
-            }
-
-            goto_tag_handler::process(manager, index)
-        }
-
         Command::Execute if val.is_none() => false,
         Command::Execute => {
             exec_shell(&val.unwrap(), &mut manager);
             false
         }
 
-        Command::CloseWindow => {
-            if let Some(window) = manager.focused_window() {
-                if window.type_ != WindowType::Dock {
-                    let act = DisplayAction::KillWindow(window.handle);
-                    manager.actions.push_back(act);
-                }
-            }
-            false
-        }
+        Command::MoveToTag if val.is_none() => false,
+        Command::MoveToTag if !is_num(&val) => false,
+        Command::MoveToTag if to_num(&val) > manager.tags.len() => false,
+        Command::MoveToTag if to_num(&val) < 1 => false,
+        Command::MoveToTag => move_to_tag(&val, manager),
 
-        Command::SwapTags => {
-            // If multi workspace, swap with other workspace
-            if manager.workspaces.len() >= 2 && manager.focused_workspace_history.len() >= 2 {
-                let mut a = manager.workspaces[manager.focused_workspace_history[0]].clone();
-                let mut b = manager.workspaces[manager.focused_workspace_history[1]].clone();
-                let swap = a.tags.clone();
-                a.tags = b.tags.clone();
-                b.tags = swap;
-                manager.workspaces[manager.focused_workspace_history[0]] = a;
-                manager.workspaces[manager.focused_workspace_history[1]] = b;
-                return true;
-            }
-            // If single workspace, swap width previous tag
-            if manager.workspaces.len() == 1 {
-                let last = manager
-                    .focused_tag_history
-                    .get(1)
-                    .map(std::string::ToString::to_string);
-                if let Some(last) = last {
-                    let tag_index = match manager.tags.iter().position(|x| x.id == last) {
-                        Some(x) => x + 1,
-                        None => return false,
-                    };
-                    return goto_tag_handler::process(manager, tag_index);
-                }
-            }
-            false
-        }
+        Command::MoveWindowUp => move_window_up(manager),
+        Command::MoveWindowDown => move_window_down(manager),
+        Command::MoveWindowTop => move_window_top(manager),
 
-        Command::MoveToLastWorkspace => {
-            if manager.workspaces.len() >= 2 && manager.focused_workspace_history.len() >= 2 {
-                let wp_tags = &manager.workspaces[manager.focused_workspace_history[1]]
-                    .tags
-                    .clone();
-                if let Some(window) = manager.focused_window_mut() {
-                    window.tags = vec![wp_tags[0].clone()];
-                    return true;
-                }
-            }
-            false
-        }
+        Command::GotoTag if val.is_none() => false,
+        Command::GotoTag if !is_num(&val) => false,
+        Command::GotoTag => goto_tag(manager, &val, config),
 
-        Command::NextLayout => {
-            if let Some(workspace) = manager.focused_workspace_mut() {
-                workspace.next_layout();
-                return true;
-            }
-            false
-        }
-        Command::PreviousLayout => {
-            if let Some(workspace) = manager.focused_workspace_mut() {
-                workspace.prev_layout();
-                return true;
-            }
-            false
-        }
+        Command::CloseWindow => close_window(manager),
+        Command::SwapTags => swap_tags(manager),
+        Command::MoveToLastWorkspace => move_to_last_workspace(manager),
+        Command::NextLayout => next_layout(manager),
+        Command::PreviousLayout => previous_layout(manager),
 
         Command::SetLayout if val.is_none() => false,
-        Command::SetLayout => {
-            if let Some(layout) = to_layout(&val) {
-                if let Some(workspace) = manager.focused_workspace_mut() {
-                    workspace.set_layout(layout);
-                    return true;
-                }
-            } // TODO: Print error message about invalid layout name
-            false
-        }
+        Command::SetLayout => set_layout(&val, manager),
 
-        Command::FloatingToTile => {
-            let workspace = manager.focused_workspace().unwrap().clone();
-            if let Some(window) = manager.focused_window_mut() {
-                if window.must_float() {
-                    return false;
-                }
-                //Not ideal as is_floating and must_float are connected so have to check
-                //them separately
-                if !window.floating() {
-                    return false;
-                }
-                window_handler::snap_to_workspace(window, &workspace);
-                let act = DisplayAction::MoveMouseOver(window.handle);
-                manager.actions.push_back(act);
-                return true;
-            }
-            false
-        }
+        Command::FloatingToTile => floating_to_tile(manager),
 
-        Command::MoveWindowUp => {
-            let handle = match manager.focused_window() {
-                Some(h) => h.handle,
-                None => {
-                    return false;
-                }
-            };
-            let (tags, layout) = match manager.focused_workspace() {
-                Some(w) => (w.tags.clone(), Some(w.layout.clone())),
-                None => {
-                    return false;
-                }
-            };
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
-            };
-
-            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
-            let is_handle = |x: &Window| -> bool { x.handle == handle };
-            helpers::reorder_vec(&mut to_reorder, is_handle, -1);
-            manager.windows.append(&mut to_reorder);
-            let mut act = DisplayAction::MoveMouseOver(handle);
-            if let Some(crate::layouts::Layout::Monocle) = layout {
-                // For Monocle we want to also move windows up/down
-                // Not the best solution but results
-                // in desired behaviour
-                let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
-                    Some(h) => h.handle,
-                    None => {
-                        return false;
-                    }
-                };
-                act = DisplayAction::MoveMouseOver(new_handle);
-            }
-            manager.actions.push_back(act);
-            true
-        }
-
-        Command::MoveWindowDown => {
-            let handle = match manager.focused_window() {
-                Some(h) => h.handle,
-                None => {
-                    return false;
-                }
-            };
-            let (tags, layout) = match manager.focused_workspace() {
-                Some(w) => (w.tags.clone(), Some(w.layout.clone())),
-                None => {
-                    return false;
-                }
-            };
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
-            };
-
-            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
-            let is_handle = |x: &Window| -> bool { x.handle == handle };
-            let mut act = DisplayAction::MoveMouseOver(handle);
-            helpers::reorder_vec(&mut to_reorder, is_handle, 1);
-            manager.windows.append(&mut to_reorder);
-            if let Some(crate::layouts::Layout::Monocle) = layout {
-                // For Monocle we want to also move windows up/down
-                // Not the best solution but results
-                // in desired behaviour
-                let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
-                    Some(h) => h.handle,
-                    None => {
-                        return false;
-                    }
-                };
-                act = DisplayAction::MoveMouseOver(new_handle);
-            }
-
-            manager.actions.push_back(act);
-            true
-        }
-        // Moves the selected window at index 0 of the window list.
-        // If the selected window is already at index 0, it is sent to index 1.
-        Command::MoveWindowTop => {
-            let handle = match manager.focused_window() {
-                Some(h) => h.handle,
-                None => {
-                    return false;
-                }
-            };
-            let tags = match manager.focused_workspace() {
-                Some(w) => w.tags.clone(),
-                None => {
-                    return false;
-                }
-            };
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
-            };
-            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
-            let is_handle = |x: &Window| -> bool { x.handle == handle };
-            let list = &mut to_reorder;
-            let len = list.len();
-            let (index, item) = match list.iter().enumerate().find(|&x| is_handle(&x.1)) {
-                Some(x) => (x.0, x.1.clone()),
-                None => {
-                    return false;
-                }
-            };
-            list.remove(index);
-            let mut new_index: usize = match index {
-                0 => 1,
-                _ => 0,
-            };
-            if new_index >= len {
-                new_index -= len
-            }
-            list.insert(new_index, item);
-
-            manager.windows.append(&mut to_reorder);
-            // focus follows the window if it was not already on top of the stack
-            if index > 0 {
-                let act = DisplayAction::MoveMouseOver(handle);
-                manager.actions.push_back(act);
-            }
-            true
-        }
-
-        Command::FocusWindowUp => {
-            let handle = match manager.focused_window() {
-                Some(h) => h.handle,
-                None => {
-                    return false;
-                }
-            };
-            let (tags, layout) = match manager.focused_workspace() {
-                Some(w) => (w.tags.clone(), Some(w.layout.clone())),
-                None => {
-                    return false;
-                }
-            };
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
-            };
-
-            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
-            let is_handle = |x: &Window| -> bool { x.handle == handle };
-            if let Some(crate::layouts::Layout::Monocle) = layout {
-                let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
-                    Some(h) => h.handle,
-                    None => {
-                        return false;
-                    }
-                };
-                helpers::reorder_vec(&mut to_reorder, is_handle, -1);
-                let act = DisplayAction::MoveMouseOver(new_handle);
-                manager.actions.push_back(act);
-            } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, -1) {
-                let act = DisplayAction::MoveMouseOver(new_focused.handle);
-                manager.actions.push_back(act);
-            }
-            manager.windows.append(&mut to_reorder);
-            true
-        }
-
-        Command::FocusWindowDown => {
-            let handle = match manager.focused_window() {
-                Some(h) => h.handle,
-                None => {
-                    return false;
-                }
-            };
-            let (tags, layout) = match manager.focused_workspace() {
-                Some(w) => (w.tags.clone(), Some(w.layout.clone())),
-                None => {
-                    return false;
-                }
-            };
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock
-            };
-
-            let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
-            let is_handle = |x: &Window| -> bool { x.handle == handle };
-            if let Some(crate::layouts::Layout::Monocle) = layout {
-                // For Monocle we want to also move windows up/down
-                // Not the best solution but results in desired behaviour
-                let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
-                    Some(h) => h.handle,
-                    None => {
-                        return false;
-                    }
-                };
-                helpers::reorder_vec(&mut to_reorder, is_handle, 1);
-                let act = DisplayAction::MoveMouseOver(new_handle);
-                manager.actions.push_back(act);
-            } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, -1) {
-                let act = DisplayAction::MoveMouseOver(new_focused.handle);
-                manager.actions.push_back(act);
-            }
-            manager.windows.append(&mut to_reorder);
-            true
-        }
-
-        Command::FocusWorkspaceNext => {
-            let current = manager.focused_workspace();
-            if current.is_none() {
-                return false;
-            }
-            let current = current.unwrap();
-            let mut index = match manager
-                .workspaces
-                .iter()
-                .enumerate()
-                .find(|&x| x.1 == current)
-            {
-                Some(x) => x.0,
-                None => {
-                    return false;
-                }
-            };
-            index += 1;
-            if index >= manager.workspaces.len() {
-                index = 0;
-            }
-            let workspace = manager.workspaces[index].clone();
-            focus_handler::focus_workspace(manager, &workspace);
-            let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
-            manager.actions.push_back(act);
-            if let Some(window) = manager
-                .windows
-                .iter()
-                .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
-            {
-                let window = window.clone();
-                focus_handler::move_cursor_over(manager, &window);
-                let act = DisplayAction::MoveMouseOver(window.handle);
-                manager.actions.push_back(act);
-            }
-            true
-        }
-
-        Command::FocusWorkspacePrevious => {
-            let current = manager.focused_workspace();
-            if current.is_none() {
-                return false;
-            }
-            let current = current.unwrap();
-            let mut index = match manager
-                .workspaces
-                .iter()
-                .enumerate()
-                .find(|&x| x.1 == current)
-            {
-                Some(x) => x.0 as i32,
-                None => {
-                    return false;
-                }
-            };
-            index -= 1;
-            if index < 0 {
-                index = (manager.workspaces.len() as i32) - 1;
-            }
-            let workspace = manager.workspaces[index as usize].clone();
-            focus_handler::focus_workspace(manager, &workspace);
-            let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
-            manager.actions.push_back(act);
-            if let Some(window) = manager
-                .windows
-                .iter()
-                .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
-            {
-                let window = window.clone();
-                focus_handler::move_cursor_over(manager, &window);
-                let act = DisplayAction::MoveMouseOver(window.handle);
-                manager.actions.push_back(act);
-            }
-            true
-        }
+        Command::FocusNextTag => focus_next_tag(manager),
+        Command::FocusPreviousTag => focus_previous_tag(manager),
+        Command::FocusWindowUp => focus_window_up(manager),
+        Command::FocusWindowDown => focus_window_down(manager),
+        Command::FocusWorkspaceNext => focus_workspace_next(manager),
+        Command::FocusWorkspacePrevious => focus_workspace_previous(manager),
 
         Command::MouseMoveWindow => false,
 
@@ -483,28 +69,448 @@ pub fn process(
         }
 
         Command::IncreaseMainWidth if val.is_none() => false,
-        Command::IncreaseMainWidth => {
-            let workspace = manager.focused_workspace_mut();
-            if workspace.is_none() {
-                return false;
-            }
-            let workspace = workspace.unwrap();
-            let delta: u8 = (&val.unwrap()).parse().unwrap();
-            workspace.increase_main_width(delta);
-            true
-        }
+        Command::IncreaseMainWidth => increase_main_width(manager, &val),
         Command::DecreaseMainWidth if val.is_none() => false,
-        Command::DecreaseMainWidth => {
-            let workspace = manager.focused_workspace_mut();
-            if workspace.is_none() {
-                return false;
-            }
-            let workspace = workspace.unwrap();
-            let delta: u8 = (&val.unwrap()).parse().unwrap();
-            workspace.decrease_main_width(delta);
-            true
+        Command::DecreaseMainWidth => decrease_main_width(manager, &val),
+    }
+}
+
+fn move_to_tag(val: &Option<String>, manager: &mut Manager) -> bool {
+    let tag_num = to_num(val);
+    let tag = manager.tags[tag_num - 1].clone();
+    if let Some(window) = manager.focused_window_mut() {
+        window.clear_tags();
+        window.set_floating(false);
+        window.tag(&tag.id);
+        let act = DisplayAction::SetWindowTags(window.handle, tag.id.clone());
+        manager.actions.push_back(act);
+        manager.sort_windows();
+    }
+    true
+}
+
+fn goto_tag(manager: &mut Manager, val: &Option<String>, config: &Config) -> bool {
+    let current_tag = manager.tag_index(&manager.focused_tag(0).unwrap_or_default());
+    let previous_tag = manager.tag_index(&manager.focused_tag(1).unwrap_or_default());
+    let input_tag = to_num(val);
+    let mut destination_tag = input_tag;
+    if !config.disable_current_tag_swap {
+        destination_tag = match (current_tag, previous_tag, input_tag) {
+            (Some(curr_tag), Some(prev_tag), inp_tag) if curr_tag + 1 == inp_tag => prev_tag + 1, // if current tag is the same as the destination tag, go to the previous tag instead
+            (_, _, _) => input_tag, // go to the input tag tag
+        };
+    }
+    goto_tag_handler::process(manager, destination_tag)
+}
+
+fn focus_next_tag(manager: &mut Manager) -> bool {
+    let current = manager.focused_tag(0);
+    let current = current.unwrap();
+    let mut index = match manager.tags.iter().position(|x| x.id == current) {
+        Some(x) => x + 1,
+        None => {
+            return false;
+        }
+    };
+    index += 1;
+    if index > manager.tags.len() {
+        index = 1;
+    }
+    goto_tag_handler::process(manager, index)
+}
+
+fn focus_previous_tag(manager: &mut Manager) -> bool {
+    let current = manager.focused_tag(0);
+    let current = current.unwrap();
+    let mut index = match manager.tags.iter().position(|x| x.id == current) {
+        Some(x) => x + 1,
+        None => {
+            return false;
+        }
+    };
+    index -= 1;
+    if index < 1 {
+        index = manager.tags.len();
+    }
+    goto_tag_handler::process(manager, index)
+}
+
+fn swap_tags(manager: &mut Manager) -> bool {
+    if manager.workspaces.len() >= 2 && manager.focused_workspace_history.len() >= 2 {
+        let mut a = manager.workspaces[manager.focused_workspace_history[0]].clone();
+        let mut b = manager.workspaces[manager.focused_workspace_history[1]].clone();
+        let swap = a.tags.clone();
+        a.tags = b.tags.clone();
+        b.tags = swap;
+        manager.workspaces[manager.focused_workspace_history[0]] = a;
+        manager.workspaces[manager.focused_workspace_history[1]] = b;
+        return true;
+    }
+    if manager.workspaces.len() == 1 {
+        let last = manager
+            .focused_tag_history
+            .get(1)
+            .map(std::string::ToString::to_string);
+        if let Some(last) = last {
+            let tag_index = match manager.tags.iter().position(|x| x.id == last) {
+                Some(x) => x + 1,
+                None => return false,
+            };
+            return goto_tag_handler::process(manager, tag_index);
         }
     }
+    false
+}
+
+fn close_window(manager: &mut Manager) -> bool {
+    if let Some(window) = manager.focused_window() {
+        if window.type_ != WindowType::Dock {
+            let act = DisplayAction::KillWindow(window.handle);
+            manager.actions.push_back(act);
+        }
+    }
+    false
+}
+
+fn move_to_last_workspace(manager: &mut Manager) -> bool {
+    if manager.workspaces.len() >= 2 && manager.focused_workspace_history.len() >= 2 {
+        let wp_tags = &manager.workspaces[manager.focused_workspace_history[1]]
+            .tags
+            .clone();
+        if let Some(window) = manager.focused_window_mut() {
+            window.tags = vec![wp_tags[0].clone()];
+            return true;
+        }
+    }
+    false
+}
+
+fn next_layout(manager: &mut Manager) -> bool {
+    if let Some(workspace) = manager.focused_workspace_mut() {
+        workspace.next_layout();
+        return true;
+    }
+    false
+}
+
+fn previous_layout(manager: &mut Manager) -> bool {
+    if let Some(workspace) = manager.focused_workspace_mut() {
+        workspace.prev_layout();
+        return true;
+    }
+    false
+}
+
+fn set_layout(val: &Option<String>, manager: &mut Manager) -> bool {
+    if let Some(layout) = to_layout(val) {
+        if let Some(workspace) = manager.focused_workspace_mut() {
+            workspace.set_layout(layout);
+            return true;
+        }
+    }
+    false
+}
+
+fn floating_to_tile(manager: &mut Manager) -> bool {
+    let workspace = manager.focused_workspace().unwrap().clone();
+    if let Some(window) = manager.focused_window_mut() {
+        if window.must_float() {
+            return false;
+        }
+        //Not ideal as is_floating and must_float are connected so have to check
+        //them separately
+        if !window.floating() {
+            return false;
+        }
+        window_handler::snap_to_workspace(window, &workspace);
+        let act = DisplayAction::MoveMouseOver(window.handle);
+        manager.actions.push_back(act);
+        return true;
+    }
+    false
+}
+
+fn move_window_up(manager: &mut Manager) -> bool {
+    let handle = match manager.focused_window() {
+        Some(h) => h.handle,
+        None => {
+            return false;
+        }
+    };
+    let (tags, layout) = match manager.focused_workspace() {
+        Some(w) => (w.tags.clone(), Some(w.layout.clone())),
+        None => {
+            return false;
+        }
+    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+    let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+    let is_handle = |x: &Window| -> bool { x.handle == handle };
+    helpers::reorder_vec(&mut to_reorder, is_handle, -1);
+    manager.windows.append(&mut to_reorder);
+    let mut act = DisplayAction::MoveMouseOver(handle);
+    if let Some(crate::layouts::Layout::Monocle) = layout {
+        // For Monocle we want to also move windows up/down
+        // Not the best solution but results
+        // in desired behaviour
+        let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+            Some(h) => h.handle,
+            None => {
+                return false;
+            }
+        };
+        act = DisplayAction::MoveMouseOver(new_handle);
+    }
+    manager.actions.push_back(act);
+    true
+}
+
+fn move_window_down(manager: &mut Manager) -> bool {
+    let handle = match manager.focused_window() {
+        Some(value) => value.handle,
+        None => return false,
+    };
+
+    let (tags, layout) = match manager.focused_workspace() {
+        Some(w) => (w.tags.clone(), Some(w.layout.clone())),
+        None => {
+            return false;
+        }
+    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+    let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+    let is_handle = |x: &Window| -> bool { x.handle == handle };
+    let mut act = DisplayAction::MoveMouseOver(handle);
+    helpers::reorder_vec(&mut to_reorder, is_handle, 1);
+    manager.windows.append(&mut to_reorder);
+    if let Some(crate::layouts::Layout::Monocle) = layout {
+        // For Monocle we want to also move windows up/down
+        // Not the best solution but results
+        // in desired behaviour
+        let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+            Some(h) => h.handle,
+            None => {
+                return false;
+            }
+        };
+        act = DisplayAction::MoveMouseOver(new_handle);
+    }
+    manager.actions.push_back(act);
+    true
+}
+
+fn move_window_top(manager: &mut Manager) -> bool {
+    // Moves the selected window at index 0 of the window list.
+    // If the selected window is already at index 0, it is sent to index 1.
+    let handle = match manager.focused_window() {
+        Some(value) => value.handle,
+        None => return false,
+    };
+    let tags = match manager.focused_workspace() {
+        Some(w) => w.tags.clone(),
+        None => {
+            return false;
+        }
+    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+    let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+    let is_handle = |x: &Window| -> bool { x.handle == handle };
+    let list = &mut to_reorder;
+    let len = list.len();
+    let (index, item) = match list.iter().enumerate().find(|&x| is_handle(&x.1)) {
+        Some(x) => (x.0, x.1.clone()),
+        None => {
+            return false;
+        }
+    };
+    list.remove(index);
+    let mut new_index: usize = match index {
+        0 => 1,
+        _ => 0,
+    };
+    if new_index >= len {
+        new_index -= len
+    }
+    list.insert(new_index, item);
+    manager.windows.append(&mut to_reorder);
+    if index > 0 {
+        let act = DisplayAction::MoveMouseOver(handle);
+        manager.actions.push_back(act);
+    }
+    true
+}
+
+fn focus_window_up(manager: &mut Manager) -> bool {
+    let handle = match manager.focused_window() {
+        Some(h) => h.handle,
+        None => {
+            return false;
+        }
+    };
+    let (tags, layout) = match manager.focused_workspace() {
+        Some(w) => (w.tags.clone(), Some(w.layout.clone())),
+        None => {
+            return false;
+        }
+    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+    let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+    let is_handle = |x: &Window| -> bool { x.handle == handle };
+    if let Some(crate::layouts::Layout::Monocle) = layout {
+        let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+            Some(h) => h.handle,
+            None => {
+                return false;
+            }
+        };
+        helpers::reorder_vec(&mut to_reorder, is_handle, -1);
+        let act = DisplayAction::MoveMouseOver(new_handle);
+        manager.actions.push_back(act);
+    } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, -1) {
+        let act = DisplayAction::MoveMouseOver(new_focused.handle);
+        manager.actions.push_back(act);
+    }
+    manager.windows.append(&mut to_reorder);
+    true
+}
+
+fn focus_window_down(manager: &mut Manager) -> bool {
+    let handle = match manager.focused_window() {
+        Some(h) => h.handle,
+        None => {
+            return false;
+        }
+    };
+    let (tags, layout) = match manager.focused_workspace() {
+        Some(w) => (w.tags.clone(), Some(w.layout.clone())),
+        None => {
+            return false;
+        }
+    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+    let mut to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
+    let is_handle = |x: &Window| -> bool { x.handle == handle };
+    if let Some(crate::layouts::Layout::Monocle) = layout {
+        // For Monocle we want to also move windows up/down
+        // Not the best solution but results in desired behaviour
+        let new_handle = match helpers::relative_find(&to_reorder, is_handle, 1) {
+            Some(h) => h.handle,
+            None => {
+                return false;
+            }
+        };
+        helpers::reorder_vec(&mut to_reorder, is_handle, 1);
+        let act = DisplayAction::MoveMouseOver(new_handle);
+        manager.actions.push_back(act);
+    } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, -1) {
+        let act = DisplayAction::MoveMouseOver(new_focused.handle);
+        manager.actions.push_back(act);
+    }
+    manager.windows.append(&mut to_reorder);
+    true
+}
+
+fn focus_workspace_next(manager: &mut Manager) -> bool {
+    let current = manager.focused_workspace();
+    if current.is_none() {
+        return false;
+    }
+    let current = current.unwrap();
+    let mut index = match manager
+        .workspaces
+        .iter()
+        .enumerate()
+        .find(|&x| x.1 == current)
+    {
+        Some(x) => x.0,
+        None => {
+            return false;
+        }
+    };
+    index += 1;
+    if index >= manager.workspaces.len() {
+        index = 0;
+    }
+    let workspace = manager.workspaces[index].clone();
+    focus_handler::focus_workspace(manager, &workspace);
+    let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
+    manager.actions.push_back(act);
+    if let Some(window) = manager
+        .windows
+        .iter()
+        .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
+    {
+        let window = window.clone();
+        focus_handler::move_cursor_over(manager, &window);
+        let act = DisplayAction::MoveMouseOver(window.handle);
+        manager.actions.push_back(act);
+    }
+    true
+}
+
+fn focus_workspace_previous(manager: &mut Manager) -> bool {
+    let current = manager.focused_workspace();
+    if current.is_none() {
+        return false;
+    }
+    let current = current.unwrap();
+    let mut index = match manager
+        .workspaces
+        .iter()
+        .enumerate()
+        .find(|&x| x.1 == current)
+    {
+        Some(x) => x.0 as i32,
+        None => {
+            return false;
+        }
+    };
+    index -= 1;
+    if index < 0 {
+        index = (manager.workspaces.len() as i32) - 1;
+    }
+    let workspace = manager.workspaces[index as usize].clone();
+    focus_handler::focus_workspace(manager, &workspace);
+    let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
+    manager.actions.push_back(act);
+    if let Some(window) = manager
+        .windows
+        .iter()
+        .find(|w| workspace.is_displaying(w) && w.type_ == WindowType::Normal)
+    {
+        let window = window.clone();
+        focus_handler::move_cursor_over(manager, &window);
+        let act = DisplayAction::MoveMouseOver(window.handle);
+        manager.actions.push_back(act);
+    }
+    true
+}
+
+fn increase_main_width(manager: &mut Manager, val: &Option<String>) -> bool {
+    let workspace = manager.focused_workspace_mut();
+    if workspace.is_none() {
+        return false;
+    }
+    let workspace = workspace.unwrap();
+    let delta: u8 = (val.as_ref().unwrap()).parse().unwrap();
+    workspace.increase_main_width(delta);
+    true
+}
+
+fn decrease_main_width(manager: &mut Manager, val: &Option<String>) -> bool {
+    let workspace = manager.focused_workspace_mut();
+    if workspace.is_none() {
+        return false;
+    }
+    let workspace = workspace.unwrap();
+    let delta: u8 = (val.as_ref().unwrap()).parse().unwrap();
+    workspace.decrease_main_width(delta);
+    true
 }
 
 /// Is the string passed in a valid number


### PR DESCRIPTION
@mautamu I appreciate your help cleaning up the code base. I thought I would help out too. I don't want to step on your toes with this project so if you want to take a different route that's cool with me. Here is a start of a refactor of the two big switch blocks. I have taken the content of each branch and pulled them out into a function. That is all. There should be no logical changes in this PR. 

My thinking here is its much easier to work with smaller functions. I could organize them into different files or refactor the contents individually. this is just a step one... 
