### PR TITLE
Fix subcommands continuing in background, fix clap errors showing for valid arguments to subcommands

### DIFF
--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -22,11 +22,13 @@ fn main() {
     subcommands.insert("state", "Print the current state of LeftWM");
     subcommands.insert("theme", "Manage LeftWM themes");
 
+    let subcommand_names: Vec<&str> = subcommands.keys().copied().collect();
+
     let args: Vec<String> = env::args().collect();
 
     // If called with arguments, attempt to execute a subcommand.
     if args.len() > 1 {
-        match execute_subcommand(&args, &subcommands.keys().copied().collect::<Vec<_>>()) {
+        match execute_subcommand(&args, &subcommand_names) {
             // Subcommand executed. Exit success.
             Some(true) => exit(0),
             // Subcommand was valid, but failed to execute. Exit failure.

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -91,13 +91,15 @@ fn main() {
 /// Executes a subcommand.
 ///
 /// If a valid subcommand is supplied, executes that subcommand, passing `args` to the program.
-/// Valid subcommands are `check`, `command`, `state` and `theme`.
 /// Prints an error to `STDERR` and exits non-zero if an invalid subcommand is supplied, or there is
 /// some error while executing the subprocess.
 ///
 /// # Arguments
 ///
-/// + `args` - The command line arguments leftwm was called with.
+/// + `args` - The command line arguments leftwm was called with. Must be length >= 2, or this will
+///   panic.
+/// + `subcommands` - A list of subcommands that should be considered valid. Subcommands not in this
+///   list will not be executed.
 ///
 /// # Panics
 ///
@@ -130,18 +132,28 @@ fn execute_subcommand(args: &[String], subcommands: &[&str]) -> Option<bool> {
     }
 }
 
-/// Show program help text and exit if `--help` or `--version` flags are passed.
+/// Show program help text and exit if `--help` or `--version` flags are passed, or if an invalid
+/// argument is given.
 ///
-/// If `--help` or `--version` flags are not passed, this will do nothing.
+/// If the first argument is a valid subcommand, this will do nothing, and will not exit.
+/// This function is not intended to be called with valid subcommands as arguments, as it will exit
+/// when given valid subcommands along with arguments. This is because we don't keep track of what
+/// arguments are valid for each subcommand here, and `clap` assumes that all undocumented arguments
+/// are erroneous.
 ///
 /// # Arguments
 ///
-/// + `args` - The command line arguments leftwm was called with.
+/// + `args` - The command line arguments leftwm was called with. Do not pass in valid subcommands.
+/// + `subcommands` - A map of subcommand names and their descriptions. This determines what
+///   subcommands are listed in the help text, as well as what subcommands are considered as valid
+///   arguments.
 ///
 /// # Exits
 ///
 /// Exits early if `--help` or `--version` flags are passed.
 /// Exits early if an invalid subcommand is given.
+/// Exits early if a valid subcommand is given along with arguments to it. Avoid this usage, as the
+/// outcome is undesireable.
 fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &str>) {
     // If there are more than two arguments, do not invoke `clap`, since `clap` will get confused
     // about arguments to subcommands and throw spurrious errors.

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -167,7 +167,6 @@ fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &s
              it is installed.",
         )
         .version(crate_version!())
-        .version_short("v")
         .settings(&[AppSettings::DisableHelpSubcommand, AppSettings::ColoredHelp]);
     for (&subcommand, &description) in subcommands {
         app = app.subcommand(SubCommand::with_name(subcommand).about(description));

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -95,9 +95,15 @@ fn execute_subcommand(args: Vec<String>) {
     if subcommands.iter().any(|x| x == &args[1]) {
         // Run the command
         let cmd = format!("leftwm-{}", &args[1]);
-        if let Err(e) = Command::new(&cmd).args(&args[2..]).spawn() {
-            eprintln!("Failed to execute {}. {}", cmd, e);
-            exit(2);
+        match &mut Command::new(&cmd).args(&args[2..]).spawn() {
+            Ok(child) => {
+                // Wait for process to end, otherwise it may continue to run in the background.
+                child.wait().expect("Failed to wait for child.");
+            }
+            Err(e) => {
+                eprintln!("Failed to execute {}. {}", cmd, e);
+                exit(2);
+            }
         }
     } else {
         eprintln!("Invalid command '{}'.", &args[1]);


### PR DESCRIPTION
As pointed out by @VuiMuich [here], subcommands had some weird behaviours.

1. `leftwm state` would give you your prompt back immediately and then run in the background (vomiting all over your terminal whenever window manager actions occurred) rather than staying alive and allowing you to stop it with `Ctrl+C`. This was because we weren't `.wait()`ing for the command to finish before exiting.
2. `leftwm state -q` and other such commands were being considered invalid by `clap`. This is because clap does not know about the arguments to the external subcommands, so it thinks they are all invalid.

`1` was an easy fix, we just needed to `.wait()` on the subcommand.

`2` does not have an obvious fix - I was unable to find a way to get `clap` to accept arbitrary arguments to subcommands as valid. The workaround I came up with is to simply skip the `clap` part if a valid subcommand is passed.

While I was at it I made two changes:
1. List the subcommands in one place so that you don't need to update multiple functions to add a new subcommand.
2. Change the short `--version` flag from `-v` to `-V`. I personally prefer `-v` because it's more common, but since our other tools already use `-V` and one of them already has a `-v` option that does something else, it's better to be consistent.

[here]: https://github.com/leftwm/leftwm/pull/367#issuecomment-852329220