### PR TITLE
Warn for duplicate keys; closes #464

### DIFF
--- a/src/bin/leftwm-check.rs
+++ b/src/bin/leftwm-check.rs
@@ -170,7 +170,9 @@ fn check_keybinds(keybinds: Vec<Keybind>, verbose: bool) -> bool {
                 ));
             }
         }
-        if bindings.contains_key(&(keybind.modifier.clone(), keybind.key.clone())) {
+        let mut modkey = keybind.modifier.clone();
+        modkey.sort();
+        if let Some(conflict_key) = bindings.get(&(modkey.clone(), keybind.key.clone())) {
             returns.push((
                 None,
                 format!(
@@ -180,14 +182,13 @@ fn check_keybinds(keybinds: Vec<Keybind>, verbose: bool) -> bool {
                     \n\x1b[0mHelp: change one of the keybindings to something else.\n",
                     keybind.modifier.join(" + "),
                     keybind.key,
-                    bindings
-                        .get(&(keybind.modifier.clone(), keybind.key.clone()))
-                        .expect("fatal"),
+                    conflict_key,
                     keybind.command,
                 ),
             ));
+        } else {
+            bindings.insert((modkey, keybind.key), keybind.command);
         }
-        bindings.insert((keybind.modifier, keybind.key), keybind.command);
     }
     if returns.is_empty() {
         println!("\x1b[0;92m    -> All keybinds OK\x1b[0m");

--- a/src/bin/leftwm-state.rs
+++ b/src/bin/leftwm-state.rs
@@ -133,7 +133,7 @@ async fn partials_in_dir_entries(mut entries: fs::ReadDir) -> Result<Vec<fs::Dir
     while let Some(entry) = entries.next_entry().await? {
         let f_n = entry.file_name();
         if is_partial_filename(&f_n) {
-            partial_paths.push(entry)
+            partial_paths.push(entry);
         }
     }
     Ok(partial_paths)


### PR DESCRIPTION
Howdy,

This PR adds an error message for leftwm-check when multiple commands are given the same keybinding.

It therefore closes #464 .

Test Case:
```toml
[[keybind]]
command = "PreviousLayout"
modifier = ["modkey", "Control"]
key = "Down"

[[keybind]]
command = "NextLayout"
modifier = ["modkey", "Control"]
key = "Down"

```

Yields:
```
:: LeftWM version: 0.2.9
:: LeftWM git hash: 0375604-modified
:: Loading configuration . . .
    -> Configuration loaded OK
:: Checking keybinds . . .
ERROR: Multiple commands bound to key combination modkey + Control + Down:
    -> PreviousLayout
    -> NextLayout
Help: change one of the keybindings to something else.

:: Checking environment . . .
    -> Environment OK
:: Checking theme . . .
    -> Theme OK
```

If three or more are issued, it throws an error for each n+1

Best,
Mautamu