### PR TITLE
Leftwm-Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo build --release
 4. Copy leftwm executables to the /usr/bin folder
 
 ```bash
-sudo install -s -Dm755 ./target/release/leftwm ./target/release/leftwm-worker ./target/release/leftwm-state ./target/release/leftwm-check -t /usr/bin
+sudo install -s -Dm755 ./target/release/leftwm ./target/release/leftwm-worker ./target/release/leftwm-state ./target/release/leftwm-check ./target/release/leftwm-command -t /usr/bin
 ```
 
 5. Copy leftwm.desktop to xsessions folder
@@ -155,6 +155,7 @@ sudo ln -s "$(pwd)"/target/release/leftwm /usr/bin/leftwm
 sudo ln -s "$(pwd)"/target/release/leftwm-worker /usr/bin/leftwm-worker
 sudo ln -s "$(pwd)"/target/release/leftwm-state /usr/bin/leftwm-state
 sudo ln -s "$(pwd)"/target/release/leftwm-check /usr/bin/leftwm-check
+sudo ln -s "$(pwd)"/target/release/leftwm-command /usr/bin/leftwm-command
 ```
 
 5. Copy leftwm.desktop to xsessions folder

--- a/src/bin/leftwm-command.rs
+++ b/src/bin/leftwm-command.rs
@@ -1,0 +1,36 @@
+use clap::{App, Arg};
+use leftwm::errors::Result;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use xdg::BaseDirectories;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let matches = App::new("LeftWM Command")
+        .author("Lex Childs <lex.childs@gmail.com>")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Sends external commands to LeftWM")
+        .arg(
+            Arg::with_name("command")
+                .help("The command to be sent.")
+                .required(true)
+                .multiple(true),
+        )
+        .get_matches();
+
+    let file_path = BaseDirectories::with_prefix("leftwm")?
+        .find_runtime_file("commands.pipe")
+        .expect("ERROR: Couldn't find commands.pipe");
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(file_path)
+        .expect("ERROR: Couldn't open commands.pipe");
+    if let Some(commands) = matches.values_of("command") {
+        for command in commands {
+            if let Err(e) = writeln!(file, "{}", command) {
+                eprintln!(" ERROR: Couldn't write to commands.pipe: {}", e);
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This is basically a wrapper for sending external commands into commands.pipe. It allows for simpler syntax in doing so and allows you to chain commands (where commands with args must be surrounded in quotes).
Thanks. 