### PR TITLE
Add subcommands to leftwm

### DIFF
--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -109,6 +109,10 @@ fn execute_subcommand(args: Vec<String>) {
 ///
 /// If `--help` or `--version` flags are not passed, this will do nothing.
 ///
+/// # Arguments
+///
+/// + `args` - The command line arguments leftwm was called with.
+///
 /// # Exits
 ///
 /// Exits early if `--help` or `--version` flags are passed.

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -112,7 +112,7 @@ fn execute_subcommand(args: Vec<String>) {
 ///
 /// Exits early if --help or --version flags are passed.
 fn handle_help_or_version_flags(args: &[String]) {
-    App::new("leftwm")
+    App::new("LeftWM")
         .author("Lex Childs <lex.childs@gmail.com>")
         .about("A window manager for adventurers.")
         .long_about(

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -1,3 +1,8 @@
+//! Starts leftwm programs.
+//!
+//! If no arguments are passed, starts `leftwm-worker`. If arguments are passed, starts
+//! `leftwm-{check, command, state, theme}` as specified, and passes along any extra arguments.
+
 use clap::{crate_version, App, AppSettings, SubCommand};
 use leftwm::child_process::{self, Nanny};
 use std::env;
@@ -7,10 +12,6 @@ use std::sync::{
     Arc,
 };
 
-/// Starts leftwm programs.
-///
-/// If no arguments are passed, starts `leftwm-worker`. If arguments are passed, starts
-/// `leftwm-{check, command, state, theme}` as specified, and passes along any extra arguments.
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -73,7 +74,7 @@ fn main() {
 ///
 /// If a valid subcommand is supplied, executes that subcommand, passing `args` to the program.
 /// Valid subcommands are `check`, `command`, `state` and `theme`.
-/// Prints an error to STDERR and exits non-zero if an invalid subcommand is supplied, or there is
+/// Prints an error to `STDERR` and exits non-zero if an invalid subcommand is supplied, or there is
 /// some error while executing the subprocess.
 ///
 /// # Arguments
@@ -104,13 +105,13 @@ fn execute_subcommand(args: Vec<String>) {
     }
 }
 
-/// Show program help text and exit if --help or --version flags are passed.
+/// Show program help text and exit if `--help` or `--version` flags are passed.
 ///
-/// If --help or --version flags are not passed, this will do nothing.
+/// If `--help` or `--version` flags are not passed, this will do nothing.
 ///
 /// # Exits
 ///
-/// Exits early if --help or --version flags are passed.
+/// Exits early if `--help` or `--version` flags are passed.
 fn handle_help_or_version_flags(args: &[String]) {
     App::new("LeftWM")
         .author("Lex Childs <lex.childs@gmail.com>")

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -13,6 +13,7 @@ use std::sync::{
 fn main() {
     let args: Vec<String> = env::args().collect();
 
+    // If at least one argument is given, execute a subcommand and exit.
     if args.len() > 1 {
         execute_subcommand(args);
         return;

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -6,7 +6,19 @@ use std::sync::{
     Arc,
 };
 
+/// Starts leftwm programs.
+///
+/// If no arguments are passed, starts `leftwm-worker`. If arguments are passed, starts
+/// `leftwm-{check, command, state, theme}` as specified, and passes along any extra arguments.
 fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() > 1 {
+        execute_subcommand(args);
+        return;
+    }
+
+    // If not invoked with a subcommand, start leftwm.
     if let Ok(current_exe) = std::env::current_exe() {
         //boot everything in ~/.config/autostart
         let mut children = Nanny::autostart();
@@ -41,7 +53,7 @@ fn main() {
 
             // TODO: either add more details or find a better workaround.
             //
-            // Left is to fast for some logging managers. We need to
+            // Left is too fast for some logging managers. We need to
             // wait to give the logging manager a second to boot.
             #[cfg(feature = "slow-dm-fix")]
             {
@@ -49,5 +61,31 @@ fn main() {
                 std::thread::sleep(delay);
             }
         }
+    }
+}
+
+/// Executes a subcommand.
+///
+/// If a valid subcommand is supplied, executes that subcommand, passing `args` to the program.
+/// Valid subcommands are `check`, `command`, `state` and `theme`.
+/// Prints an error to STDERR and returns `false` if an invalid subcommand is supplied.
+///
+/// # Arguments
+///
+/// + `args` - The command line arguments leftwm was called with.
+///
+/// # Panics
+///
+/// Panics if `args` has length < 2.
+fn execute_subcommand(args: Vec<String>) -> bool {
+    if ["check", "command", "state", "theme"]
+        .iter()
+        .any(|x| x == &args[1])
+    {
+        println!("Running leftwm-{} with args {:?}", &args[1], &args[2..]);
+        true
+    } else {
+        eprintln!("Invalid command '{}'.", &args[1]);
+        false
     }
 }


### PR DESCRIPTION
I'm not sure why, but I find it really irritating to type `leftwm-theme` rather than `leftwm theme`. So I implemented four subcommands for `leftwm`:
+ `leftwm check`
+ `leftwm command`
+ `leftwm state`
+ `leftwm theme`
If you run any of these, it will simply run the corresponding program e.g. `leftwm-theme` rather than attempting to start the window manager. If you call it with no arguments, it will function as normal and attempt to start the window manager.

Further arguments will be passed to the corresponding program, so `leftwm theme update` will run `leftwm-theme update`.