### PR TITLE
Update for clippy 0.1.54

### DIFF
--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
         let template = liquid::ParserBuilder::with_stdlib()
             .build()
             .expect("Unable to build template")
-            .parse(&string_literal)
+            .parse(string_literal)
             .expect("Unable to parse template");
         while let Some(line) = stream_reader.next_line().await? {
             let _droppable = template_handler(&template, newline, ws_num, &line);
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
 }
 
 fn raw_handler(line: &str) -> Result<()> {
-    let s: ManagerState = serde_json::from_str(&line)?;
+    let s: ManagerState = serde_json::from_str(line)?;
     let display: DisplayState = s.into();
     let json = serde_json::to_string(&display)?;
     println!("{}", json);
@@ -115,7 +115,7 @@ fn template_handler(
     ws_num: Option<usize>,
     line: &str,
 ) -> Result<()> {
-    let s: ManagerState = serde_json::from_str(&line)?;
+    let s: ManagerState = serde_json::from_str(line)?;
     let display: DisplayState = s.into();
 
     let globals = if let Some(ws_num) = ws_num {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ use xdg::BaseDirectories;
 pub use keybind::Keybind;
 pub use scratchpad::ScratchPad;
 pub use theme_setting::ThemeSetting;
-pub use workspace_config::WorkspaceConfig;
+pub use workspace_config::Workspace;
 
 /// General configuration
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -30,7 +30,7 @@ pub use workspace_config::WorkspaceConfig;
 pub struct Config {
     pub modkey: String,
     pub mousekey: String,
-    pub workspaces: Option<Vec<WorkspaceConfig>>,
+    pub workspaces: Option<Vec<Workspace>>,
     pub tags: Option<Vec<String>>,
     pub layouts: Vec<Layout>,
     pub scratchpad: Option<Vec<ScratchPad>>,
@@ -70,7 +70,7 @@ fn load_from_file() -> Result<Config> {
         let config = Config::default();
         let toml = toml::to_string(&config).unwrap();
         let mut file = File::create(&config_filename)?;
-        file.write_all(&toml.as_bytes())?;
+        file.write_all(toml.as_bytes())?;
         Ok(config)
     }
 }

--- a/src/config/workspace_config.rs
+++ b/src/config/workspace_config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct WorkspaceConfig {
+pub struct Workspace {
     pub x: i32,
     pub y: i32,
     pub height: i32,

--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -86,7 +86,7 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent>
     let trans = xw.get_transient_for(event.window);
     if let Some(hint) = xw.get_hint_sizing_as_xyhw(event.window) {
         hint.update_window_floating(&mut w);
-        w.set_requested(hint)
+        w.set_requested(hint);
     }
     w.set_states(xw.get_window_states(event.window));
     if w.floating() {

--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -59,7 +59,7 @@ impl DisplayServer for XlibDisplayServer {
                 Some(f) => f.handle == window.handle,
                 None => false,
             };
-            self.xw.update_window(&window, is_focused);
+            self.xw.update_window(window, is_focused);
             if window.is_fullscreen() {
                 self.xw.move_to_top(&window.handle);
             }
@@ -90,7 +90,7 @@ impl DisplayServer for XlibDisplayServer {
             let event = XEvent(&self.xw, xlib_event).into();
             if let Some(e) = event {
                 log::trace!("DisplayEvent: {:?}", e);
-                events.push(e)
+                events.push(e);
             }
         }
 
@@ -145,7 +145,7 @@ impl DisplayServer for XlibDisplayServer {
                     .iter()
                     .filter(|&x| *x != self.root)
                     .map(|x| WindowHandle::XlibHandle(*x))
-                    .filter(|h| !wins.contains(&h))
+                    .filter(|h| !wins.contains(h))
                     .collect();
                 let all: Vec<WindowHandle> = unmanged.iter().chain(wins.iter()).copied().collect();
                 self.xw.restack(all);
@@ -174,7 +174,7 @@ impl DisplayServer for XlibDisplayServer {
             }
             DisplayAction::SetWindowTags(handle, tag) => {
                 if let WindowHandle::XlibHandle(window) = handle {
-                    self.xw.set_window_desktop(window, &tag)
+                    self.xw.set_window_desktop(window, &tag);
                 }
                 None
             }
@@ -257,6 +257,6 @@ impl XlibDisplayServer {
     }
 
     pub fn flush(&self) {
-        self.xw.flush()
+        self.xw.flush();
     }
 }

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -554,7 +554,7 @@ impl XWrap {
             }
         }
         if indexes.is_empty() {
-            indexes.push(0)
+            indexes.push(0);
         }
         self.set_desktop_prop(&indexes, self.atoms.NetDesktopViewport);
     }
@@ -568,7 +568,7 @@ impl XWrap {
             }
         }
         if indexes.is_empty() {
-            indexes.push(0)
+            indexes.push(0);
         }
         unsafe {
             (self.xlib.XChangeProperty)(
@@ -593,7 +593,7 @@ impl XWrap {
             }
         }
         if indexes.is_empty() {
-            indexes.push(0)
+            indexes.push(0);
         }
         self.set_desktop_prop(&indexes, self.atoms.NetCurrentDesktop);
     }
@@ -1501,7 +1501,7 @@ impl XWrap {
             self.mode = mode.clone();
             //safe this point as the start of the move/resize
             if let Ok(loc) = self.get_cursor_point() {
-                self.mode_origin = loc
+                self.mode_origin = loc;
             }
             let cursor = match mode {
                 Mode::ResizingWindow(_) => self.cursors.resize,

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -33,19 +33,19 @@ pub fn process_internal(
     val: &Option<String>,
 ) -> Option<bool> {
     match command {
-        Command::Execute => execute(manager, &val),
+        Command::Execute => execute(manager, val),
 
-        Command::ToggleScratchPad => toggle_scratchpad(manager, &val),
+        Command::ToggleScratchPad => toggle_scratchpad(manager, val),
 
         Command::ToggleFullScreen => toggle_fullscreen(manager),
 
-        Command::MoveToTag => move_to_tag(&val, manager),
+        Command::MoveToTag => move_to_tag(val, manager),
 
         Command::MoveWindowUp => move_focus_common_vars(move_window_change, manager, -1),
         Command::MoveWindowDown => move_focus_common_vars(move_window_change, manager, 1),
         Command::MoveWindowTop => move_focus_common_vars(move_window_top, manager, 0),
 
-        Command::GotoTag => goto_tag(manager, &val, &config),
+        Command::GotoTag => goto_tag(manager, val, config),
 
         Command::CloseWindow => close_window(manager),
         Command::SwapTags => swap_tags(manager),
@@ -53,7 +53,7 @@ pub fn process_internal(
         Command::NextLayout => next_layout(manager),
         Command::PreviousLayout => previous_layout(manager),
 
-        Command::SetLayout => set_layout(&val, manager),
+        Command::SetLayout => set_layout(val, manager),
 
         Command::FloatingToTile => floating_to_tile(manager),
 
@@ -77,9 +77,9 @@ pub fn process_internal(
 
         Command::RotateTag => rotate_tag(manager),
 
-        Command::IncreaseMainWidth => change_main_width(manager, &val, 1),
-        Command::DecreaseMainWidth => change_main_width(manager, &val, -1),
-        Command::SetMarginMultiplier => set_margin_multiplier(manager, &val),
+        Command::IncreaseMainWidth => change_main_width(manager, val, 1),
+        Command::DecreaseMainWidth => change_main_width(manager, val, -1),
+        Command::SetMarginMultiplier => set_margin_multiplier(manager, val),
     }
 }
 
@@ -354,7 +354,7 @@ fn move_window_top(
         _ => 0,
     };
     if new_index >= len {
-        new_index -= len
+        new_index -= len;
     }
     list.insert(new_index, item);
 
@@ -394,7 +394,7 @@ fn focus_window_change(
                 None => len.saturating_sub(1) as usize,
             };
             let window_group = &to_reorder[..=index];
-            handle = helpers::relative_find(&window_group, is_handle, -val)?.handle;
+            handle = helpers::relative_find(window_group, is_handle, -val)?.handle;
         }
     } else if let Some(new_focused) = helpers::relative_find(&to_reorder, is_handle, val) {
         handle = new_focused.handle;
@@ -449,7 +449,7 @@ fn set_margin_multiplier(manager: &mut Manager, val: &Option<String>) -> Option<
             helpers::vec_extract(&mut manager.windows, for_active_workspace);
         for w in &mut to_apply_margin_multiplier {
             if let Some(ws) = manager.focused_workspace() {
-                w.apply_margin_multiplier(ws.margin_multiplier())
+                w.apply_margin_multiplier(ws.margin_multiplier());
             }
         }
         manager.windows.append(&mut to_apply_margin_multiplier);

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -56,7 +56,7 @@ pub fn focus_window(manager: &mut Manager, handle: &WindowHandle) -> bool {
     }
 
     //make sure the focused window's tag is focused
-    if let Some(tag) = tags.iter().find(|t| window.has_tag(&t)) {
+    if let Some(tag) = tags.iter().find(|t| window.has_tag(t)) {
         let _ = focus_tag_work(manager, tag);
     }
     true
@@ -136,7 +136,7 @@ fn focus_closest_window(manager: &mut Manager, x: i32, y: i32) -> bool {
     let mut dists: Vec<(i32, &Window)> = manager
         .windows
         .iter()
-        .filter(|x| ws.is_managed(&x) && x.can_focus())
+        .filter(|x| ws.is_managed(x) && x.can_focus())
         .map(|w| (distance(w, x, y), w))
         .collect();
     dists.sort_by(|a, b| (a.0).cmp(&b.0));

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -40,7 +40,7 @@ pub fn created(mut manager: &mut Manager, mut window: Window, x: i32, y: i32) ->
     }
 
     if let Some(cmd) = &manager.theme_setting.on_new_window_cmd.clone() {
-        exec_shell(&cmd, &mut manager);
+        exec_shell(cmd, &mut manager);
     }
 
     true
@@ -54,7 +54,7 @@ fn setup_window(
     layout: &mut Layout,
     is_first: &mut bool,
 ) {
-    let is_scratchpad = is_scratchpad(manager, &window);
+    let is_scratchpad = is_scratchpad(manager, window);
     //When adding a window we add to the workspace under the cursor, This isn't necessarily the
     //focused workspace. If the workspace is empty, it might not have received focus. This is so
     //the workspace that has windows on its is still active not the empty workspace.
@@ -112,7 +112,7 @@ fn setup_window(
         }
     }
 
-    if let Some(parent) = find_transient_parent(manager, &window) {
+    if let Some(parent) = find_transient_parent(manager, window) {
         window.set_floating(true);
         let new_float_exact = parent.calculated_xyhw().center_halfed();
         window.normal = parent.normal;

--- a/src/handlers/window_move_handler.rs
+++ b/src/handlers/window_move_handler.rs
@@ -62,16 +62,16 @@ fn should_snap(window: &mut Window, workspace: &Workspace) -> bool {
     let ws_top = workspace.y();
     let ws_bottom = workspace.y() + workspace.height();
     if (win_top - ws_top).abs() < dist {
-        return window_handler::snap_to_workspace(window, &workspace);
+        return window_handler::snap_to_workspace(window, workspace);
     }
     if (win_bottom - ws_bottom).abs() < dist {
-        return window_handler::snap_to_workspace(window, &workspace);
+        return window_handler::snap_to_workspace(window, workspace);
     }
     if (win_left - ws_left).abs() < dist {
-        return window_handler::snap_to_workspace(window, &workspace);
+        return window_handler::snap_to_workspace(window, workspace);
     }
     if (win_right - ws_right).abs() < dist {
-        return window_handler::snap_to_workspace(window, &workspace);
+        return window_handler::snap_to_workspace(window, workspace);
     }
     false
 }

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -57,7 +57,7 @@ impl Layout {
     pub fn update_windows(&self, workspace: &Workspace, windows: &mut Vec<&mut Window>) {
         match self {
             Self::MainAndVertStack | Self::LeftWiderRightStack => {
-                main_and_vert_stack::update(workspace, windows)
+                main_and_vert_stack::update(workspace, windows);
             }
             Self::MainAndHorizontalStack => main_and_horizontal_stack::update(workspace, windows),
             Self::MainAndDeck => main_and_deck::update(workspace, windows),

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -45,7 +45,7 @@ impl Manager {
     /// Return the currently focused workspace.
     #[must_use]
     pub fn focused_workspace(&self) -> Option<&Workspace> {
-        self.focus_manager.workspace(&self)
+        self.focus_manager.workspace(self)
     }
 
     /// Return the currently focused workspace.
@@ -69,7 +69,7 @@ impl Manager {
     /// Return the currently focused window.
     #[must_use]
     pub fn focused_window(&self) -> Option<&Window> {
-        self.focus_manager.window(&self)
+        self.focus_manager.window(self)
     }
 
     /// Return the currently focused window.
@@ -85,7 +85,7 @@ impl Manager {
             .for_each(|w| {
                 let (x, y) = w.strut.unwrap_or_default().center();
                 if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
-                    w.tags = ws.tags.clone()
+                    w.tags = ws.tags.clone();
                 }
             });
     }

--- a/src/models/screen.rs
+++ b/src/models/screen.rs
@@ -1,5 +1,5 @@
 use super::{DockArea, WindowHandle};
-use crate::config::WorkspaceConfig;
+use crate::config::Workspace;
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 use x11_dl::xlib;
@@ -56,8 +56,8 @@ impl Screen {
     }
 }
 
-impl From<&WorkspaceConfig> for Screen {
-    fn from(wsc: &WorkspaceConfig) -> Self {
+impl From<&Workspace> for Screen {
+    fn from(wsc: &Workspace) -> Self {
         Screen {
             root: WindowHandle::MockHandle(0),
             bbox: BBox {

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -48,7 +48,7 @@ impl TagModel {
         }
         *mwp += delta as u8;
         if *mwp > 100 {
-            *mwp = 100
+            *mwp = 100;
         }
     }
 

--- a/src/models/window.rs
+++ b/src/models/window.rs
@@ -172,11 +172,11 @@ impl Window {
     }
 
     pub fn set_width(&mut self, width: i32) {
-        self.normal.set_w(width)
+        self.normal.set_w(width);
     }
 
     pub fn set_height(&mut self, height: i32) {
-        self.normal.set_h(height)
+        self.normal.set_h(height);
     }
 
     pub fn set_states(&mut self, states: Vec<WindowState>) {
@@ -194,7 +194,7 @@ impl Window {
     }
 
     pub fn set_requested(&mut self, change: XyhwChange) {
-        self.requested = Some(change)
+        self.requested = Some(change);
     }
 
     pub fn get_requested(&mut self) -> Option<XyhwChange> {
@@ -207,7 +207,7 @@ impl Window {
             log::warn!(
                 "Negative margin multiplier detected. Will be applied as absolute: {:?}",
                 self.margin_multiplier()
-            )
+            );
         };
     }
 
@@ -231,7 +231,7 @@ impl Window {
                 - (self.border * 2);
         }
         if value < 100 && !self.is_unmanaged() {
-            value = 100
+            value = 100;
         }
         value
     }
@@ -251,16 +251,16 @@ impl Window {
                 - (self.border * 2);
         }
         if value < 100 && !self.is_unmanaged() {
-            value = 100
+            value = 100;
         }
         value
     }
 
     pub fn set_x(&mut self, x: i32) {
-        self.normal.set_x(x)
+        self.normal.set_x(x);
     }
     pub fn set_y(&mut self, y: i32) {
-        self.normal.set_y(y)
+        self.normal.set_y(y);
     }
 
     #[must_use]
@@ -341,7 +341,7 @@ impl Window {
         let mut new_tags: Vec<TagId> = Vec::new();
         for t in &self.tags {
             if t != tag {
-                new_tags.push(t.clone())
+                new_tags.push(t.clone());
             }
         }
         self.tags = new_tags;

--- a/src/models/xyhw.rs
+++ b/src/models/xyhw.rs
@@ -191,16 +191,16 @@ impl Xyhw {
 
     fn update_limits(&mut self) {
         if self.h > self.maxh {
-            self.h = self.maxh
+            self.h = self.maxh;
         }
         if self.w > self.maxw {
-            self.w = self.maxw
+            self.w = self.maxw;
         }
         if self.h < self.minh {
-            self.h = self.minh
+            self.h = self.minh;
         }
         if self.w < self.minw {
-            self.w = self.minw
+            self.w = self.minw;
         }
     }
 

--- a/src/utils/child_process.rs
+++ b/src/utils/child_process.rs
@@ -147,14 +147,14 @@ impl Children {
     }
     /// Merge another `Children` into this `Children`.
     pub fn merge(&mut self, reaper: Self) {
-        self.inner.extend(reaper.inner.into_iter())
+        self.inner.extend(reaper.inner.into_iter());
     }
     /// Try reaping all the children processes managed by this struct.
     pub fn reap(&mut self) {
         // The `try_wait` needs `child` to be `mut`, but only `HashMap::retain`
         // allows modifying the value. Here `id` is not needed.
         self.inner
-            .retain(|_, child| child.try_wait().map_or(true, |ret| ret.is_none()))
+            .retain(|_, child| child.try_wait().map_or(true, |ret| ret.is_none()));
     }
 }
 
@@ -172,7 +172,7 @@ impl FromIterator<Child> for Children {
 impl Extend<Child> for Children {
     fn extend<T: IntoIterator<Item = Child>>(&mut self, iter: T) {
         self.inner
-            .extend(iter.into_iter().map(|child| (child.id(), child)))
+            .extend(iter.into_iter().map(|child| (child.id(), child)));
     }
 }
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -97,10 +97,10 @@ where
 
     let mut find_index = index as i32 + shift;
     if find_index < 0 {
-        find_index += len
+        find_index += len;
     }
     if find_index >= len {
-        find_index -= len
+        find_index -= len;
     }
     list.get(find_index as usize)
 }

--- a/src/utils/xkeysym_lookup.rs
+++ b/src/utils/xkeysym_lookup.rs
@@ -11,7 +11,7 @@ pub type Button = c_uint;
 pub fn into_modmask(keys: &[String]) -> ModMask {
     let mut mask = 0;
     for s in keys {
-        mask |= into_mod(&s);
+        mask |= into_mod(s);
     }
     //clean the mask
     mask &= !(xlib::Mod2Mask | xlib::LockMask);


### PR DESCRIPTION
This is mostly adding semicolons and removing ampersands. Also renames the struct WorkspaceConfig to Workspace as it ended in the containing module's name.
Thanks.