### PR TITLE
Stop fullscreen window being 'sticky', and hide non-fullscreen windows on the workspace

### DIFF
--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -137,7 +137,10 @@ impl Workspace {
             .iter_mut()
             .filter(|w| self.is_displaying(w))
             .collect();
-        all_mine.iter_mut().for_each(|w| w.set_visible(true));
+        match all_mine.iter_mut().find(|w| w.is_fullscreen()) {
+            Some(w) => w.set_visible(true),
+            None => all_mine.iter_mut().for_each(|w| w.set_visible(true)),
+        }
         //update the location of all non-floating windows
         let mut managed_nonfloat: Vec<&mut Window> = windows
             .iter_mut()

--- a/src/utils/window_updater.rs
+++ b/src/utils/window_updater.rs
@@ -9,7 +9,7 @@ pub fn update_windows(manager: &mut Manager) {
     manager
         .windows
         .iter_mut()
-        .for_each(|w| w.set_visible(w.tags.is_empty() || w.is_fullscreen()));
+        .for_each(|w| w.set_visible(w.tags.is_empty()));
     let mut all_windows = &mut manager.windows;
     manager.workspaces.iter_mut().for_each(|ws| {
         ws.update_windows(&mut all_windows);


### PR DESCRIPTION
As mentioned in #170, #174. Was there a reason for this check?
While testing with fullscreen I have found a bug where if a window that is fullscreened loses focus to a window below it. However it only loses focus to the window if it is above in the list. I am planning on creating an exclusive fullscreen through leftwm and could fix this by moving it up in the stack (but it then wouldn't return to the same position) and this wouldn't fix it if the window makes it's self fullscreen.
Also should all windows on a tag where a window is fullscreen be set invisible (would this also fix the previous issue?)?
Closes #170.
Thanks

Edit: I also made the windows that are on the same screen as a full screen window not get turned visible, which has indeed fixed the focus issue and setups nicely for a fullscreen command (as windows won't be seen through transparent windows). However doesn't hide the panel.
Thanks+