### PR TITLE
Add margins and gutters to workspace

### DIFF
--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -11,6 +11,7 @@ pub struct ThemeSetting {
     pub border_width: i32,
     pub window_margin: Margins,
     pub workspace_margin: Margins,
+    pub gutter: i32,
     pub default_border_color: String,
     pub floating_border_color: String,
     pub focused_border_color: String,
@@ -37,6 +38,7 @@ impl Default for ThemeSetting {
             border_width: 1,
             window_margin: Margins::Int(10),
             workspace_margin: Margins::Int(10),
+            gutter: 0,
             default_border_color: "#000000".to_owned(),
             floating_border_color: "#000000".to_owned(),
             focused_border_color: "#FF0000".to_owned(),
@@ -64,6 +66,7 @@ mod tests {
 border_width = 0
 window_margin = 5
 workspace_margin = 5
+gutter = 0
 default_border_color = '#222222'
 floating_border_color = '#005500'
 focused_border_color = '#FFB53A'
@@ -77,6 +80,7 @@ on_new_window = 'echo Hello World'
                 border_width: 0,
                 window_margin: Margins::Int(5),
                 workspace_margin: Margins::Int(5),
+                gutter: 0,
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),

--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -1,4 +1,5 @@
 use crate::errors::Result;
+use crate::models::Gutter;
 use crate::models::Margins;
 use serde::{Deserialize, Serialize};
 use std::default::Default;
@@ -11,7 +12,7 @@ pub struct ThemeSetting {
     pub border_width: i32,
     pub window_margin: Margins,
     pub workspace_margin: Margins,
-    pub gutter: i32,
+    pub gutter: Option<Vec<Gutter>>,
     pub default_border_color: String,
     pub floating_border_color: String,
     pub focused_border_color: String,
@@ -23,6 +24,14 @@ impl ThemeSetting {
     #[must_use]
     pub fn load(path: &Path) -> ThemeSetting {
         load_theme_file(path).unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn get_list_of_gutters(&self) -> Vec<Gutter> {
+        if let Some(gutters) = &self.gutter {
+            return gutters.clone();
+        }
+        vec![]
     }
 }
 
@@ -38,7 +47,7 @@ impl Default for ThemeSetting {
             border_width: 1,
             window_margin: Margins::Int(10),
             workspace_margin: Margins::Int(10),
-            gutter: 0,
+            gutter: None,
             default_border_color: "#000000".to_owned(),
             floating_border_color: "#000000".to_owned(),
             focused_border_color: "#FF0000".to_owned(),
@@ -50,6 +59,7 @@ impl Default for ThemeSetting {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::Side;
 
     #[test]
     fn deserialize_empty_theme_config() {
@@ -66,11 +76,14 @@ mod tests {
 border_width = 0
 window_margin = 5
 workspace_margin = 5
-gutter = 0
 default_border_color = '#222222'
 floating_border_color = '#005500'
 focused_border_color = '#FFB53A'
 on_new_window = 'echo Hello World'
+
+[[gutter]]
+side = "Top"
+value = 0
 "#;
         let config: ThemeSetting = toml::from_str(config).unwrap();
 
@@ -80,7 +93,10 @@ on_new_window = 'echo Hello World'
                 border_width: 0,
                 window_margin: Margins::Int(5),
                 workspace_margin: Margins::Int(5),
-                gutter: 0,
+                gutter: Some(vec![Gutter {
+                    side: Side::Top,
+                    value: 0
+                }]),
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),

--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -9,7 +9,8 @@ use std::path::Path;
 #[serde(default)]
 pub struct ThemeSetting {
     pub border_width: i32,
-    pub margin: Margins,
+    pub window_margin: Margins,
+    pub workspace_margin: Margins,
     pub default_border_color: String,
     pub floating_border_color: String,
     pub focused_border_color: String,
@@ -34,7 +35,8 @@ impl Default for ThemeSetting {
     fn default() -> Self {
         ThemeSetting {
             border_width: 1,
-            margin: Margins::Int(10),
+            window_margin: Margins::Int(10),
+            workspace_margin: Margins::Int(10),
             default_border_color: "#000000".to_owned(),
             floating_border_color: "#000000".to_owned(),
             focused_border_color: "#FF0000".to_owned(),
@@ -60,7 +62,8 @@ mod tests {
     fn deserialize_custom_theme_config() {
         let config = r#"
 border_width = 0
-margin = 5
+window_margin = 5
+workspace_margin = 5
 default_border_color = '#222222'
 floating_border_color = '#005500'
 focused_border_color = '#FFB53A'
@@ -72,7 +75,8 @@ on_new_window = 'echo Hello World'
             config,
             ThemeSetting {
                 border_width: 0,
-                margin: Margins::Int(5),
+                window_margin: Margins::Int(5),
+                workspace_margin: Margins::Int(5),
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),

--- a/src/config/theme_setting.rs
+++ b/src/config/theme_setting.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 #[serde(default)]
 pub struct ThemeSetting {
     pub border_width: i32,
-    pub window_margin: Margins,
+    pub margin: Margins,
     pub workspace_margin: Margins,
     pub gutter: Option<Vec<Gutter>>,
     pub default_border_color: String,
@@ -45,7 +45,7 @@ impl Default for ThemeSetting {
     fn default() -> Self {
         ThemeSetting {
             border_width: 1,
-            window_margin: Margins::Int(10),
+            margin: Margins::Int(10),
             workspace_margin: Margins::Int(10),
             gutter: None,
             default_border_color: "#000000".to_owned(),
@@ -74,7 +74,7 @@ mod tests {
     fn deserialize_custom_theme_config() {
         let config = r#"
 border_width = 0
-window_margin = 5
+margin = 5
 workspace_margin = 5
 default_border_color = '#222222'
 floating_border_color = '#005500'
@@ -91,7 +91,7 @@ value = 0
             config,
             ThemeSetting {
                 border_width: 0,
-                window_margin: Margins::Int(5),
+                margin: Margins::Int(5),
                 workspace_margin: Margins::Int(5),
                 gutter: Some(vec![Gutter {
                     side: Side::Top,

--- a/src/handlers/external_command_handler.rs
+++ b/src/handlers/external_command_handler.rs
@@ -129,6 +129,9 @@ fn load_theme(manager: &mut Manager, theme: ThemeSetting) -> bool {
     for win in &mut manager.windows {
         win.update_for_theme(&theme);
     }
+    for ws in &mut manager.workspaces {
+        ws.update_for_theme(&theme);
+    }
     manager.theme_setting = theme;
     true
 }

--- a/src/handlers/screen_create_handler.rs
+++ b/src/handlers/screen_create_handler.rs
@@ -7,6 +7,7 @@ pub fn process(manager: &mut Manager, screen: Screen) -> bool {
     let tag_index = manager.workspaces.len();
 
     let mut workspace = Workspace::new(screen.bbox, manager.tags.clone(), manager.layouts.clone());
+    workspace.update_for_theme(&manager.theme_setting);
     workspace.id = tag_index as i32;
     //make sure are enough tags for this new screen
     if manager.tags.len() <= tag_index {

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -156,6 +156,7 @@ mod tests {
             vec![],
             vec![],
         );
+        ws.margin = Margins::Int(0);
         ws.xyhw.set_minh(600);
         ws.xyhw.set_minw(800);
         ws.update_avoided_areas();

--- a/src/models/gutter.rs
+++ b/src/models/gutter.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum Side {
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Gutter {
+    pub side: Side,
+    pub value: i32,
+}
+
+impl Gutter {
+    #[must_use]
+    pub fn new(side: Side, value: i32) -> Gutter {
+        Gutter { side, value }
+    }
+}
+
+impl Default for Gutter {
+    fn default() -> Self {
+        Gutter {
+            side: Side::Top,
+            value: 0,
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! Objects (such as windows) used to develop `LeftWM`.
 mod dock_area;
+mod gutter;
 mod manager;
 mod margins;
 mod mode;
@@ -17,6 +18,8 @@ pub mod dto;
 use crate::layouts;
 
 pub use dock_area::DockArea;
+pub use gutter::Gutter;
+pub use gutter::Side;
 pub use manager::Manager;
 pub use margins::Margins;
 pub use mode::Mode;

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -74,7 +74,7 @@ impl Window {
 
     pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
         if self.type_ == WindowType::Normal {
-            self.margin = theme.window_margin.clone();
+            self.margin = theme.margin.clone();
             self.border = theme.border_width;
         } else {
             self.margin = Margins::Int(0);

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -74,7 +74,7 @@ impl Window {
 
     pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
         if self.type_ == WindowType::Normal {
-            self.margin = theme.margin.clone();
+            self.margin = theme.window_margin.clone();
             self.border = theme.border_width;
         } else {
             self.margin = Margins::Int(0);

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -19,6 +19,7 @@ pub struct Workspace {
     pub tags: Vec<TagId>,
     pub margin: Margins,
     pub margin_multiplier: f32,
+    pub gutter: i32,
     #[serde(skip)]
     all_tags: Vec<Tag>,
     layouts: Vec<Layout>,
@@ -56,6 +57,7 @@ impl Workspace {
             tags: vec![],
             margin: Margins::Int(10),
             margin_multiplier: 1.0,
+            gutter: 0,
             avoid: vec![],
             all_tags,
             layouts,
@@ -80,6 +82,7 @@ impl Workspace {
 
     pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
         self.margin = theme.workspace_margin.clone();
+        self.gutter = theme.gutter;
     }
 
     pub fn show_tag(&mut self, tag: &Tag) {
@@ -176,13 +179,13 @@ impl Workspace {
     #[must_use]
     pub fn y(&self) -> i32 {
         let top = self.margin.clone().top() as f32;
-        self.xyhw_avoided.y() + (self.margin_multiplier * top) as i32
+        self.xyhw_avoided.y() + (self.margin_multiplier * top) as i32 + self.gutter
     }
     #[must_use]
     pub fn height(&self) -> i32 {
         let top = self.margin.clone().top() as f32;
         let bottom = self.margin.clone().bottom() as f32;
-        self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32
+        self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32 - self.gutter
     }
     #[must_use]
     pub fn width(&self) -> i32 {

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -1,4 +1,6 @@
 use super::{layouts::Layout, Margins};
+use crate::models::Gutter;
+use crate::models::Side;
 use crate::models::Tag;
 use crate::models::TagId;
 use crate::models::Window;
@@ -19,7 +21,7 @@ pub struct Workspace {
     pub tags: Vec<TagId>,
     pub margin: Margins,
     pub margin_multiplier: f32,
-    pub gutter: i32,
+    pub gutters: Vec<Gutter>,
     #[serde(skip)]
     all_tags: Vec<Tag>,
     layouts: Vec<Layout>,
@@ -57,7 +59,7 @@ impl Workspace {
             tags: vec![],
             margin: Margins::Int(10),
             margin_multiplier: 1.0,
-            gutter: 0,
+            gutters: vec![],
             avoid: vec![],
             all_tags,
             layouts,
@@ -82,7 +84,8 @@ impl Workspace {
 
     pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
         self.margin = theme.workspace_margin.clone();
-        self.gutter = theme.gutter;
+        self.gutters = theme.get_list_of_gutters();
+        log::info!("Gutter: {:?}", self.gutters)
     }
 
     pub fn show_tag(&mut self, tag: &Tag) {
@@ -174,24 +177,37 @@ impl Workspace {
     #[must_use]
     pub fn x(&self) -> i32 {
         let left = self.margin.clone().left() as f32;
-        self.xyhw_avoided.x() + (self.margin_multiplier * left) as i32
+        let gutter = self.get_gutter(&Side::Left);
+        self.xyhw_avoided.x() + (self.margin_multiplier * left) as i32 + gutter
     }
     #[must_use]
     pub fn y(&self) -> i32 {
         let top = self.margin.clone().top() as f32;
-        self.xyhw_avoided.y() + (self.margin_multiplier * top) as i32 + self.gutter
+        let gutter = self.get_gutter(&Side::Top);
+        self.xyhw_avoided.y() + (self.margin_multiplier * top) as i32 + gutter
     }
     #[must_use]
     pub fn height(&self) -> i32 {
         let top = self.margin.clone().top() as f32;
         let bottom = self.margin.clone().bottom() as f32;
-        self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32 - self.gutter
+        //Only one side
+        let gutter = self.get_gutter(&Side::Top) + self.get_gutter(&Side::Bottom);
+        self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32 - gutter
     }
     #[must_use]
     pub fn width(&self) -> i32 {
         let left = self.margin.clone().left() as f32;
         let right = self.margin.clone().right() as f32;
-        self.xyhw_avoided.w() - (self.margin_multiplier * (left + right)) as i32
+        //Only one side
+        let gutter = self.get_gutter(&Side::Left) + self.get_gutter(&Side::Right);
+        self.xyhw_avoided.w() - (self.margin_multiplier * (left + right)) as i32 - gutter
+    }
+
+    fn get_gutter(&self, side: &Side) -> i32 {
+        match self.gutters.iter().find(|g| &g.side == side) {
+            Some(g) => g.value,
+            None => 0,
+        }
     }
 
     #[must_use]

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -1,11 +1,11 @@
-use super::layouts::Layout;
-use crate::models::BBox;
+use super::{layouts::Layout, Margins};
 use crate::models::Tag;
 use crate::models::TagId;
 use crate::models::Window;
 use crate::models::WindowType;
 use crate::models::Xyhw;
 use crate::models::XyhwBuilder;
+use crate::{config::ThemeSetting, models::BBox};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -17,6 +17,7 @@ pub struct Workspace {
     pub layout: Layout,
     layout_rotation: usize,
     pub tags: Vec<TagId>,
+    pub margin: Margins,
     pub margin_multiplier: f32,
     #[serde(skip)]
     all_tags: Vec<Tag>,
@@ -53,6 +54,7 @@ impl Workspace {
             layout: Layout::new(&layouts),
             layout_rotation: 0,
             tags: vec![],
+            margin: Margins::Int(10),
             margin_multiplier: 1.0,
             avoid: vec![],
             all_tags,
@@ -74,6 +76,10 @@ impl Workspace {
             }
             .into(),
         }
+    }
+
+    pub fn update_for_theme(&mut self, theme: &ThemeSetting) {
+        self.margin = theme.workspace_margin.clone();
     }
 
     pub fn show_tag(&mut self, tag: &Tag) {
@@ -164,19 +170,25 @@ impl Workspace {
 
     #[must_use]
     pub fn x(&self) -> i32 {
-        self.xyhw_avoided.x()
+        let left = self.margin.clone().left() as f32;
+        self.xyhw_avoided.x() + (self.margin_multiplier * left) as i32
     }
     #[must_use]
     pub fn y(&self) -> i32 {
-        self.xyhw_avoided.y()
+        let top = self.margin.clone().top() as f32;
+        self.xyhw_avoided.y() + (self.margin_multiplier * top) as i32
     }
     #[must_use]
     pub fn height(&self) -> i32 {
-        self.xyhw_avoided.h()
+        let top = self.margin.clone().top() as f32;
+        let bottom = self.margin.clone().bottom() as f32;
+        self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32
     }
     #[must_use]
     pub fn width(&self) -> i32 {
-        self.xyhw_avoided.w()
+        let left = self.margin.clone().left() as f32;
+        let right = self.margin.clone().right() as f32;
+        self.xyhw_avoided.w() - (self.margin_multiplier * (left + right)) as i32
     }
 
     #[must_use]


### PR DESCRIPTION
Adds margins to workspaces, this closes #327 as the user could now add a gap their selves at the top of the workspace if the automatic system doesnt work. This also closes #194 and closes #270, as if you add half the margin you want to workspace and the other half to window, the gap will be consistent. E.g. if you want a gap of 8 consistently, if you set window_margin to 4 and workspace_margin to 4, all the gaps will be 8.
The reason the theme config breaks is because margin has changed to window_margin to be more clear, but this isn't necessary if we don't want to break the config.
Thanks.