### PR TITLE
Hide bars when entering fullscreen

### DIFF
--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -91,7 +91,7 @@ impl Window {
     #[must_use]
     pub fn visible(&self) -> bool {
         self.visible
-            || self.type_ == WindowType::Dock
+            // || self.type_ == WindowType::Dock
             || self.type_ == WindowType::Menu
             || self.type_ == WindowType::Splash
             || self.type_ == WindowType::Dialog

--- a/src/utils/window_updater.rs
+++ b/src/utils/window_updater.rs
@@ -1,30 +1,50 @@
 use crate::models::Manager;
-use crate::models::Window;
 
 /*
  * step over all the windows for each workspace and updates all the things
  * based on the new state of the WM
  */
 pub fn update_windows(manager: &mut Manager) {
-    manager
-        .windows
-        .iter_mut()
-        .for_each(|w| w.set_visible(w.tags.is_empty()));
-    let mut all_windows = &mut manager.windows;
-    manager.workspaces.iter_mut().for_each(|ws| {
-        ws.update_windows(&mut all_windows);
-        let mut windows: Vec<&mut Window> = all_windows.iter_mut().collect();
+    let mut strut_windows = vec![];
+    for w in &mut manager.windows {
+        w.set_visible(w.tags.is_empty());
+        if w.strut.is_some() {
+            strut_windows.push(w);
+        }
+    }
+    // Update the current tags for static windows, currently only docks
+    // This is to allow us to effectively "manage" them when it is necessary
+    for ws in &manager.workspaces {
+        strut_windows
+            .iter_mut()
+            .filter(|w| {
+                // It should always unwrap as strut is_some()
+                ws.contains_point(
+                    w.strut.unwrap_or_default().x(),
+                    w.strut.unwrap_or_default().y(),
+                )
+            })
+            .for_each(|w| {
+                w.tags = ws.tags.clone();
+            });
+    }
+    for ws in &mut manager.workspaces {
+        ws.update_windows(&mut manager.windows);
 
-        windows
+        manager
+            .windows
             .iter_mut()
             .filter(|w| ws.is_displaying(w) && w.is_fullscreen())
             .for_each(|w| {
                 w.set_floating(false);
                 w.normal = ws.xyhw;
             });
-
-        windows.iter().filter(|x| x.debugging).for_each(|w| {
+    }
+    manager
+        .windows
+        .iter()
+        .filter(|x| x.debugging)
+        .for_each(|w| {
             println!("{:?}", w);
         });
-    });
 }


### PR DESCRIPTION
This allows us to hide bars aswell when entering fullscreen and closes #360.
Another issue I would like to ask about comes from not handling non send event unmap events (if that makes sense), related #351. For the devour script there was an easy fix, but for larger projects, such as polybar, which use XUnmapWindow to hide their window can't easily be modified to work. Is there a reason not to handle these events, and if there is should we partially handle them, as for the example of polybar when telling it to hide it will disappear (nothing updates as we don't handle it) and then won't reappear when unhiding as the manager already knows about it.
Many Thanks.