### PR TITLE
Fix move/resize when in ClickTo mode

### DIFF
--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -43,8 +43,10 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             xlib::ButtonPress => {
                 let event = xlib::XButtonPressedEvent::from(raw_event);
                 let h = WindowHandle::XlibHandle(event.window);
-                xw.replay_click();
-                Some(DisplayEvent::MouseCombo(event.state, event.button, h))
+                let mut mod_mask = event.state;
+                mod_mask &= !(xlib::Mod2Mask | xlib::LockMask);
+                xw.replay_click(mod_mask);
+                Some(DisplayEvent::MouseCombo(mod_mask, event.button, h))
             }
             xlib::ButtonRelease => Some(DisplayEvent::ChangeToNormalMode),
 

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -1519,9 +1519,13 @@ impl XWrap {
         }
     }
 
-    pub fn replay_click(&self) {
-        // Only replay the click when in ClickToFocus
-        if self.focus_behaviour == FocusBehaviour::ClickTo {
+    pub fn replay_click(&self, mod_mask: ModMask) {
+        // Only replay the click when in ClickToFocus and we are not trying to move/resize the
+        // window
+        if self.focus_behaviour == FocusBehaviour::ClickTo
+            && !(mod_mask == self.mouse_key_mask
+                || mod_mask == (self.mouse_key_mask | xlib::ShiftMask))
+        {
             unsafe {
                 (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
                 (self.xlib.XSync)(self.display, 0);

--- a/src/handlers/mouse_combo_handler.rs
+++ b/src/handlers/mouse_combo_handler.rs
@@ -45,14 +45,13 @@ pub fn process(
 
 fn build_action(
     manager: &mut Manager,
-    mut mod_mask: ModMask,
+    mod_mask: ModMask,
     button: Button,
     window: WindowHandle,
     modifier: ModMask,
 ) -> Option<DisplayAction> {
     match button {
         xlib::Button1 => {
-            mod_mask &= !(xlib::Mod2Mask | xlib::LockMask);
             if mod_mask == modifier || mod_mask == (modifier | xlib::ShiftMask) {
                 let _ = manager
                     .windows


### PR DESCRIPTION
This fixes when moving/resizing in clickto mode would cause the window to be stuck to the cursor.
Thanks.