### PR TITLE
Be more efficient when updating bar tags

### DIFF
--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -214,32 +214,13 @@ fn swap_tags(manager: &mut Manager) -> Option<bool> {
     if manager.workspaces.len() >= 2 && manager.focus_manager.workspace_history.len() >= 2 {
         let hist_a = *manager.focus_manager.workspace_history.get(0)?;
         let hist_b = *manager.focus_manager.workspace_history.get(1)?;
-        //Update dock tags
-        let ws_a = manager.workspaces.get(hist_a)?;
-        let ws_b = manager.workspaces.get(hist_b)?;
-        let mut changed = vec![];
-        manager
-            .windows
-            .iter_mut()
-            .filter(|w| helpers::intersect(&ws_a.tags, &w.tags) && w.strut.is_some())
-            .for_each(|w| {
-                w.tags = ws_b.tags.clone();
-                changed.push(w.handle)
-            });
-        manager
-            .windows
-            .iter_mut()
-            .filter(|w| {
-                helpers::intersect(&ws_b.tags, &w.tags)
-                    && w.strut.is_some()
-                    && !changed.contains(&w.handle)
-            })
-            .for_each(|w| w.tags = ws_a.tags.clone());
         //Update workspace tags
         let mut temp = vec![];
         std::mem::swap(&mut manager.workspaces.get_mut(hist_a)?.tags, &mut temp);
         std::mem::swap(&mut manager.workspaces.get_mut(hist_b)?.tags, &mut temp);
         std::mem::swap(&mut manager.workspaces.get_mut(hist_a)?.tags, &mut temp);
+        //Update dock tags
+        manager.update_docks();
         return Some(true);
     }
     if manager.workspaces.len() == 1 {

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -214,6 +214,28 @@ fn swap_tags(manager: &mut Manager) -> Option<bool> {
     if manager.workspaces.len() >= 2 && manager.focus_manager.workspace_history.len() >= 2 {
         let hist_a = *manager.focus_manager.workspace_history.get(0)?;
         let hist_b = *manager.focus_manager.workspace_history.get(1)?;
+        //Update dock tags
+        let ws_a = manager.workspaces.get(hist_a)?;
+        let ws_b = manager.workspaces.get(hist_b)?;
+        let mut changed = vec![];
+        manager
+            .windows
+            .iter_mut()
+            .filter(|w| helpers::intersect(&ws_a.tags, &w.tags) && w.strut.is_some())
+            .for_each(|w| {
+                w.tags = ws_b.tags.clone();
+                changed.push(w.handle)
+            });
+        manager
+            .windows
+            .iter_mut()
+            .filter(|w| {
+                helpers::intersect(&ws_b.tags, &w.tags)
+                    && w.strut.is_some()
+                    && !changed.contains(&w.handle)
+            })
+            .for_each(|w| w.tags = ws_a.tags.clone());
+        //Update workspace tags
         let mut temp = vec![];
         std::mem::swap(&mut manager.workspaces.get_mut(hist_a)?.tags, &mut temp);
         std::mem::swap(&mut manager.workspaces.get_mut(hist_b)?.tags, &mut temp);

--- a/src/handlers/goto_tag_handler.rs
+++ b/src/handlers/goto_tag_handler.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::wildcard_imports)]
-use crate::utils::helpers;
-
 use super::*;
 
 pub fn process(manager: &mut Manager, tag_num: usize) -> bool {
@@ -15,40 +13,17 @@ pub fn process(manager: &mut Manager, tag_num: usize) -> bool {
         Some(ws) => ws.tags.clone(),
         None => return false,
     };
-    let mut changed = vec![];
     if let Some(ws) = manager.workspaces.iter_mut().find(|ws| ws.tags == new_tags) {
-        update_dock_tags(&mut manager.windows, ws, &old_tags, &mut changed);
         ws.tags = old_tags;
     }
 
-    match manager.focus_manager.workspace_mut(&mut manager.workspaces) {
-        Some(ws) => {
-            update_dock_tags(&mut manager.windows, ws, &new_tags, &mut changed);
-            ws.tags = new_tags
-        }
+    match manager.focused_workspace_mut() {
+        Some(aws) => aws.tags = new_tags,
         None => return false,
     }
     focus_handler::focus_tag(manager, &tag.id);
+    manager.update_docks();
     true
-}
-
-fn update_dock_tags(
-    windows: &mut Vec<Window>,
-    ws: &Workspace,
-    tags: &[String],
-    changed: &mut Vec<WindowHandle>,
-) {
-    let clone = changed.clone();
-    //Update the tags of the docks
-    windows
-        .iter_mut()
-        .filter(|w| {
-            helpers::intersect(&ws.tags, &w.tags) && w.strut.is_some() && !clone.contains(&w.handle)
-        })
-        .for_each(|w| {
-            w.tags = tags.to_vec();
-            changed.push(w.handle)
-        });
 }
 
 #[cfg(test)]

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -176,21 +176,25 @@ pub fn destroyed(manager: &mut Manager, handle: &WindowHandle) -> bool {
 }
 
 pub fn changed(manager: &mut Manager, change: WindowChange) -> bool {
+    let mut changed = false;
+    let strut_changed = change.strut.is_some();
     if let Some(w) = manager
         .windows
         .iter_mut()
         .find(|w| w.handle == change.handle)
     {
         log::debug!("WINDOW CHANGED {:?} {:?}", &w, change);
-        let changed = change.update(&manager.workspaces, w);
+        changed = change.update(w);
         if w.type_ == WindowType::Dock {
             update_workspace_avoid_list(manager);
             //don't left changes from docks re-render the worker. This will result in an
             //infinite loop. Just be patient a rerender will occur.
         }
-        return changed;
     }
-    false
+    if strut_changed {
+        manager.update_docks();
+    }
+    changed
 }
 
 fn find_window<'w>(manager: &'w Manager, handle: &WindowHandle) -> Option<&'w Window> {

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -182,7 +182,7 @@ pub fn changed(manager: &mut Manager, change: WindowChange) -> bool {
         .find(|w| w.handle == change.handle)
     {
         log::debug!("WINDOW CHANGED {:?} {:?}", &w, change);
-        let changed = change.update(w);
+        let changed = change.update(&manager.workspaces, w);
         if w.type_ == WindowType::Dock {
             update_workspace_avoid_list(manager);
             //don't left changes from docks re-render the worker. This will result in an

--- a/src/models/dto.rs
+++ b/src/models/dto.rs
@@ -110,13 +110,7 @@ impl From<&Manager> for ManagerState {
         tags_len = if tags_len == 0 { 0 } else { tags_len - 1 };
         let working_tags = manager.tags[0..tags_len]
             .iter()
-            .filter(|tag| {
-                manager
-                    .windows
-                    .iter()
-                    .filter(|w| !(w.is_fullscreen() || w.floating()))
-                    .any(|w| w.has_tag(&tag.id))
-            })
+            .filter(|tag| manager.windows.iter().any(|w| w.has_tag(&tag.id)))
             .map(|t| t.id.clone())
             .collect();
         for ws in &manager.workspaces {

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -77,6 +77,19 @@ impl Manager {
         self.focus_manager.window_mut(&mut self.windows)
     }
 
+    pub fn update_docks(&mut self) {
+        let workspaces = self.workspaces.clone();
+        self.windows
+            .iter_mut()
+            .filter(|w| w.strut.is_some())
+            .for_each(|w| {
+                let (x, y) = w.strut.unwrap_or_default().center();
+                if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
+                    w.tags = ws.tags.clone()
+                }
+            });
+    }
+
     //sorts the windows and puts them in order of importance
     //keeps the order for each importance level
     pub fn sort_windows(&mut self) {

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -3,7 +3,6 @@ use super::WindowHandle;
 use super::WindowState;
 use super::WindowType;
 use crate::models::{Margins, XyhwChange};
-use crate::Workspace;
 
 type MaybeWindowHandle = Option<WindowHandle>;
 type MaybeName = Option<String>;
@@ -35,7 +34,7 @@ impl WindowChange {
         }
     }
 
-    pub fn update(self, workspaces: &[Workspace], window: &mut Window) -> bool {
+    pub fn update(self, window: &mut Window) -> bool {
         let mut changed = false;
         if let Some(trans) = &self.transient {
             let changed_trans = window.transient.is_none() || &window.transient != trans;
@@ -70,13 +69,6 @@ impl WindowChange {
         }
         if let Some(strut) = self.strut {
             let changed_strut = strut.update_window_strut(window);
-            //Update the windows tags
-            if let Some(xyhw) = window.strut {
-                let (x, y) = xyhw.center();
-                if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
-                    window.tags = ws.tags.clone();
-                }
-            }
             //////if changed_strut {
             //////    warn!("CHANGED: strut");
             //////}

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -3,6 +3,7 @@ use super::WindowHandle;
 use super::WindowState;
 use super::WindowType;
 use crate::models::{Margins, XyhwChange};
+use crate::Workspace;
 
 type MaybeWindowHandle = Option<WindowHandle>;
 type MaybeName = Option<String>;
@@ -34,7 +35,7 @@ impl WindowChange {
         }
     }
 
-    pub fn update(self, window: &mut Window) -> bool {
+    pub fn update(self, workspaces: &[Workspace], window: &mut Window) -> bool {
         let mut changed = false;
         if let Some(trans) = &self.transient {
             let changed_trans = window.transient.is_none() || &window.transient != trans;
@@ -69,6 +70,13 @@ impl WindowChange {
         }
         if let Some(strut) = self.strut {
             let changed_strut = strut.update_window_strut(window);
+            //Update the windows tags
+            if let Some(xyhw) = window.strut {
+                let (x, y) = xyhw.center();
+                if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
+                    window.tags = ws.tags.clone();
+                }
+            }
             //////if changed_strut {
             //////    warn!("CHANGED: strut");
             //////}

--- a/src/state.rs
+++ b/src/state.rs
@@ -85,6 +85,7 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
             window.normal = old.normal;
             window.tags = tags;
             window.strut = old.strut;
+            window.set_states(old.states());
             ordered.push(window.clone());
             manager.windows.remove(index);
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -71,11 +71,20 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
             .enumerate()
             .find(|w| w.1.handle == old.handle)
         {
+            let mut tags = old.tags.clone();
+            if let Some(xyhw) = old.strut {
+                let (x, y) = xyhw.center();
+                if let Some(ws) = manager.workspaces.iter().find(|ws| ws.contains_point(x, y)) {
+                    tags = ws.tags.clone()
+                }
+            }
+
             window.set_floating(old.floating());
             window.set_floating_offsets(old.get_floating_offsets());
             window.apply_margin_multiplier(old.margin_multiplier);
             window.normal = old.normal;
-            window.tags = old.tags.clone();
+            window.tags = tags;
+            window.strut = old.strut;
             ordered.push(window.clone());
             manager.windows.remove(index);
         }

--- a/src/utils/window_updater.rs
+++ b/src/utils/window_updater.rs
@@ -5,28 +5,11 @@ use crate::models::Manager;
  * based on the new state of the WM
  */
 pub fn update_windows(manager: &mut Manager) {
-    let mut strut_windows = vec![];
-    for w in &mut manager.windows {
-        w.set_visible(w.tags.is_empty());
-        if w.strut.is_some() {
-            strut_windows.push(w);
-        }
-    }
-    // Update the current tags for static windows, currently only docks
-    // This is to allow us to effectively "manage" them when it is necessary
-    for ws in &manager.workspaces {
-        strut_windows
-            .iter_mut()
-            .filter(|w| {
-                // It should always unwrap as strut is_some()
-                let xyhw = w.strut.unwrap_or_default();
-                let (x, y) = xyhw.center();
-                ws.contains_point(x, y)
-            })
-            .for_each(|w| {
-                w.tags = ws.tags.clone();
-            });
-    }
+    manager
+        .windows
+        .iter_mut()
+        .for_each(|w| w.set_visible(w.tags.is_empty()));
+
     for ws in &mut manager.workspaces {
         ws.update_windows(&mut manager.windows);
 


### PR DESCRIPTION
Rework of #361. I felt that the previous attempt unnecessarily updated the tags for the docks to often taking unneeded processor time (not matter how little). This now only updates the tags of the windows with a strut when a change occurs (the strut changes or we move to a different tag). I am not 100% we need the code in state, I guess it catches windows that don't get relaunched on reload.
Thanks.

Now fixes #366.