### PR TITLE
Update for Clippy 0.1.53 (42816d6 2021-04-24)

### DIFF
--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -145,7 +145,7 @@ impl DisplayServer for XlibDisplayServer {
                     .map(|x| WindowHandle::XlibHandle(*x))
                     .filter(|h| !wins.contains(&h))
                     .collect();
-                let all: Vec<WindowHandle> = unmanged.iter().chain(wins.iter()).cloned().collect();
+                let all: Vec<WindowHandle> = unmanged.iter().chain(wins.iter()).copied().collect();
                 self.xw.restack(all);
                 None
             }
@@ -196,12 +196,12 @@ impl XlibDisplayServer {
                     events.push(e);
                 });
             } else {
-                workspaces.iter().for_each(|wsc| {
+                for wsc in workspaces.iter() {
                     let mut screen = Screen::from(wsc);
                     screen.root = WindowHandle::XlibHandle(self.root);
                     let e = DisplayEvent::ScreenCreate(screen);
                     events.push(e);
-                });
+                }
             }
         }
 

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -1407,7 +1407,7 @@ impl XWrap {
                     return;
                 }
             }
-            _ => {}
+            Mode::Normal => {}
         }
         if self.mode == Mode::Normal && mode != Mode::Normal {
             self.mode = mode.clone();

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -390,11 +390,11 @@ fn set_margin_multiplier(manager: &mut Manager, val: &Option<String>) -> Option<
         };
         let mut to_apply_margin_multiplier =
             helpers::vec_extract(&mut manager.windows, for_active_workspace);
-        to_apply_margin_multiplier.iter_mut().for_each(|w| {
+        for w in &mut to_apply_margin_multiplier {
             if let Some(ws) = manager.focused_workspace() {
                 w.apply_margin_multiplier(ws.margin_multiplier())
             }
-        });
+        }
         manager.windows.append(&mut to_apply_margin_multiplier);
     }
     Some(true)
@@ -409,33 +409,24 @@ mod tests {
         let mut manager = Manager::default();
         let config = Config::default();
         // no screen creation here
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("6".to_string())
-            ),
-            false
-        );
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("2".to_string())
-            ),
-            false
-        );
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("15".to_string())
-            ),
-            false
-        );
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("6".to_string())
+        ));
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("2".to_string())
+        ));
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("15".to_string())
+        ),);
     }
 
     #[test]
@@ -458,15 +449,12 @@ mod tests {
             &Some("1".to_string())
         ));
         // we only have one tag per screen created automatically
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("3".to_string())
-            ),
-            false
-        );
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("3".to_string())
+        ),);
     }
 
     #[test]
@@ -482,28 +470,19 @@ mod tests {
             TagModel::new("E39"),
             TagModel::new("F67"),
         ];
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("abc".to_string())
-            ),
-            false
-        );
-        assert_eq!(
-            process(
-                &mut manager,
-                &config,
-                &Command::GotoTag,
-                &Some("ab45c".to_string())
-            ),
-            false
-        );
-        assert_eq!(
-            process(&mut manager, &config, &Command::GotoTag, &None),
-            false
-        );
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("abc".to_string())
+        ),);
+        assert!(!process(
+            &mut manager,
+            &config,
+            &Command::GotoTag,
+            &Some("ab45c".to_string())
+        ));
+        assert!(!process(&mut manager, &config, &Command::GotoTag, &None));
     }
 
     #[test]

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -185,9 +185,9 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
         .filter(|w| w.has_tag(tag))
         .cloned()
         .collect();
-    to_focus.iter().for_each(|w| {
+    for w in &to_focus {
         focus_workspace_work(manager, w.id);
-    });
+    }
     //make sure the focused window is on this workspace
     let act = DisplayAction::FocusWindowUnderCursor;
     manager.actions.push_back(act);

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -147,9 +147,9 @@ impl Workspace {
             .filter(|w| self.is_managed(w) && !w.floating())
             .collect();
         self.layout.update_windows(self, &mut managed_nonfloat);
-        managed_nonfloat.iter_mut().for_each(|w| {
+        for w in &mut managed_nonfloat {
             w.container_size = Some(self.xyhw);
-        });
+        }
         //update the location of all floating windows
         windows
             .iter_mut()


### PR DESCRIPTION
Howdy,

This PR prepares for Clippy 0.1.53 to hit the CI by updating some tests to avoid for_each and a .cloned().

Best,
Mautamu