### PR TITLE
Unfocus last window when switching to an empty tag

### DIFF
--- a/src/display_action.rs
+++ b/src/display_action.rs
@@ -34,8 +34,7 @@ pub enum DisplayAction {
     /// Tell a window that it is to become focused.
     WindowTakeFocus(Window),
 
-    /// Remove focus on any visible window by focusing the dock, or the
-    /// root window
+    /// Remove focus on any visible window by focusing the root window
     Unfocus,
 
     /// To the window under the cursor to take the focus

--- a/src/display_action.rs
+++ b/src/display_action.rs
@@ -34,6 +34,10 @@ pub enum DisplayAction {
     /// Tell a window that it is to become focused.
     WindowTakeFocus(Window),
 
+    /// Remove focus on any visible window by focusing the dock, or the
+    /// root window
+    Unfocus,
+
     /// To the window under the cursor to take the focus
     FocusWindowUnderCursor,
 

--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -131,6 +131,10 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.window_take_focus(&w);
                 None
             }
+            DisplayAction::Unfocus => {
+                self.xw.unfocus();
+                None
+            }
             DisplayAction::SetFullScreen(w, fullscreen) => {
                 self.xw.set_fullscreen(&w, fullscreen);
                 None

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -23,7 +23,6 @@ use crate::models::XyhwChange;
 use crate::utils::xkeysym_lookup::ModMask;
 use crate::DisplayEvent;
 use crate::{config::ThemeSetting, models::FocusBehaviour};
-use std::alloc::handle_alloc_error;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong};
 use std::ptr;
@@ -1256,12 +1255,7 @@ impl XWrap {
     pub fn unfocus(&self) {
         let handle = self.get_default_root();
         unsafe {
-            (self.xlib.XSetInputFocus)(
-                self.display,
-                handle,
-                xlib::RevertToNone,
-                xlib::CurrentTime,
-            );
+            (self.xlib.XSetInputFocus)(self.display, handle, xlib::RevertToNone, xlib::CurrentTime);
             (self.xlib.XChangeProperty)(
                 self.display,
                 self.get_default_root(),

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -1252,6 +1252,21 @@ impl XWrap {
         }
     }
 
+    pub fn unfocus(&self) {
+        let windows = self.get_windows_for_root(self.get_default_root());
+        if let Ok(windows) = windows {
+            let dock = windows.iter().find(|w| {
+                self.get_atom_prop_value(**w, self.atoms.NetWMWindowType)
+                    == Some(self.atoms.NetWMWindowTypeDock)
+            });
+            if let Some(dock) = dock {
+                self.window_take_focus(&Window::new(WindowHandle::XlibHandle(*dock), None, None));
+                return;
+            }
+        }
+        self.window_take_focus(&Window::new(self.get_default_root_handle(), None, None));
+    }
+
     pub fn kill_window(&self, h: &WindowHandle) {
         if let WindowHandle::XlibHandle(handle) = h {
             //nicely ask the window to close

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -113,7 +113,9 @@ fn toggle_scratchpad(manager: &mut Manager, val: &Option<String>) -> Option<bool
             if is_tagged {
                 w.tag("NSP");
                 if let Some(prev) = manager.focus_manager.window_history.get(1) {
-                    handle = Some(*prev);
+                    if let Some(prev) = prev {
+                        handle = Some(*prev);
+                    }
                 }
             } else {
                 w.tag(tag);

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -112,10 +112,8 @@ fn toggle_scratchpad(manager: &mut Manager, val: &Option<String>) -> Option<bool
             w.clear_tags();
             if is_tagged {
                 w.tag("NSP");
-                if let Some(prev) = manager.focus_manager.window_history.get(1) {
-                    if let Some(prev) = prev {
-                        handle = Some(*prev);
-                    }
+                if let Some(Some(prev)) = manager.focus_manager.window_history.get(1) {
+                    handle = Some(*prev);
                 }
             } else {
                 w.tag(tag);

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -85,7 +85,10 @@ fn focus_window_by_handle_work(manager: &mut Manager, handle: &WindowHandle) -> 
     //clean old ones
     manager.focus_manager.window_history.truncate(10);
     //add this focus to the history
-    manager.focus_manager.window_history.push_front(Some(*handle));
+    manager
+        .focus_manager
+        .window_history
+        .push_front(Some(*handle));
 
     Some(found.clone())
 }

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -205,10 +205,13 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     // Unfocus last window if the target tag is empty
     if let Some(window) = manager.focused_window().cloned() {
         if !window.tags.contains(&tag.to_owned()) {
-            // Arbitrary handle value here, hopefully not used by any real window
-            let w = Window::new(WindowHandle::XlibHandle(c_ulong::MAX), None, None);
-            manager.focus_manager.window_history.push_front(w.handle);
-            let act = DisplayAction::WindowTakeFocus(w);
+            let w = manager.windows.clone().into_iter().find(|w| w.type_ == WindowType::Dock);
+            let act = match w {
+                Some(w) => DisplayAction::WindowTakeFocus(w),
+                // Fallback to last method if no dock for now
+                None => DisplayAction::WindowTakeFocus(Window::new(WindowHandle::XlibHandle(c_ulong::MAX), None, None)),
+            };
+            // TODO: Append None to the window history
             manager.actions.push_back(act);
         }
     }

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::wildcard_imports)]
-use std::os::raw::c_ulong;
 
 use super::*;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
@@ -196,7 +195,11 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     } else if let Some(handle) = manager.focus_manager.tags_last_window.get(tag).copied() {
         focus_window_by_handle_work(manager, &handle);
     } else if let Some(ws) = to_focus.first() {
-        let handle = manager.windows.iter().find(|w| ws.is_managed(w)).map(|w| w.handle);
+        let handle = manager
+            .windows
+            .iter()
+            .find(|w| ws.is_managed(w))
+            .map(|w| w.handle);
         if let Some(h) = handle {
             focus_window_by_handle_work(manager, &h);
         }
@@ -205,14 +208,7 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     // Unfocus last window if the target tag is empty
     if let Some(window) = manager.focused_window().cloned() {
         if !window.tags.contains(&tag.to_owned()) {
-            let w = manager.windows.clone().into_iter().find(|w| w.type_ == WindowType::Dock);
-            let act = match w {
-                Some(w) => DisplayAction::WindowTakeFocus(w),
-                // Fallback to last method if no dock for now
-                None => DisplayAction::WindowTakeFocus(Window::new(WindowHandle::XlibHandle(c_ulong::MAX), None, None)),
-            };
-            // TODO: Append None to the window history
-            manager.actions.push_back(act);
+            manager.actions.push_back(DisplayAction::Unfocus);
         }
     }
     true

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::wildcard_imports)]
+use std::os::raw::c_ulong;
+
 use super::*;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
@@ -204,7 +206,7 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     if let Some(window) = manager.focused_window().cloned() {
         if !window.tags.contains(&tag.to_owned()) {
             // Arbitrary handle value here, hopefully not used by any real window
-            let w = Window::new(WindowHandle::XlibHandle(u64::MAX), None, None);
+            let w = Window::new(WindowHandle::XlibHandle(c_ulong::MAX), None, None);
             manager.focus_manager.window_history.push_front(w.handle);
             let act = DisplayAction::WindowTakeFocus(w);
             manager.actions.push_back(act);

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -194,10 +194,7 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     } else if let Some(handle) = manager.focus_manager.tags_last_window.get(tag).copied() {
         focus_window_by_handle_work(manager, &handle);
     } else if let Some(ws) = to_focus.first() {
-        let handle = match manager.windows.iter().find(|w| ws.is_managed(w)) {
-            Some(w) => Some(w.handle),
-            None => None,
-        };
+        let handle = manager.windows.iter().find(|w| ws.is_managed(w)).map(|w| w.handle);
         if let Some(h) = handle {
             focus_window_by_handle_work(manager, &h);
         }

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -85,7 +85,7 @@ fn focus_window_by_handle_work(manager: &mut Manager, handle: &WindowHandle) -> 
     //clean old ones
     manager.focus_manager.window_history.truncate(10);
     //add this focus to the history
-    manager.focus_manager.window_history.push_front(*handle);
+    manager.focus_manager.window_history.push_front(Some(*handle));
 
     Some(found.clone())
 }
@@ -209,6 +209,7 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
     if let Some(window) = manager.focused_window().cloned() {
         if !window.tags.contains(&tag.to_owned()) {
             manager.actions.push_back(DisplayAction::Unfocus);
+            manager.focus_manager.window_history.push_front(None);
         }
     }
     true

--- a/src/handlers/focus_handler.rs
+++ b/src/handlers/focus_handler.rs
@@ -195,10 +195,23 @@ pub fn focus_tag(manager: &mut Manager, tag: &str) -> bool {
         focus_window_by_handle_work(manager, &handle);
     } else if let Some(ws) = to_focus.first() {
         let handle = match manager.windows.iter().find(|w| ws.is_managed(w)) {
-            Some(w) => w.handle,
-            None => return true,
+            Some(w) => Some(w.handle),
+            None => None,
         };
-        focus_window_by_handle_work(manager, &handle);
+        if let Some(h) = handle {
+            focus_window_by_handle_work(manager, &h);
+        }
+    }
+
+    // Unfocus last window if the target tag is empty
+    if let Some(window) = manager.focused_window().cloned() {
+        if !window.tags.contains(&tag.to_owned()) {
+            // Arbitrary handle value here, hopefully not used by any real window
+            let w = Window::new(WindowHandle::XlibHandle(u64::MAX), None, None);
+            manager.focus_manager.window_history.push_front(w.handle);
+            let act = DisplayAction::WindowTakeFocus(w);
+            manager.actions.push_back(act);
+        }
     }
     true
 }
@@ -369,5 +382,18 @@ mod tests {
         let actual = manager.focused_workspace().unwrap().id;
         let expected = manager.workspaces[1].id;
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn focusing_an_empty_tag_should_unfocus_any_focused_window() {
+        let mut manager = Manager::default();
+        screen_create_handler::process(&mut manager, Screen::default());
+        let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
+        window.tag("1");
+        manager.windows.push(window.clone());
+        focus_window(&mut manager, &window.handle);
+        focus_tag(&mut manager, "2");
+        let focused = manager.focused_window();
+        assert!(focused.is_none());
     }
 }

--- a/src/handlers/window_handler.rs
+++ b/src/handlers/window_handler.rs
@@ -195,7 +195,7 @@ pub fn destroyed(manager: &mut Manager, handle: &WindowHandle) -> bool {
 
     let focused = manager.focus_manager.window_history.get(0);
     //make sure focus is recalculated if we closed the currently focused window
-    if focused == Some(handle) {
+    if focused == Some(&Some(*handle)) {
         if manager.focus_manager.behaviour == FocusBehaviour::Sloppy {
             let act = DisplayAction::FocusWindowUnderCursor;
             manager.actions.push_back(act);

--- a/src/models/focus_manager.rs
+++ b/src/models/focus_manager.rs
@@ -3,6 +3,8 @@ use crate::{models::TagId, models::WindowHandle, Manager, Window, Workspace};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
+use super::MaybeWindowHandle;
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum FocusBehaviour {
     Sloppy,
@@ -21,7 +23,7 @@ pub struct FocusManager {
     pub behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
     pub workspace_history: VecDeque<usize>,
-    pub window_history: VecDeque<WindowHandle>,
+    pub window_history: VecDeque<MaybeWindowHandle>,
     pub tag_history: VecDeque<String>,
     pub tags_last_window: HashMap<TagId, WindowHandle>,
 }
@@ -64,7 +66,10 @@ impl FocusManager {
         'a: 'b,
     {
         let handle = *self.window_history.get(0)?;
-        manager.windows.iter().find(|w| w.handle == handle)
+        if let Some(handle) = handle {
+            return manager.windows.iter().find(|w| w.handle == handle);
+        }
+        None
     }
 
     /// Return the currently focused window.
@@ -73,6 +78,9 @@ impl FocusManager {
         'a: 'b,
     {
         let handle = *self.window_history.get(0)?;
-        windows.iter_mut().find(|w| w.handle == handle)
+        if let Some(handle) = handle {
+            return windows.iter_mut().find(|w| w.handle == handle);
+        }
+        None
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -41,3 +41,4 @@ pub use tag::Tag;
 pub use tag::TagModel;
 
 pub type TagId = String;
+type MaybeWindowHandle = Option<WindowHandle>;

--- a/src/models/window_change.rs
+++ b/src/models/window_change.rs
@@ -1,10 +1,10 @@
+use super::MaybeWindowHandle;
 use super::Window;
 use super::WindowHandle;
 use super::WindowState;
 use super::WindowType;
 use crate::models::{Margins, XyhwChange};
 
-type MaybeWindowHandle = Option<WindowHandle>;
 type MaybeName = Option<String>;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Hey,

This pull request fixes a problem i had.
When switching to an empty tag from a tag where a window had focus, the window on the previous tag would still have the focus.
This can be very annoying since you could still perform actions on this window while it was not visible.

I fixed this issue by telling LeftWM to focus an imaginary window with an arbitrary handle value, which seems to work fine for now.
I had to adapt some code for this to work on the first focus of a tag.
