### PR TITLE
Adds check to leftwm-check for XDG_RUNTIME_DIR/elogind. Closes 307.

### DIFF
--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     println!("\x1b[0;94m::\x1b[0m Loading configuration . . .");
     match load_from_file(config_file, verbose) {
         Ok(config) => {
-            println!("\x1b[0;92m    -> Configuration loaded OK \x1b[0;92m");
+            println!("\x1b[0;92m    -> Configuration loaded OK \x1b[0m");
             if config == Config::default() {
                 println!("\x1b[1;32mWARN: The file loaded was the default. Your configuration is likely invalid \x1b[0m");
             }
@@ -154,29 +154,31 @@ fn check_elogind(verbose: bool) -> Result<()> {
         }
         (Ok(val), false) => {
             if verbose {
-                println!(":: XDG_RUNTIME_DIR: {}, LOGINCTL BAD", val);
+                println!(":: XDG_RUNTIME_DIR: {}, LOGINCTL not installed", val);
             }
-            println!("\x1b[1;91mERROR: XDG_RUNTIME_DIR found, but elogind not installed.\x1b[0m",);
-            Err(leftwm::errors::LeftError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Elogind not installed/operating.",
-            )))
+
+            println!("\x1b[0;92m    -> Environment OK (has XDG_RUNTIME_DIR) \x1b[0;92m");
+
+            Ok(())
         }
         (Err(e), false) => {
             if verbose {
                 println!(":: XDG_RUNTIME_DIR_ERROR: {:?}, LOGINCTL BAD", e);
             }
-            println!("\x1b[1;91mERROR: Elogind not installed. Install elogind.\x1b[0m",);
+            println!("\x1b[1;91mERROR: XDG_RUNTIME_DIR not set and elogind not found.\nSee https://github.com/leftwm/leftwm/wiki/XDG_RUNTIME_DIR for more information.\x1b[0m",);
+
             Err(leftwm::errors::LeftError::from(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                "Elogind not installed/operating.",
+                "Elogind not installed/operating and no alternative XDG_RUNTIME_DIR is set.",
             )))
         }
         (Err(e), true) => {
             if verbose {
                 println!(":: XDG_RUNTIME_DIR: {:?}, LOGINCTL OKAY", e);
             }
-            println!("\x1b[1;33mWARN: Elogind installed but not running.\x1b[0m",);
+            println!(
+                "\x1b[1;33mWARN: Elogind/systemd installed but XDG_RUNTIME_DIR not set.\nThis may be because elogind isn't started. \x1b[0m",
+            );
             Ok(())
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,8 @@ fn load_from_file() -> Result<Config> {
     }
 }
 
-fn is_program_in_path(program: &str) -> bool {
+#[must_use]
+pub fn is_program_in_path(program: &str) -> bool {
     if let Ok(path) = env::var("PATH") {
         for p in path.split(':') {
             let p_str = format!("{}/{}", p, program);


### PR DESCRIPTION
Howdy,

A number of folks (myself included) have had issues setting up leftwm on non-systemd machines. This adds a lint to leftwm-check which ensures that:

1. Either XDG_RUNTIME_DIR is specified presently, and warns if it isn't;
2. Or, the loginctl command (as a proxy for elogind) exists.

Closes #307 .  Tagging  @byfw and #228.

Best,
Mautamu