### PR TITLE
Faster vec_extract: Testing requested

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -18,13 +18,26 @@ where
     F: Fn(&T) -> bool,
     T: Clone,
 {
+    let len = list.len();
     let mut removed = vec![];
-    for x in list.iter() {
-        if test(x) {
-            removed.push(x.clone())
+    let mut del = 0;
+        let v = &mut **list;
+
+        for i in 0..len {
+            if test(&v[i]) {
+                removed.push(v[i].clone());
+                del += 1;
+            } else if del > 0 {
+                v.swap(i - del, i);
+                //This is faster but crashes
+                // let src: *const T = &v[i];
+                // let dst: *mut T = &mut v[i - del];
+                // unsafe {
+                //     ptr::copy_nonoverlapping(src, dst, 1);
+                // }
+            }
         }
-    }
-    list.retain(|x| !test(x));
+    list.truncate(len - del);
     removed
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -21,6 +21,7 @@ where
     let len = list.len();
     let mut removed = vec![];
     let mut del = 0;
+    {
         let v = &mut **list;
 
         for i in 0..len {
@@ -37,6 +38,7 @@ where
                 // }
             }
         }
+    }
     list.truncate(len - del);
     removed
 }


### PR DESCRIPTION
vec_extract inspired by drain_filter() (which currently is in rust nightly). Using the basic test:
```
#![feature(drain_filter)]

use std::ptr;
use std::time::Instant;

fn main() {
    //Check the arrays are correct
    let vec: Vec<u32> = (0..=100).collect();
    let mut list = vec.clone();
    let test = vec_extract(&mut list, |x| *x % 2 == 0);
    println!("{:?}, {:?}", list, test);
    let mut list2 = vec.clone();
    let test2 = vec_extract2(&mut list2, |x| *x % 2 == 0);
    println!("{:?}, {:?}", list2, test2);
    let mut list3 = vec.clone();
    let test3 = vec_extract3(&mut list3, |x| *x % 2 == 0);
    println!("{:?}, {:?}", list3, test3);
    let vec: Vec<u32> = (0..=1000).collect();
    //Performace tests
    let start = Instant::now();
    for i in 1..=1000 {
        let mut list = vec.clone();
        vec_extract(&mut list, |x| *x % i == 0);
    }
    println!("{:?}", start.elapsed() / 1000);
    let start2 = Instant::now();
    for i in 1..=1000 {
        let mut list = vec.clone();
        vec_extract2(&mut list, |x| *x % i == 0);
    }
    println!("{:?}", start2.elapsed() / 1000);
    let start4 = Instant::now();
    for i in 1..=1000 {
        let mut list = vec.clone();
        vec_extract3(&mut list, |x| *x % i == 0);
    }
    println!("{:?}", start4.elapsed() / 1000);
    let start3 = Instant::now();
    for i in 1..=1000 {
        let mut list = vec.clone();
        let _droppable = list.drain_filter(|x| *x % i == 0).collect::<Vec<_>>();
    }
    println!("{:?}", start3.elapsed() / 1000);
}

pub fn vec_extract<T, F>(list: &mut Vec<T>, test: F) -> Vec<T>
where
    F: Fn(&T) -> bool,
    T: Clone,
{
    let mut removed = vec![];
    for x in list.iter() {
        if test(x) {
            removed.push(x.clone())
        }
    }
    list.retain(|x| !test(x));
    removed
}

pub fn vec_extract2<T, F>(list: &mut Vec<T>, test: F) -> Vec<T>
where
    F: Fn(&T) -> bool,
    T: Clone,
{
    let len = list.len();
    let mut removed = vec![];
    let mut del = 0;
    {
        let v = &mut **list;

        for i in 0..len {
            if test(&v[i]) {
                removed.push(v[i].clone());
                del += 1;
            } else if del > 0 {
                v.swap(i - del, i);
            }
        }
    }
    list.truncate(len - del);
    removed
}

pub fn vec_extract3<T, F>(list: &mut Vec<T>, test: F) -> Vec<T>
where
    F: Fn(&T) -> bool,
    T: Clone,
{
    let len = list.len();
    let mut removed = vec![];
    let mut del = 0;
        let v = &mut **list;

        for i in 0..len {
            if test(&v[i]) {
                removed.push(v[i].clone());
                del += 1;
            } else if del > 0 {
                let src: *const T = &v[i];
                let dst: *mut T = &mut v[i - del];
                unsafe {
                    ptr::copy_nonoverlapping(src, dst, 1);
                }
            }
        }
    list.truncate(len - del);
    removed
}
```
I found the results:
```
[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47
55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99
, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 5
 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100]
[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47
55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99
, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 5
 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100]
[1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 33, 35, 37, 39, 41, 43, 45, 47
55, 57, 59, 61, 63, 65, 67, 69, 71, 73, 75, 77, 79, 81, 83, 85, 87, 89, 91, 93, 95, 97, 99
, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 5
 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100]
36.21µs
18.827µs
15.713µs
14.17µs
```
First bit is just checking I get the correct results, the times show (for this test) that the one I pushed is about twice as fast as the original. The other attempt uses an unsafe function and seems to crash leftwm (not sure why), and the fastest is the drain_filter function which was the mark I was trying to reach.

I feel once drain_filter leaves the nightly build we should use it instead (however its been there for nearly 4 years so don't know when it will make it to stable).