### PR TITLE
focus_handler: don't clone all workspace tags, only the one being set

### DIFF
--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -224,11 +224,10 @@ fn focus_tag_work(manager: &mut Manager, tag: &str) -> Option<()> {
 /// Create an action to inform the DM of the new current tags.
 pub fn update_current_tags(manager: &mut Manager) {
     if let Some(workspace) = manager.focused_workspace() {
-        let tags = workspace.tags.clone();
-        if tags.is_empty() {
+        if let Some(tag) = workspace.tags.first().cloned() {
             manager
                 .actions
-                .push_back(DisplayAction::SetCurrentTags(tags[0].clone()));
+                .push_back(DisplayAction::SetCurrentTags(tag));
         }
     }
 }


### PR DESCRIPTION
Clones only the first workspace tag, not all of them.

Also, unless I really need sleep, the current function panics since it specifically checks if `tags` is empty and then goes on to access the first element of `tags` anyway.

This behavior no longer happens under the proposed changes