### PR TITLE
Various fixes

### DIFF
--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -8,7 +8,6 @@ use leftwm::{
     config, external_command_handler, models, CommandPipe, DisplayEvent, DisplayEventHandler,
     DisplayServer, Manager, Mode, StateSocket, Window, Workspace, XlibDisplayServer,
 };
-use std::collections::HashMap;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::sync::{atomic::Ordering, Once};
@@ -45,11 +44,7 @@ fn main() {
         let mut manager = Manager {
             focus_manager,
             tags,
-            scratchpads: config
-                .get_list_of_scratchpads()
-                .iter()
-                .map(|s| (s.clone(), None))
-                .collect::<HashMap<_, _>>(),
+            scratchpads: config.get_list_of_scratchpads(),
             layouts: config.layouts.clone(),
             ..Manager::default()
         };

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -91,13 +91,13 @@ fn execute(manager: &mut Manager, val: &Option<String>) -> Option<bool> {
 fn toggle_scratchpad(manager: &mut Manager, val: &Option<String>) -> Option<bool> {
     let name = val.clone()?;
     let tag = &manager.focused_tag(0)?;
-    let (s, id) = manager
+    let s = manager
         .scratchpads
         .iter()
-        .find(|(s, _)| name == s.name.clone())
-        .map(|(s, id)| (s.clone(), id))?;
+        .find(|s| name == s.name.clone())
+        .map(|s| s.clone())?;
 
-    if id.is_some() {
+    if let Some(id) = manager.active_scratchpads.get(&s.name) {
         if let Some(w) = manager.windows.iter_mut().find(|w| w.pid == *id) {
             let is_tagged = w.has_tag(tag);
             w.clear_tags();
@@ -112,13 +112,9 @@ fn toggle_scratchpad(manager: &mut Manager, val: &Option<String>) -> Option<bool
             return Some(true);
         }
     }
+    let name = s.name.clone();
     let pid = exec_shell(&s.value, manager);
-    let id = manager
-        .scratchpads
-        .iter_mut()
-        .find(|(s, _)| name == s.name.clone())
-        .map(|(_, id)| id)?;
-    *id = pid;
+    manager.active_scratchpads.insert(name, pid);
     None
 }
 

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -94,8 +94,8 @@ fn toggle_scratchpad(manager: &mut Manager, val: &Option<String>) -> Option<bool
     let s = manager
         .scratchpads
         .iter()
-        .find(|s| name == s.name.clone())
-        .map(|s| s.clone())?;
+        .find(|s| name == s.name.clone())?
+        .clone();
 
     if let Some(id) = manager.active_scratchpads.get(&s.name) {
         if let Some(w) = manager.windows.iter_mut().find(|w| w.pid == *id) {

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -366,18 +366,20 @@ fn focus_window_change(
         let _ = helpers::cycle_vec(&mut to_reorder, val);
     } else if let Some(Layout::MainAndDeck) = layout {
         let len = to_reorder.len() as i32;
-        let index = match to_reorder.iter().position(|x: &Window| !x.floating()) {
-            Some(i) => {
-                if i as i32 == len - 1 {
-                    i
-                } else {
-                    i + 1
+        if len > 0 {
+            let index = match to_reorder.iter().position(|x: &Window| !x.floating()) {
+                Some(i) => {
+                    if i as i32 == len - 1 {
+                        i
+                    } else {
+                        i + 1
+                    }
                 }
-            }
-            None => len.checked_sub(1)? as usize,
-        };
-        let window_group = &to_reorder[..=index];
-        handle = helpers::relative_find(&window_group, is_handle, -val)?.handle;
+                None => len.saturating_sub(1) as usize,
+            };
+            let window_group = &to_reorder[..=index];
+            handle = helpers::relative_find(&window_group, is_handle, -val)?.handle;
+        }
     } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, val) {
         handle = new_focused.handle;
     }

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -365,10 +365,17 @@ fn focus_window_change(
         handle = helpers::relative_find(&to_reorder, is_handle, -val)?.handle;
         let _ = helpers::cycle_vec(&mut to_reorder, val);
     } else if let Some(Layout::MainAndDeck) = layout {
-        if to_reorder.len() == 1_usize {
-            return None;
-        }
-        let index = to_reorder.iter().position(|x: &Window| !x.floating())? + 1;
+        let len = to_reorder.len() as i32;
+        let index = match to_reorder.iter().position(|x: &Window| !x.floating()) {
+            Some(i) => {
+                if i as i32 == len - 1 {
+                    i
+                } else {
+                    i + 1
+                }
+            }
+            None => len.checked_sub(1)? as usize,
+        };
         let window_group = &to_reorder[..=index];
         handle = helpers::relative_find(&window_group, is_handle, -val)?.handle;
     } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, val) {

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -163,7 +163,10 @@ fn insert_window(manager: &mut Manager, window: &mut Window, layout: &Layout) {
 }
 
 fn is_scratchpad(manager: &Manager, window: &Window) -> bool {
-    manager.scratchpads.iter().any(|(_, &id)| window.pid == id)
+    manager
+        .active_scratchpads
+        .iter()
+        .any(|(_, &id)| window.pid == id)
 }
 
 /// Process a collection of events, and apply them changes to a manager.

--- a/src/models/dock_area.rs
+++ b/src/models/dock_area.rs
@@ -49,7 +49,6 @@ impl DockArea {
         screens_width: i32,
         screen: &Screen,
     ) -> Option<Xyhw> {
-        log::info!("DockArea: {:?}", self);
         if self.top > 0 {
             return Some(self.xyhw_from_top(screen.bbox.y));
         }

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -27,8 +27,8 @@ pub struct Manager {
     #[serde(skip)]
     pub tags: Vec<Tag>, //list of all known tags
     pub layouts: Vec<Layout>,
-    #[serde(skip)]
-    pub scratchpads: HashMap<ScratchPad, Option<u32>>,
+    pub scratchpads: Vec<ScratchPad>,
+    pub active_scratchpads: HashMap<String, Option<u32>>,
     pub actions: VecDeque<DisplayAction>,
 
     //this is used to limit framerate when resizing/moving windows

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -159,7 +159,6 @@ impl Window {
         self.transient.is_some()
             || self.type_ == WindowType::Dock
             || self.type_ == WindowType::Splash
-            || self.is_fullscreen()
     }
     #[must_use]
     pub fn can_move(&self) -> bool {

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,6 +49,7 @@ fn load_old_state() -> Result<Manager> {
 fn restore_state(manager: &mut Manager, old_manager: &Manager) {
     restore_workspaces(manager, old_manager);
     restore_windows(manager, old_manager);
+    restore_scratchpads(manager, old_manager);
 }
 
 /// Restore workspaces layout.
@@ -82,6 +83,7 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
             window.set_floating(old.floating());
             window.set_floating_offsets(old.get_floating_offsets());
             window.apply_margin_multiplier(old.margin_multiplier);
+            window.pid = old.pid;
             window.normal = old.normal;
             window.tags = old.tags.clone();
             window.strut = old.strut;
@@ -94,4 +96,10 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
         manager.update_docks();
     }
     manager.windows.append(&mut ordered);
+}
+
+fn restore_scratchpads(manager: &mut Manager, old_manager: &Manager) {
+    for (scratchpad, id) in &old_manager.active_scratchpads {
+        manager.active_scratchpads.insert(scratchpad.clone(), *id);
+    }
 }

--- a/src/utils/window_updater.rs
+++ b/src/utils/window_updater.rs
@@ -17,10 +17,7 @@ pub fn update_windows(manager: &mut Manager) {
             .windows
             .iter_mut()
             .filter(|w| ws.is_displaying(w) && w.is_fullscreen())
-            .for_each(|w| {
-                w.set_floating(false);
-                w.normal = ws.xyhw;
-            });
+            .for_each(|w| w.normal = ws.xyhw);
     }
     manager
         .windows


### PR DESCRIPTION
Fixes #387, with partial fixes for #388 and #390. In terms of #390 we can't (nicely) keep the window as fullscreen due to #386, as the window is restored in fullscreen briefly and gets minimised as the windows are still being re-added to the manager which then minimises it (if there is a way to hold the state being reloaded until all previous windows are loaded into the new manager, that I feel would be the easiest way). With #388 I think I have squashed any crashes around main_and_deck (If anymore are found let my know), but the focusing weirdness may require handling the focus change differently (I not 100% sure if this can be solved elegantly atleast with the issues I have found where the focus is sloppy and a floating window is above the centre of the next window to focus, meaning the focus moves to the floating window).
If anyone has some ideas on how to handle the bits I currently couldn't find a solution for let me know.
Thanks.