### PR TITLE
using hjkl instead of arrow keys

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -191,7 +191,7 @@ impl Default for Config {
             Keybind {
                 command: Command::Execute,
                 value: Some(default_terminal().to_owned()),
-                modifier: vec!["modkey".to_owned(), "Shift".to_owned()],
+                modifier: vec!["modkey".to_owned()],
                 key: "Return".to_owned(),
             },
             // Mod + Shift + q => kill focused window
@@ -240,55 +240,55 @@ impl Default for Config {
                 command: Command::MoveWindowUp,
                 value: None,
                 modifier: vec!["modkey".to_owned(), "Shift".to_owned()],
-                key: "Up".to_owned(),
+                key: "k".to_owned(),
             },
             Keybind {
                 command: Command::MoveWindowDown,
                 value: None,
                 modifier: vec!["modkey".to_owned(), "Shift".to_owned()],
-                key: "Down".to_owned(),
+                key: "j".to_owned(),
             },
             Keybind {
                 command: Command::MoveWindowTop,
                 value: None,
-                modifier: vec!["modkey".to_owned()],
+                modifier: vec!["modkey".to_owned(), "Shift".to_owned()],
                 key: "Return".to_owned(),
             },
             Keybind {
                 command: Command::FocusWindowUp,
                 value: None,
                 modifier: vec!["modkey".to_owned()],
-                key: "Up".to_owned(),
+                key: "k".to_owned(),
             },
             Keybind {
                 command: Command::FocusWindowDown,
                 value: None,
                 modifier: vec!["modkey".to_owned()],
-                key: "Down".to_owned(),
+                key: "j".to_owned(),
             },
             Keybind {
                 command: Command::NextLayout,
                 value: None,
                 modifier: vec!["modkey".to_owned(), "Control".to_owned()],
-                key: "Up".to_owned(),
+                key: "k".to_owned(),
             },
             Keybind {
                 command: Command::PreviousLayout,
                 value: None,
                 modifier: vec!["modkey".to_owned(), "Control".to_owned()],
-                key: "Down".to_owned(),
+                key: "j".to_owned(),
             },
             Keybind {
                 command: Command::FocusWorkspaceNext,
                 value: None,
                 modifier: vec!["modkey".to_owned()],
-                key: "Right".to_owned(),
+                key: "l".to_owned(),
             },
             Keybind {
                 command: Command::FocusWorkspacePrevious,
                 value: None,
                 modifier: vec!["modkey".to_owned()],
-                key: "Left".to_owned(),
+                key: "h".to_owned(),
             },
         ];
 


### PR DESCRIPTION
hey guys, i think using vim like keybindings (hjkl) as default keybindings is better cause thay are more easy to access than arrow keys and most of the users at least have some experince with vim.
and one more thing.
most of the wm users will set mod+Return as the key for launching terminal cause you need to launch terminal many times a day, it has less key and its easy to access.
if  we change this keybindings thats less problem for people to at least give a try to leftwm.
they dont have to Memorize new keybinding to be able to launch a terminal or even use the config.toml to change the keybindings maybe.
for example i use mod+1..9 to change focus between desktops, some wm use somethings else but with leftwm i dont have to change the keybindings.