### PR TITLE
Fix focus crash

### DIFF
--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -92,7 +92,6 @@ where
     let index = list.iter().position(|x| test(x))?;
     let len = list.len() as i32;
     if len == 1 {
-        // return None;
         return list.get(index as usize);
     }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -89,11 +89,12 @@ where
     F: Fn(&T) -> bool,
     T: Clone,
 {
+    let index = list.iter().position(|x| test(x))?;
     let len = list.len() as i32;
     if len == 1 {
-        return None;
+        // return None;
+        return list.get(index as usize);
     }
-    let index = list.iter().position(|x| test(x))?;
 
     let mut find_index = index as i32 + shift;
     if find_index < 0 {


### PR DESCRIPTION
Closes #328

I don't really get, why this caused only crashes with `FocusWindow{Up/Down}` and not also with `Move...` but it seems like this fixed it.
Could you please verify I am not overlooking any possible case, where `relative_finde` returning `None` is actually expected? I beleive this is not the case, but not 100% sure.