### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ List of LeftWM dependencies:
 
 List of common dependencies for themes:
 
+
 | Dependency<br>(git) | Ubuntu 20.4.1<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 33<br> _sudo dnf install {}_ | PKGS |
-|--------------------------|-----------|------------------|-----------|--------------------------|
-| [feh][feh-git]           | feh       | feh              | feh       | [feh][feh-pkg]           |
-| [compton][compton-git]   | compton   | yay -S picom*    | compton   | [compton][compton-pkg]   |
-| [picom][picom-git]       | manual ** | picom            | picom     | [picom][picom-pkg]       |
-| [polybar][polybar-git]   | manual ** | yay -S polybar*  | polybar   | [polybar][polybar-pkg]   |
-| [xmobar][xmobar-git]     | xmobar    | xmobar           | xmobar    | [xmobar][xmobar-pkg]     |
-| [lemonbar][lemonbar-git] | lemonbar  | yay -S lemonbar* | manual ** | [lemonbar][lemonbar-pkg] |
-| [conky][conky-git]       | conky     | conky            | conky     | [conky][conky-pkg]       |
-| [dmenu][dmenu-git]       | dmenu     | dmenu            | dmenu     | [dmenu][dmenu-pkg]       |
+|--------------------------|-----------|-------------------|-----------|--------------------------|
+| [feh][feh-git]           | feh       | feh               | feh       | [feh][feh-pkg]           |
+| [compton][compton-git]   | compton   | paru -S picom*    | compton   | [compton][compton-pkg]   |
+| [picom][picom-git]       | manual ** | picom             | picom     | [picom][picom-pkg]       |
+| [polybar][polybar-git]   | manual ** | paru -S polybar*  | polybar   | [polybar][polybar-pkg]   |
+| [xmobar][xmobar-git]     | xmobar    | xmobar            | xmobar    | [xmobar][xmobar-pkg]     |
+| [lemonbar][lemonbar-git] | lemonbar  | paru -S lemonbar* | manual ** | [lemonbar][lemonbar-pkg] |
+| [conky][conky-git]       | conky     | conky             | conky     | [conky][conky-pkg]       |
+| [dmenu][dmenu-git]       | dmenu     | dmenu             | dmenu     | [dmenu][dmenu-pkg]       |
 
 [feh-git]: https://github.com/derf/feh
 [feh-pkg]: https://pkgs.org/search/?q=feh&on=provides
@@ -118,14 +119,14 @@ List of common dependencies for themes:
 [dmenu-pkg]: https://pkgs.org/download/dmenu
 
 
-> \* You can use whichever AUR wrapper you like  
+> \* You can use whichever AUR wrapper you like. See [paru] and [yay].
 > \*\* See the git page (link in first column) for how to install these manually
 
 # Installation (with package manager)
 
-Archlinux ([AUR])
+Archlinux ([AUR] - [paru] is an AUR helper like [yay], but written in [Rust].)
 ```sh
-yay -S leftwm
+paru -S leftwm
 ```
 
 Fedora ([copr])
@@ -147,6 +148,8 @@ sudo cp PATH_TO_LEFTWM/leftwm.desktop /usr/share/xsessions
 [AUR]: https://aur.archlinux.org/packages/leftwm
 [copr]: https://copr.fedorainfracloud.org/coprs/atim/leftwm/
 [crates.io]: https://crates.io/crates/leftwm
+[paru]: https://github.com/Morganamilo/paru
+[yay]: https://github.com/Jguer/yay
 
 # Manual Installation (no package manager)
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ simple black screen on login.  For a more customized look, install a theme.
 
 If your goal is to continously build leftwm and keep up to date with the latest releases, you may
 prefer to symlink the leftwm executables instead of copying them.  If you choose to install this
-way, make sure you do not move the build directory as it will break your installation.  
+way, make sure you do not move the build directory as it will break your installation.
 
 1. Dependencies: Rust, Cargo
 2. Clone the repository and cd into the directory

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Archlinux ([AUR])
 paru -S leftwm
 ```
 
-_[paru] is an AUR helper like [yay], but written in [Rust]._
+[paru] is an AUR helper like [yay], but written in [Rust].
 
 Fedora ([copr])
 ```sh

--- a/README.md
+++ b/README.md
@@ -66,16 +66,34 @@ List of LeftWM dependencies:
 
 List of common dependencies for themes:
 
