### PR TITLE
Fix #395

### DIFF
--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -702,7 +702,8 @@ impl XWrap {
                 (self.xlib.XSync)(self.display, 0);
             }
 
-            if self.get_window_type(handle) == WindowType::Dock {
+            let type_ = self.get_window_type(handle);
+            if type_ == WindowType::Dock || type_ == WindowType::Desktop {
                 if let Some(dock_area) = self.get_window_strut_array(handle) {
                     let dems = self.screens_area_dimensions();
                     let screen = self
@@ -714,7 +715,7 @@ impl XWrap {
                     if let Some(xyhw) = dock_area.as_xyhw(dems.0, dems.1, &screen) {
                         let mut change = WindowChange::new(h);
                         change.strut = Some(xyhw.into());
-                        change.type_ = Some(WindowType::Dock);
+                        change.type_ = Some(type_);
                         return Some(DisplayEvent::WindowChange(change));
                     }
                 } else if let Ok(geo) = self.get_window_geometry(handle) {
@@ -722,7 +723,7 @@ impl XWrap {
                     geo.update(&mut xyhw);
                     let mut change = WindowChange::new(h);
                     change.strut = Some(xyhw.into());
-                    change.type_ = Some(WindowType::Dock);
+                    change.type_ = Some(type_);
                     return Some(DisplayEvent::WindowChange(change));
                 }
             } else {

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -18,6 +18,7 @@ use crate::models::Mode;
 use crate::models::WindowChange;
 use crate::models::WindowState;
 use crate::models::WindowType;
+use crate::models::Xyhw;
 use crate::models::XyhwChange;
 use crate::utils::xkeysym_lookup::ModMask;
 use crate::DisplayEvent;
@@ -710,12 +711,19 @@ impl XWrap {
                         .find(|s| s.contains_dock_area(dock_area, dems))?
                         .clone();
 
-                    if let Some(xywh) = dock_area.as_xyhw(dems.0, dems.1, &screen) {
+                    if let Some(xyhw) = dock_area.as_xyhw(dems.0, dems.1, &screen) {
                         let mut change = WindowChange::new(h);
-                        change.strut = Some(xywh.into());
+                        change.strut = Some(xyhw.into());
                         change.type_ = Some(WindowType::Dock);
                         return Some(DisplayEvent::WindowChange(change));
                     }
+                } else if let Ok(geo) = self.get_window_geometry(handle) {
+                    let mut xyhw = Xyhw::default();
+                    geo.update(&mut xyhw);
+                    let mut change = WindowChange::new(h);
+                    change.strut = Some(xyhw.into());
+                    change.type_ = Some(WindowType::Dock);
+                    return Some(DisplayEvent::WindowChange(change));
                 }
             } else {
                 if follow_mouse {

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -166,9 +166,8 @@ fn move_to_tag(val: &Option<String>, manager: &mut Manager) -> Option<bool> {
     if manager.focus_manager.behaviour != FocusBehaviour::Sloppy {
         if let Some(ws) = manager.focused_workspace() {
             // TODO focus the window which takes the place on the screen of the closed window
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&ws.tags, &x.tags) && x.type_ != WindowType::Dock
-            };
+            let for_active_workspace =
+                |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
             if let Some(first) = manager.windows.iter().find(|w| for_active_workspace(w)) {
                 let handle = first.handle;
                 focus_handler::focus_window(manager, &handle);
@@ -241,7 +240,7 @@ fn swap_tags(manager: &mut Manager) -> Option<bool> {
 
 fn close_window(manager: &mut Manager) -> Option<bool> {
     let window = manager.focused_window()?;
-    if window.type_ != WindowType::Dock {
+    if !window.is_unmanaged() {
         let act = DisplayAction::KillWindow(window.handle);
         manager.actions.push_back(act);
     }
@@ -303,7 +302,7 @@ where
     let (tags, layout) = (w.tags.clone(), Some(w.layout.clone()));
 
     let for_active_workspace =
-        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && x.type_ != WindowType::Dock };
+        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && !x.is_unmanaged() };
 
     let to_reorder = helpers::vec_extract(&mut manager.windows, for_active_workspace);
     func(manager, val, handle, &layout, to_reorder)

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -66,7 +66,7 @@ fn focus_window_by_handle_work(manager: &mut Manager, handle: &WindowHandle) -> 
     //Docks don't want to get focus. If they do weird things happen. They don't get events...
     //Do the focus, Add the action to the list of action
     let found: &Window = manager.windows.iter().find(|w| &w.handle == handle)?;
-    if found.type_ == WindowType::Dock {
+    if found.is_unmanaged() {
         return None;
     }
     //NOTE: we are intentionally creating the focus event even if we think this window
@@ -192,9 +192,8 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
         let act = DisplayAction::FocusWindowUnderCursor;
         manager.actions.push_back(act);
     } else if let Some(ws) = to_focus.first() {
-        let for_active_workspace = |x: &Window| -> bool {
-            helpers::intersect(&ws.tags, &x.tags) && x.type_ != WindowType::Dock
-        };
+        let for_active_workspace =
+            |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
         let handle = match manager.windows.iter().find(|w| for_active_workspace(w)) {
             Some(w) => w.handle,
             None => return true,

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -68,9 +68,8 @@ fn setup_window(
         .or_else(|| manager.focused_workspace()); //backup plan
 
     if let Some(ws) = ws {
-        let for_active_workspace = |x: &Window| -> bool {
-            helpers::intersect(&ws.tags, &x.tags) && x.type_ != WindowType::Dock
-        };
+        let for_active_workspace =
+            |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
         *is_first = !manager.windows.iter().any(|w| for_active_workspace(w));
         window.tags = ws.tags.clone();
         *layout = ws.layout.clone();
@@ -124,9 +123,8 @@ fn setup_window(
 }
 fn insert_window(manager: &mut Manager, window: &mut Window, layout: &Layout) {
     // If the tag contains a fullscreen window, minimize it
-    let for_active_workspace = |x: &Window| -> bool {
-        helpers::intersect(&window.tags, &x.tags) && x.type_ != WindowType::Dock
-    };
+    let for_active_workspace =
+        |x: &Window| -> bool { helpers::intersect(&window.tags, &x.tags) && !x.is_unmanaged() };
     let mut was_fullscreen = false;
     if let Some(fsw) = manager
         .windows
@@ -186,9 +184,8 @@ pub fn destroyed(manager: &mut Manager, handle: &WindowHandle) -> bool {
             manager.actions.push_back(act);
         } else if let Some(ws) = manager.focused_workspace() {
             // TODO focus the window which takes the place on the screen of the closed window
-            let for_active_workspace = |x: &Window| -> bool {
-                helpers::intersect(&ws.tags, &x.tags) && x.type_ != WindowType::Dock
-            };
+            let for_active_workspace =
+                |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
             let first = match manager.windows.iter().find(|w| for_active_workspace(w)) {
                 Some(w) => w.handle,
                 None => return true,

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -92,7 +92,6 @@ impl Window {
     #[must_use]
     pub fn visible(&self) -> bool {
         self.visible
-            // || self.type_ == WindowType::Dock
             || self.type_ == WindowType::Menu
             || self.type_ == WindowType::Splash
             || self.type_ == WindowType::Dialog
@@ -156,32 +155,37 @@ impl Window {
     }
     #[must_use]
     pub fn must_float(&self) -> bool {
-        self.transient.is_some()
-            || self.type_ == WindowType::Dock
-            || self.type_ == WindowType::Splash
+        self.transient.is_some() || self.is_unmanaged() || self.type_ == WindowType::Splash
     }
     #[must_use]
     pub fn can_move(&self) -> bool {
-        self.type_ != WindowType::Dock
+        !self.is_unmanaged()
     }
     #[must_use]
     pub fn can_resize(&self) -> bool {
-        self.type_ != WindowType::Dock
+        !self.is_unmanaged()
     }
 
     #[must_use]
     pub fn can_focus(&self) -> bool {
-        !self.never_focus && self.type_ != WindowType::Dock && self.visible()
+        !self.never_focus && !self.is_unmanaged() && self.visible()
     }
 
     pub fn set_width(&mut self, width: i32) {
         self.normal.set_w(width)
     }
+
     pub fn set_height(&mut self, height: i32) {
         self.normal.set_h(height)
     }
+
     pub fn set_states(&mut self, states: Vec<WindowState>) {
         self.states = states;
+    }
+
+    #[must_use]
+    pub fn has_state(&self, state: &WindowState) -> bool {
+        self.states.contains(state)
     }
 
     #[must_use]
@@ -226,7 +230,7 @@ impl Window {
                     * self.margin_multiplier) as i32
                 - (self.border * 2);
         }
-        if value < 100 && self.type_ != WindowType::Dock {
+        if value < 100 && !self.is_unmanaged() {
             value = 100
         }
         value
@@ -246,7 +250,7 @@ impl Window {
                     * self.margin_multiplier) as i32
                 - (self.border * 2);
         }
-        if value < 100 && self.type_ != WindowType::Dock {
+        if value < 100 && !self.is_unmanaged() {
             value = 100
         }
         value
@@ -341,6 +345,11 @@ impl Window {
             }
         }
         self.tags = new_tags;
+    }
+
+    #[must_use]
+    pub fn is_unmanaged(&self) -> bool {
+        self.type_ == WindowType::Desktop || self.type_ == WindowType::Dock
     }
 }
 

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -81,7 +81,7 @@ impl WindowChange {
             //}
             changed = changed || changed_type;
             window.type_ = type_.clone();
-            if window.type_ == WindowType::Dock {
+            if window.is_unmanaged() {
                 window.border = 0;
                 window.margin = Margins::Int(0);
             }

--- a/src/models/workspace.rs
+++ b/src/models/workspace.rs
@@ -4,7 +4,6 @@ use crate::models::Side;
 use crate::models::Tag;
 use crate::models::TagId;
 use crate::models::Window;
-use crate::models::WindowType;
 use crate::models::Xyhw;
 use crate::models::XyhwBuilder;
 use crate::{config::ThemeSetting, models::BBox};
@@ -139,7 +138,7 @@ impl Workspace {
     /// Returns true if the workspace is to update the locations info of this window.
     #[must_use]
     pub fn is_managed(&self, window: &Window) -> bool {
-        self.is_displaying(window) && window.type_ != WindowType::Dock
+        self.is_displaying(window) && !window.is_unmanaged()
     }
 
     pub fn update_windows(&self, windows: &mut Vec<Window>) {


### PR DESCRIPTION
Fixes #395. Using window type desktop for conky is now required to prevent us avoiding conkys buggly (if they have type dock).
Hopefully I haven't broken anything, but we may want to make people aware that conkys need to be type desktop.
Thanks!