### PR TITLE
Add `git-hash` to `leftwm -V` output

### DIFF
--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -158,6 +158,7 @@ fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &s
     // If there are more than two arguments, do not invoke `clap`, since `clap` will get confused
     // about arguments to subcommands and throw spurrious errors.
 
+    let version = format!("{}, Git-Hash: {}", crate_version!(), git_version::git_version!(fallback = "NONE"));
     let mut app = App::new("LeftWM")
         .author("Lex Childs <lex.childs@gmail.com>")
         .about("A window manager for adventurers.")
@@ -166,7 +167,7 @@ fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &s
              the corresponding leftwm program, e.g. 'leftwm theme' will execute 'leftwm-theme', if \
              it is installed.",
         )
-        .version(crate_version!())
+        .version(&*version)
         .settings(&[AppSettings::DisableHelpSubcommand, AppSettings::ColoredHelp]);
     for (&subcommand, &description) in subcommands {
         app = app.subcommand(SubCommand::with_name(subcommand).about(description));

--- a/src/bin/leftwm.rs
+++ b/src/bin/leftwm.rs
@@ -158,7 +158,11 @@ fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &s
     // If there are more than two arguments, do not invoke `clap`, since `clap` will get confused
     // about arguments to subcommands and throw spurrious errors.
 
-    let version = format!("{}, Git-Hash: {}", crate_version!(), git_version::git_version!(fallback = "NONE"));
+    let version = format!(
+        "{}, Git-Hash: {}",
+        crate_version!(),
+        git_version::git_version!(fallback = "NONE")
+    );
     let mut app = App::new("LeftWM")
         .author("Lex Childs <lex.childs@gmail.com>")
         .about("A window manager for adventurers.")


### PR DESCRIPTION
Not much more to say beyond the title I guess.

I was thinking of adding a bit of logic to print the git hash only when it actually has some, but then decided to do the same as `leftem-check` with the `"NONE"` string.
