### PR TITLE
Docs: add busy indicator to basic themes

### DIFF
--- a/themes/basic_lemonbar/template.liquid
+++ b/themes/basic_lemonbar/template.liquid
@@ -2,12 +2,16 @@
 {% assign mine_close = '%{B-}%{F-}' %}
 {% assign visible_open = '%{F#000000}%{B#999999}' %}
 {% assign visible_close = '%{B-}%{F-}' %}
+{% assign busy_open = '%{F#999999}%{B#333333}' %}
+{% assign busy_close = '%{B-}%{F-}' %}
 
 {% for tag in workspace.tags %}
 {% if tag.mine %}
 {{mine_open}}  {{ tag.name }}  {{mine_close}}
 {% elsif tag.visible  %}
 {{visible_open}}  {{ tag.name }}  {{visible_close}}
+{% elsif tag.busy  %}
+{{busy_open}}  {{ tag.name }}  {{busy_close}}
 {% else tag.visible  %}
   {{ tag.name }}  
 {% endif %}

--- a/themes/basic_polybar/template.liquid
+++ b/themes/basic_polybar/template.liquid
@@ -7,6 +7,10 @@
 %{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
 %{F#000000}%{B#E60053}  {{tag.name}}  %{B-}%{F-}
 %{A}
+{% elsif tag.busy %}
+%{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
+%{F#FFB52A}   {{tag.name}}   %{F-}
+%{A}
 {% else tag.visible  %}
 %{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
 %{F#FFFFFF}  {{tag.name}}  %{F-}

--- a/themes/basic_xmobar/template.liquid
+++ b/themes/basic_xmobar/template.liquid
@@ -3,6 +3,8 @@
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`><fc=#FF0000>  {{tag.name}}  </fc></action>
 {% elsif tag.visible  %}
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`><fc=#FF9999>  {{tag.name}}  </fc></action>
+{% elsif tag.busy  %}
+<action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`>  {{tag.name}}* </action>
 {% else tag.visible  %}
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`><fc=#FFFFFF>  {{tag.name}}  </fc></action>
 {% endif %}


### PR DESCRIPTION
Related to #177 
### Description

Since this feature needs some documentation, a good way is to just show it to newcomers. 

__1__ is visible (other monitor), __2__ is busy (with windows, but not visible) and __3__ is owned tag:

* Polybar
![polybar](https://user-images.githubusercontent.com/46683255/114287738-a2e39700-9a69-11eb-8863-3cd07f719590.png)

* XMobar
![xmobar](https://user-images.githubusercontent.com/46683255/114287739-a70fb480-9a69-11eb-851c-199ffe348eac.png)

* Lemonbar
![lemon](https://user-images.githubusercontent.com/46683255/114287742-ad9e2c00-9a69-11eb-82c6-71e6dddda77a.png)

I tried to respect the style of the theme, but any change is welcome!

### Implementation
Simply modified the `template.liquid` files for each basic theme.
