### PR TITLE
Make themes more portable.

### DIFF
--- a/themes/basic_lemonbar/change_to_tag
+++ b/themes/basic_lemonbar/change_to_tag
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SendWorkspaceToTag $1 $2" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/basic_lemonbar/down
+++ b/themes/basic_lemonbar/down
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 

--- a/themes/basic_lemonbar/up
+++ b/themes/basic_lemonbar/up
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 

--- a/themes/basic_polybar/change_to_tag
+++ b/themes/basic_polybar/change_to_tag
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SendWorkspaceToTag $1 $2" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/basic_polybar/down
+++ b/themes/basic_polybar/down
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 

--- a/themes/basic_polybar/up
+++ b/themes/basic_polybar/up
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 

--- a/themes/basic_xmobar/change_to_tag
+++ b/themes/basic_xmobar/change_to_tag
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SendWorkspaceToTag $1 $2" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/basic_xmobar/down
+++ b/themes/basic_xmobar/down
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 

--- a/themes/basic_xmobar/up
+++ b/themes/basic_xmobar/up
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 

--- a/themes/controlling_leftwm/change_to_tag
+++ b/themes/controlling_leftwm/change_to_tag
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SendWorkspaceToTag $1 $2" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/controlling_leftwm/move_window_to_last_workspace
+++ b/themes/controlling_leftwm/move_window_to_last_workspace
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "MoveWindowToLastWorkspace" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/controlling_leftwm/move_window_to_tag
+++ b/themes/controlling_leftwm/move_window_to_tag
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SendWindowToTag $1" > $XDG_RUNTIME_DIR/leftwm/commands.pipe

--- a/themes/controlling_leftwm/swap_screens
+++ b/themes/controlling_leftwm/swap_screens
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "SwapScreens" > $XDG_RUNTIME_DIR/leftwm/commands.pipe


### PR DESCRIPTION
This is to allow these themes to be applied without patching in systems where `bash` is installed in a different location.

E.g. FreeBSD, `/usr/local/bin/bash`.

Thank you.