### PR TITLE
faster reorder_vec with manual reordering

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -60,37 +60,17 @@ where
         }
     };
     let mut new_index = index as i32 + shift;
-    //Manually handle edge cases to allow more consistent behaviour
+    list.remove(index);
+    let v = &mut **list;
+
     if new_index < 0 {
         new_index += len;
-        manual_reorder(list, len, index as i32, item, new_index, -1);
+        v.rotate_right(1);
     } else if new_index >= len {
         new_index -= len;
-        manual_reorder(list, len, index as i32, item, new_index, 1);
-    } else {
-        list.remove(index);
-        list.insert(new_index as usize, item);
+        v.rotate_left(1);
     }
-}
-
-fn manual_reorder<T>(list: &mut Vec<T>, len: i32, index: i32, item: T, new_index: i32, val: i32)
-where
-    T: Clone,
-{
-    let mut i = index + val;
-    let mut i_alt = index;
-    while i != new_index + val {
-        if i < 0 {
-            i += len;
-        }
-        if i >= len {
-            i -= len;
-        }
-        list[i_alt as usize] = list[i as usize].clone();
-        i_alt = i;
-        i += val;
-    }
-    list[new_index as usize] = item;
+    list.insert(new_index as usize, item);
 }
 
 pub fn relative_find<T, F>(list: &[T], test: F, shift: i32) -> Option<&T>


### PR DESCRIPTION
This improves the speed when dealing with the manual reordering and massively reduces the needed code. Test:
```
use std::time::Instant;

fn main() {
    //Check the arrays are correct
    let vec: Vec<u32> = (0..=100).collect();
    let mut list = vec.clone();
    reorder_vec(&mut list, |x| *x == 0, -5);
    println!("{:?}", list);
    let mut list2 = vec.clone();
    reorder_vec2(&mut list2, |x| *x == 0, -5);
    println!("{:?}", list2);
    //Performace tests
    let vec: Vec<u32> = (0..=1000).collect();
    let start = Instant::now();
    let mut x = 600;
    for _i in 1..=1000 {
        let mut list = vec.clone();
        reorder_vec(&mut list, |x| *x == 800, x);
        x *= -1;
    }
    println!("{:?}", start.elapsed() / 1000);
    let start2 = Instant::now();
    for _i in 1..=1000 {
        let mut list = vec.clone();
        reorder_vec2(&mut list, |x| *x == 800, x);
        x *= -1;
    }
    println!("{:?}", start2.elapsed() / 1000);
}

pub fn reorder_vec<T, F>(list: &mut Vec<T>, test: F, shift: i32)
where
    F: Fn(&T) -> bool,
    T: Clone,
{
    let len = list.len() as i32;
    let (index, item) = match list.iter().enumerate().find(|&x| test(x.1)) {
        Some(x) => (x.0, x.1.clone()),
        None => {
            return;
        }
    };
    let mut new_index = index as i32 + shift;
    //Manually handle edge cases to allow more consistent behaviour
    if new_index < 0 {
        new_index += len;
        manual_reorder(list, len, index as i32, item, new_index, -1);
    } else if new_index >= len {
        new_index -= len;
        manual_reorder(list, len, index as i32, item, new_index, 1);
    } else {
        list.remove(index);
        list.insert(new_index as usize, item);
    }
}

fn manual_reorder<T>(list: &mut Vec<T>, len: i32, index: i32, item: T, new_index: i32, val: i32)
where
    T: Clone,
{
    let mut i = index + val;
    let mut i_alt = index;
    while i != new_index + val {
        if i < 0 {
            i += len;
        }
        if i >= len {
            i -= len;
        }
        list[i_alt as usize] = list[i as usize].clone();
        i_alt = i;
        i += val;
    }
    list[new_index as usize] = item;
}

pub fn reorder_vec2<T, F>(list: &mut Vec<T>, test: F, shift: i32)
where
    F: Fn(&T) -> bool,
    T: Clone,
{
    let len = list.len() as i32;
    let (index, item) = match list.iter().enumerate().find(|&x| test(x.1)) {
        Some(x) => (x.0, x.1.clone()),
        None => {
            return;
        }
    };
    let mut new_index = index as i32 + shift;
    list.remove(index);
    let v = &mut **list;

    if new_index < 0 {
        new_index += len;
        v.rotate_right(1);
    } else if new_index >= len {
        new_index -= len;
        v.rotate_left(1);
    } 
    list.insert(new_index as usize, item);
}
```
Results:
```
[100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 0, 96, 97, 98, 99]
[100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 0, 96, 97, 98, 99]
28.298µs
18.278µs
```
Thanks.