### PR TITLE
Layout Per Tag

### DIFF
--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -37,7 +37,7 @@ fn main() {
         let mut tags: Vec<Tag> = config
             .get_list_of_tags()
             .iter()
-            .map(|s| Tag::new(s))
+            .map(|s| Tag::new(s, config.layouts.clone()))
             .collect();
         tags.push(Tag {
             id: "NSP".to_owned(),

--- a/src/handlers/screen_create_handler.rs
+++ b/src/handlers/screen_create_handler.rs
@@ -30,7 +30,7 @@ pub fn process(manager: &mut Manager, screen: Screen) -> bool {
     //make sure are enough tags for this new screen
     if manager.tags.len() <= tag_index {
         let id = (tag_index + 1).to_string();
-        manager.tags.push(Tag::new(&id));
+        manager.tags.push(Tag::new(&id, manager.layouts.clone()));
     }
     let next_tag = manager.tags[tag_index].clone();
     focus_handler::focus_workspace(manager, &workspace);

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -48,6 +48,12 @@ pub const LAYOUTS: [Layout; 12] = [
     Layout::LeftWiderRightStack,
 ];
 
+impl Default for Layout {
+    fn default() -> Self {
+        Layout::MainAndVertStack
+    }
+}
+
 // This is tedious, but simple and effective.
 impl Layout {
     pub fn new(layouts: &[Layout]) -> Self {

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -1,12 +1,13 @@
-// We allow this so that we can be verbose and indicate that
-// this is `TagModel` and not `WindowModel` or anything else.
-#![allow(clippy::module_name_repetitions)]
 use serde::{Deserialize, Serialize};
+
+use crate::layouts::Layout;
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct Tag {
     pub id: String,
     pub hidden: bool,
+    pub layout: Layout,
+    pub layouts: Vec<Layout>,
     #[serde(skip)]
     pub main_width_percentage: u8,
     #[serde(skip)]
@@ -17,10 +18,12 @@ pub struct Tag {
 
 impl Tag {
     #[must_use]
-    pub fn new(id: &str) -> Tag {
+    pub fn new(id: &str, layouts: Vec<Layout>) -> Tag {
         Tag {
             id: id.to_owned(),
             hidden: false,
+            layout: Layout::new(&layouts),
+            layouts,
             main_width_percentage: 50,
             flipped_horizontal: false,
             flipped_vertical: false,


### PR DESCRIPTION
Tagging #260, #447, #292. This is just an initial commit, and to open a bit of a discussion. I agree with the notes in #447, where there should be an option to allow the user to choose to have per tag or per workspace layouts with which could be toggled via a command. Other issues we should address is the management of layouts, with this added complexity it becomes harder for a new dev to find their way through the code, e.g. the fact that the layout vec is stored in config, manager, workspace, and now tag. I feel it would be helpful to add a layout manager similar to the [focus manager](#356), which holds the list, which mode the user is in, and common functions around changing the layout. 

Another option we could add would be choosing the mode per workspace, say tags sent to workspace one will be forced to the same layout but on workspace two will use the tags preferred layout.

Many Thanks!