### PR TITLE
much faster cycle_vec

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -32,17 +32,15 @@ pub fn cycle_vec<T>(list: &mut Vec<T>, shift: i32)
 where
     T: Clone,
 {
-    let temp_list = list.clone();
-    let len = list.len() as i32;
-    for (index, item) in temp_list.iter().enumerate() {
-        let mut new_index = index as i32 + shift;
-        if new_index < 0 {
-            new_index += len;
-        }
-        if new_index >= len {
-            new_index -= len;
-        }
-        list[new_index as usize] = item.clone();
+    if shift == 0 {
+        return
+    }
+    let v = &mut **list;
+    let change = shift.abs() as usize;
+    if shift > 0 {
+        v.rotate_right(change);
+    } else if shift < 0 {
+        v.rotate_left(change);
     }
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -39,7 +39,7 @@ where
     match shift.cmp(&0) {
         Ordering::Less => v.rotate_left(change),
         Ordering::Greater => v.rotate_right(change),
-        Ordering::Equal => return,
+        Ordering::Equal => {},
     }
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -33,7 +33,7 @@ where
     T: Clone,
 {
     if shift == 0 {
-        return
+        return;
     }
     let v = &mut **list;
     let change = shift.abs() as usize;

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -39,7 +39,7 @@ where
     match shift.cmp(&0) {
         Ordering::Less => v.rotate_left(change),
         Ordering::Greater => v.rotate_right(change),
-        Ordering::Equal => {},
+        Ordering::Equal => {}
     }
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -32,15 +32,12 @@ pub fn cycle_vec<T>(list: &mut Vec<T>, shift: i32)
 where
     T: Clone,
 {
-    if shift == 0 {
-        return;
-    }
     let v = &mut **list;
     let change = shift.abs() as usize;
-    if shift > 0 {
-        v.rotate_right(change);
-    } else if shift < 0 {
-        v.rotate_left(change);
+    match shift.cmp(&0) {
+        Ordering::Less => v.rotate_left(change),
+        Ordering::Greater => v.rotate_right(change),
+        Ordering::Equal => return,
     }
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -1,4 +1,6 @@
 //! Generic intersection, finding, reordering, and Vec extraction
+use std::cmp::Ordering;
+
 pub fn intersect<T>(v1: &[T], v2: &[T]) -> bool
 where
     T: PartialEq,


### PR DESCRIPTION
Similar to my over pull request, just with cycle_vec (much greater improvement). Testing code:
```
use std::time::Instant;

fn main() {
    //Check the arrays are correct
    let vec: Vec<u32> = (0..=100).collect();
    let mut list = vec.clone();
    cycle_vec(&mut list, -5);
    println!("{:?}", list);
    let mut list2 = vec.clone();
    cycle_vec2(&mut list2, -5);
    println!("{:?}", list2);
    //Performace tests
    let vec: Vec<u32> = (0..=1000).collect();
    let start = Instant::now();
    let mut x = 600;
    for _i in 1..=1000 {
        let mut list = vec.clone();
        cycle_vec(&mut list, x);
        x *= -1;
    }
    println!("{:?}", start.elapsed() / 1000);
    let start2 = Instant::now();
    for _i in 1..=1000 {
        let mut list = vec.clone();
        cycle_vec2(&mut list, x);
        x *= -1;
    }
    println!("{:?}", start2.elapsed() / 1000);
}

pub fn cycle_vec<T>(list: &mut Vec<T>, shift: i32)
where
    T: Clone,
{
    let temp_list = list.clone();
    let len = list.len() as i32;
    for (index, item) in temp_list.iter().enumerate() {
        let mut new_index = index as i32 + shift;
        if new_index < 0 {
            new_index += len;
        }
        if new_index >= len {
            new_index -= len;
        }
        list[new_index as usize] = item.clone();
    }
}

pub fn cycle_vec2<T>(list: &mut Vec<T>, shift: i32)
where
    T: Clone,
{
    if shift == 0 {
        return
    }
    let v = &mut **list;
    let change = shift.abs() as usize;
    if shift > 0 {
        v.rotate_right(change);
    } else if shift < 0 {
        v.rotate_left(change);
    }
}
```
Test results:
```
[5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
96, 97, 98, 99, 100, 0, 1, 2, 3, 4]
[5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
96, 97, 98, 99, 100, 0, 1, 2, 3, 4]
38.651µs
1.689µs
```
Thanks.