### PR TITLE
Fixes #394

### DIFF
--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -22,14 +22,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             xlib::MapRequest => from_map_request(raw_event, xw),
 
             // window is deleted
-            xlib::UnmapNotify => from_unmap_event(raw_event),
-
-            // window is deleted
-            xlib::DestroyNotify => {
-                let event = xlib::XDestroyWindowEvent::from(raw_event);
-                let h = WindowHandle::XlibHandle(event.window);
-                Some(DisplayEvent::WindowDestroy(h))
-            }
+            xlib::UnmapNotify | xlib::DestroyNotify => from_unmap_event(raw_event),
 
             xlib::ClientMessage => {
                 match &xw.mode {
@@ -111,12 +104,8 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent>
 
 fn from_unmap_event(raw_event: xlib::XEvent) -> Option<DisplayEvent> {
     let event = xlib::XUnmapEvent::from(raw_event);
-    if event.send_event == xlib::False {
-        None
-    } else {
-        let h = WindowHandle::XlibHandle(event.window);
-        Some(DisplayEvent::WindowDestroy(h))
-    }
+    let h = WindowHandle::XlibHandle(event.window);
+    Some(DisplayEvent::WindowDestroy(h))
 }
 
 fn from_enter_notify(xw: &XWrap, raw_event: xlib::XEvent) -> Option<DisplayEvent> {

--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -22,7 +22,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             xlib::MapRequest => from_map_request(raw_event, xw),
 
             // window is deleted
-            xlib::UnmapNotify | xlib::DestroyNotify => from_unmap_event(raw_event),
+            xlib::UnmapNotify | xlib::DestroyNotify => Some(from_unmap_event(raw_event)),
 
             xlib::ClientMessage => {
                 match &xw.mode {
@@ -102,10 +102,10 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent>
     Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1))
 }
 
-fn from_unmap_event(raw_event: xlib::XEvent) -> Option<DisplayEvent> {
+fn from_unmap_event(raw_event: xlib::XEvent) -> DisplayEvent {
     let event = xlib::XUnmapEvent::from(raw_event);
     let h = WindowHandle::XlibHandle(event.window);
-    Some(DisplayEvent::WindowDestroy(h))
+    DisplayEvent::WindowDestroy(h)
 }
 
 fn from_enter_notify(xw: &XWrap, raw_event: xlib::XEvent) -> Option<DisplayEvent> {


### PR DESCRIPTION
This is a quick fix for #394. I thinking about reworking how we handle windows such that we don't need to forget them when they are unmapped and using unmap to hide a window when it is invisible.
Thanks.