### PR TITLE
Add check for modifier keys

### DIFF
--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -157,15 +157,11 @@ fn check_keybinds(keybinds: Vec<Keybind>, verbose: bool) -> bool {
             ));
         }
 
-        keybind
-            .modifier
-            .iter()
-            .filter(|&m| {
-                m != "modkey" && m != "mousekey" && utils::xkeysym_lookup::into_mod(m) == 0
-            })
-            .for_each(|m| {
+        for m in &keybind.modifier {
+            if m != "modkey" && m != "mousekey" && utils::xkeysym_lookup::into_mod(m) == 0 {
                 returns.push((keybind.clone(), format!("Modifier `{}` is not valid", m)))
-            });
+            }
+        }
     }
     if returns.is_empty() {
         println!("\x1b[0;92m    -> All keybinds OK\x1b[0m");

--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -160,7 +160,9 @@ fn check_keybinds(keybinds: Vec<Keybind>, verbose: bool) -> bool {
         keybind
             .modifier
             .iter()
-            .filter(|&m| m != "modkey" && utils::xkeysym_lookup::into_mod(m) == 0)
+            .filter(|&m| {
+                m != "modkey" && m != "mousekey" && utils::xkeysym_lookup::into_mod(m) == 0
+            })
             .for_each(|m| {
                 returns.push((keybind.clone(), format!("Modifier `{}` is not valid", m)))
             });

--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -156,6 +156,14 @@ fn check_keybinds(keybinds: Vec<Keybind>, verbose: bool) -> bool {
                 format!("Key `{}` is not valid", keybind.key),
             ));
         }
+
+        keybind
+            .modifier
+            .iter()
+            .filter(|&m| m != "modkey" && utils::xkeysym_lookup::into_mod(m) == 0)
+            .for_each(|m| {
+                returns.push((keybind.clone(), format!("Modifier `{}` is not valid", m)))
+            });
     }
     if returns.is_empty() {
         println!("\x1b[0;92m    -> All keybinds OK\x1b[0m");


### PR DESCRIPTION
Adds a check for the modifier keys when editing leftwm config.
Previous behaviour would allow modifier keys to be anything even when they were not a valid key.
Will output an error when the modifier key is not valid!