-| Dependency<br>(git)| Ubuntu 20.4.1<br> _sudo apt install {}_  | Arch<br> _sudo pacman -S {}_  | Fedora 33<br> _sudo dnf install {}_  | PKGS  |
-|- |- |- |- |- |
-| [feh](https://github.com/derf/feh)  | feh  | feh  | feh  | [feh](https://pkgs.org/search/?q=feh&on=provides)  |
-| [compton](https://github.com/chjj/compton)  | compton  | yay -S picom*  | compton  | [compton](https://pkgs.org/download/compton)  |
-| [picom](https://github.com/yshui/picom)  | manual **  | picom  | picom  | [picom](https://pkgs.org/download/picom)  |
-| [polybar](https://github.com/polybar/polybar)  | manual **  | yay -S polybar*  | polybar  | [polybar](https://pkgs.org/download/polybar)  |
-| [xmobar](https://github.com/jaor/xmobar)  | xmobar  | xmobar  | xmobar  | [xmobar](https://pkgs.org/download/xmobar)  |
-| [lemonbar](https://github.com/LemonBoy/bar)  | lemonbar  | yay -S lemonbar*  | manual **  | [lemonbar](https://pkgs.org/download/lemonbar)  |
-| [conky](https://github.com/brndnmtthws/conky)  | conky  | conky  | conky  | [conky](https://pkgs.org/download/conky)  |
-| [dmenu](https://git.suckless.org/dmenu)  | dmenu  | dmenu  | dmenu  | [dmenu](https://pkgs.org/download/dmenu)  |
+| Dependency<br>(git) | Ubuntu 20.4.1<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 33<br> _sudo dnf install {}_ | PKGS |
+|--------------------------|-----------|------------------|-----------|--------------------------|
+| [feh][feh-git]           | feh       | feh              | feh       | [feh][feh-pkg]           |
+| [compton][compton-git]   | compton   | yay -S picom*    | compton   | [compton][compton-pkg]   |
+| [picom][picom-git]       | manual ** | picom            | picom     | [picom][picom-pkg]       |
+| [polybar][polybar-git]   | manual ** | yay -S polybar*  | polybar   | [polybar][polybar-pkg]   |
+| [xmobar][xmobar-git]     | xmobar    | xmobar           | xmobar    | [xmobar][xmobar-pkg]     |
+| [lemonbar][lemonbar-git] | lemonbar  | yay -S lemonbar* | manual ** | [lemonbar][lemonbar-pkg] |
+| [conky][conky-git]       | conky     | conky            | conky     | [conky][conky-pkg]       |
+| [dmenu][dmenu-git]       | dmenu     | dmenu            | dmenu     | [dmenu][dmenu-pkg]       |
+
+[feh-git]: https://github.com/derf/feh
+[feh-pkg]: https://pkgs.org/search/?q=feh&on=provides
+[compton-git]: https://github.com/chjj/compton
+[compton-pkg]: https://pkgs.org/download/compton
+[picom-git]: https://github.com/yshui/picom
+[picom-pkg]: https://pkgs.org/download/picom
+[polybar-git]: https://github.com/polybar/polybar
+[polybar-pkg]: https://pkgs.org/download/polybar
+[xmobar-git]: https://github.com/jaor/xmobar
+[xmobar-pkg]: https://pkgs.org/download/xmobar
+[lemonbar-git]: https://github.com/LemonBoy/bar
+[lemonbar-pkg]: https://pkgs.org/download/lemonbar
+[conky-git]: https://github.com/brndnmtthws/conky
+[conky-pkg]: https://pkgs.org/download/conky
+[dmenu-git]: https://git.suckless.org/dmenu
+[dmenu-pkg]: https://pkgs.org/download/dmenu
+
 
 > \* You can use whichever AUR wrapper you like  
 > \*\* See the git page (link in first column) for how to install these manually

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ List of common dependencies for themes:
 [dmenu-pkg]: https://pkgs.org/download/dmenu
 
 
-> \* You can use whichever AUR wrapper you like. See [paru] and [yay].
+> \* You can use whichever AUR wrapper you like. See [paru] and [yay].  
 > \*\* See the git page (link in first column) for how to install these manually
 
 # Installation (with package manager)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@
     <strong>A window manager for adventurers</strong>
   </p>
   <p>
-    <a href="https://github.com/leftwm/leftwm/actions?query=workflow%3ACI"><img src="https://github.com/leftwm/leftwm/workflows/CI/badge.svg" alt="build status" /></a>
-    <a href="https://github.com/leftwm/leftwm/wiki"><img src="https://img.shields.io/badge/wiki-0.2.6-green.svg" alt="wiki" /></a>
-    <a href="https://docs.rs/leftwm/"><img src="https://docs.rs/leftwm/badge.svg" alt="Documentation" /></a>
+    <a href="https://github.com/leftwm/leftwm/actions?query=workflow%3ACI">
+        <img src="https://github.com/leftwm/leftwm/workflows/CI/badge.svg" alt="build status" />
+    </a>
+    <a href="https://github.com/leftwm/leftwm/wiki">
+        <img src="https://img.shields.io/badge/wiki-0.2.6-green.svg" alt="wiki" />
+    </a>
+    <a href="https://docs.rs/leftwm/">
+        <img src="https://docs.rs/leftwm/badge.svg" alt="Documentation" />
+    </a>
   </p>
 </div>
 
@@ -34,23 +40,40 @@
 
 # Why go left
 
-LeftWM is a tiling window manager written in [Rust](https://github.com/rust-lang/rust) that aims to be stable and performant. LeftWM is [designed to do one thing and to do that one thing well](https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well): _be a window manager_. LeftWM therefore follows the following mantra:
+LeftWM is a tiling window manager written in [Rust] that aims to be stable and performant. LeftWM is
+[designed to do one thing and to do that one thing well][unix-philosophy]: _be a window manager_.
+LeftWM therefore follows the following mantra:
 
 > LeftWM is not a compositor.  
 > LeftWM is not a lock screen.  
-> LeftWM is not a bar. But, there are lots of good bars out there. With themes, picking one is as simple as setting a symlink.
+> LeftWM is not a bar. But, there are lots of good bars out there. With themes, picking one is as
+  simple as setting a symlink.
 
-Because you probably want more than just a black screen, LeftWM is built around the concept of themes. With themes, you can choose between different bars, compositors, backgrounds, colors, docks, and whatever else makes you happy.
+Because you probably want more than just a black screen, LeftWM is built around the concept of
+themes. With themes, you can choose between different bars, compositors, backgrounds, colors, docks,
+and whatever else makes you happy.
 
-LeftWM was built from the very beginning to support multiple screens and ultrawide monitors. The default keybindings support ultrawide monitors and multiple screens.
+LeftWM was built from the very beginning to support multiple screens and ultrawide monitors. The
+default keybindings support ultrawide monitors and multiple screens.
+
+[Rust]: https://github.com/rust-lang/rust
+[unix-philosophy]: https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well
 
 ## One of the core concepts/features of LeftWM is theming
 
 With LeftWM, there are two types of configuration files:
 
-- **LeftWM Configuration files:** LeftWM configurations are specific to you and don’t change for different themes. These are settings like keybindings, workspace locations, and names of desktops/tags. These settings can be found in `~/.config/leftwm/config.toml`.
+- **LeftWM Configuration files:** LeftWM configurations are specific to you and don’t change for
+  different themes. These are settings like keybindings, workspace locations, and names of
+  desktops/tags. These settings can be found in `~/.config/leftwm/config.toml`.
 
-- **Theme Configuration files:** The appearance of your desktop is different. It’s fun to try new looks and feels. It’s fun to tweak and customize the appearance (AKA: [ricing](https://www.reddit.com/r/unixporn/comments/3iy3wd/stupid_question_what_is_ricing/)). It’s fun to share so others can experience your awesome desktop! LeftWM is built around this concept. By pulling all these settings out into themes, you can now easily tweak, switch, and share your experiences. This configuration is spread between `theme.toml` and related files contained within a theme's folder.
+- **Theme Configuration files:** The appearance of your desktop is different. It’s fun to try new
+  looks and feels. It’s fun to tweak and customize the appearance (AKA: [ricing]). It’s fun to share
+  so others can experience your awesome desktop! LeftWM is built around this concept. By pulling all
+  these settings out into themes, you can now easily tweak, switch, and share your experiences. This
+  configuration is spread between `theme.toml` and related files contained within a theme's folder.
+
+[ricing]: https://www.reddit.com/r/unixporn/comments/3iy3wd/stupid_question_what_is_ricing/
 
 # Dependencies
 
@@ -100,7 +123,9 @@ List of common dependencies for themes:
 
 # Installation (with package manager)
 
-LeftWM is available in the AUR as well as crates.io. Both are good options for simple installation. If you install LeftWM with crates.io, you will need to link to the xsession desktop file if you want to be able to login to LeftWM from a graphical login screen:
+LeftWM is available in the AUR as well as crates.io. Both are good options for simple installation.
+If you install LeftWM with crates.io, you will need to link to the xsession desktop file if you want
+to be able to login to LeftWM from a graphical login screen:
 
 ```bash
 sudo cp PATH_TO_LEFTWM/leftwm.desktop /usr/share/xsessions
@@ -142,11 +167,14 @@ sudo install -s -Dm755 ./target/release/leftwm ./target/release/leftwm-worker ./
 sudo cp leftwm.desktop /usr/share/xsessions/
 ```
 
-You should now see LeftWM in your list of available window managers.  At this point, expect only a simple black screen on login.  For a more customized look, install a theme.
+You should now see LeftWM in your list of available window managers.  At this point, expect only a
+simple black screen on login.  For a more customized look, install a theme.
 
 ## Optional Development Installation
 
-If your goal is to continously build leftwm and keep up to date with the latest releases, you may prefer to symlink the leftwm executables instead of copying them.  If you choose to install this way, make sure you do not move the build directory as it will break your installation.  
+If your goal is to continously build leftwm and keep up to date with the latest releases, you may
+prefer to symlink the leftwm executables instead of copying them.  If you choose to install this
+way, make sure you do not move the build directory as it will break your installation.  
 
 1. Dependencies: Rust, Cargo
 2. Clone the repository and cd into the directory
@@ -182,7 +210,8 @@ sudo ln -s "$(pwd)"/target/release/leftwm-command /usr/bin/leftwm-command
 sudo cp leftwm.desktop /usr/share/xsessions/
 ```
 
-You should now see LeftWM in your list of available window managers.  At this point, expect only a simple black screen on login.  For a more customized look, install a theme.
+You should now see LeftWM in your list of available window managers.  At this point, expect only a
+simple black screen on login.  For a more customized look, install a theme.
 
 ### Rebuilding the development installation
 
@@ -236,9 +265,14 @@ cd ~/.config/leftwm/themes
 ln -s PATH_TO_THE_THEME_YOU_LIKE current
 ```
 
-LeftWM comes packaged with a couple of default themes. There is also a [community repository for sharing themes](https://github.com/leftwm/leftwm-community-themes)
+LeftWM comes packaged with a couple of default themes. There is also a
+[community repository][community-repo] for sharing themes.
 
-For more information about themes check out our theme guide [here](https://github.com/leftwm/leftwm/tree/master/themes) or the wiki [here](https://github.com/leftwm/leftwm/wiki/Themes).
+For more information about themes check out our [theme guide][theme-guide] or the [wiki].
+
+[community-repo]: https://github.com/leftwm/leftwm-community-themes
+[theme-guide]: https://github.com/leftwm/leftwm/tree/master/themes
+[wiki]: https://github.com/leftwm/leftwm/wiki/Themes
 
 # Configuring
 
@@ -270,7 +304,10 @@ the file is automatically generated when leftwm or leftwm-check is run for the f
 | Mod + Shift + R     | Reload LeftWM and its config                                           |
 | Mod + p             | Use dmenu to start application                                         |
 
-**Note:** Although we encourage you to use [Alacritty](https://github.com/alacritty/alacritty), LeftWM will set your default terminal to the first terminal it finds in this list (in the order presented):
+**Note:** Although we encourage you to use [Alacritty](https://github.com/alacritty/alacritty),
+LeftWM will set your default terminal to the first terminal it finds in this list (in the order
+presented):
+
 1. Alacritty
 2. Termite
 3. URXVT
@@ -296,13 +333,16 @@ You can optionally switch between tiling or floating mode for any window.
 
 ## Workspaces
 
-By default, workspaces have a one-to-one relationship with screens, but this is configurable. There are many reasons you might want to change this, but the main reason is for ultrawide monitors. You might want to have two or even three workspaces on a single screen.
+By default, workspaces have a one-to-one relationship with screens, but this is configurable. There
+are many reasons you might want to change this, but the main reason is for ultrawide monitors. You
+might want to have two or even three workspaces on a single screen.
 
 Here is an example config changing the way workspaces are defined (~/.config/leftwm/config.toml)
 
 ---
 **NOTE**
-The line `workspaces = []` needs to be removed, or commented out if a configuration like the following example is used.
+The line `workspaces = []` needs to be removed, or commented out if a configuration like the
+following example is used.
 
 ---
 
@@ -325,7 +365,8 @@ width = 1720
 The default tags are 1-9. They can be renamed in the config file by setting the
 list of tags.
 
-Here is an example config changing the list of available tags. NOTE: tag navigation (Mod + #) doesn't change based on the name of the tag
+Here is an example config changing the list of available tags. NOTE: tag navigation (Mod + #)
+doesn't change based on the name of the tag.
 
 ```toml
 tags = ["Web", "Code", "Shell", "Music", "Connect"]
@@ -333,14 +374,18 @@ tags = ["Web", "Code", "Shell", "Music", "Connect"]
 
 ## Layouts
 
-By default, all layouts are enabled. There are a lot of layouts so you might want to consider only enabling the ones you use. To do this add a layout section to your config.toml file. This enables only the layouts you specify 
+By default, all layouts are enabled. There are a lot of layouts so you might want to consider only
+enabling the ones you use. To do this add a layout section to your config.toml file. This enables
+only the layouts you specify.
 
 Example:
 ```toml
 layouts = ["MainAndHorizontalStack", "GridHorizontal", "Fibonacci", "EvenVertical", "EvenHorizontal", "CenterMain"]
 ```
 
-[More detailed configuration information can be found in the Wiki](https://github.com/leftwm/leftwm/wiki/Config).
+[More detailed configuration information can be found in the Wiki.][config-wiki]
+
+[config-wiki]: https://github.com/leftwm/leftwm/wiki/Config
 
 ## LeftWM is [EWMH](https://en.wikipedia.org/wiki/Extended_Window_Manager_Hints) compliant
 

--- a/README.md
+++ b/README.md
@@ -326,14 +326,20 @@ presented):
 
 1. Alacritty
 2. Termite
-3. URXVT
-4. RXVT
-5. ST
-6. ROXTerm
-7. Eterm
-8. Terminator
-9. Terminology
+3. Kitty
+4. URXVT
+5. RXVT
+6. ST
+7. ROXTerm
+8. Eterm
+9. XTerm
+10. Terminator
+11. Terminology
 10. Gnome Terminal
+12. XFCE4 Terminal
+13. Konsole
+14. UXTerm
+15. Guake
  
 
 ## Floating Windows

--- a/README.md
+++ b/README.md
@@ -123,19 +123,30 @@ List of common dependencies for themes:
 
 # Installation (with package manager)
 
-LeftWM is available in the AUR as well as crates.io. Both are good options for simple installation.
-If you install LeftWM with crates.io, you will need to link to the xsession desktop file if you want
-to be able to login to LeftWM from a graphical login screen:
+Archlinux ([AUR])
+```sh
+yay -S leftwm
+```
 
-```bash
+Fedora ([copr])
+```sh
+sudo dnf copr enable atim/leftwm -y && sudo dnf install leftwm
+```
+
+Cargo ([crates.io])
+```sh
+cargo install leftwm
+```
+If you install LeftWM with crates.io, you will need to link to the xsession desktop file if you want
+to be able to login to LeftWM from a display manager (GDM, SSDM, LightDM, etc.):
+
+```sh
 sudo cp PATH_TO_LEFTWM/leftwm.desktop /usr/share/xsessions
 ```
 
-LeftWM is also available in Fedora [Copr](https://copr.fedorainfracloud.org/coprs/atim/leftwm/):
-
-```bash
-sudo dnf copr enable atim/leftwm -y && sudo dnf install leftwm
-```
+[AUR]: https://aur.archlinux.org/packages/leftwm
+[copr]: https://copr.fedorainfracloud.org/coprs/atim/leftwm/
+[crates.io]: https://crates.io/crates/leftwm
 
 # Manual Installation (no package manager)
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ List of common dependencies for themes:
 
 # Installation (with package manager)
 
-Archlinux ([AUR] - [paru] is an AUR helper like [yay], but written in [Rust].)
+Archlinux ([AUR])
 ```sh
 paru -S leftwm
 ```
+
+_[paru] is an AUR helper like [yay], but written in [Rust]._
 
 Fedora ([copr])
 ```sh


### PR DESCRIPTION
When I first installed LeftWM I didn't realize there was an AUR package for it because it was buried in a paragraph and I must have skimmed over it. I rewrote the installation (with package manager) section to be more clear.

I am a big fan of `paru` so I changed `yay` to `paru` and added some notes about what it is, since it is less pervasive. I think it makes sense to mention it since it's a rusty tool (and it's very good).

I got a bit carried away with the formatting - everything should display the same as it did, but I reduced the line lengths where possible and added citation style links where I felt like it improved the flow.