### PR TITLE
allow changing main_window size in CenterMain/CenterMainBalanced layouts

### DIFF
--- a/src/layouts/center_main.rs
+++ b/src/layouts/center_main.rs
@@ -109,7 +109,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
         if let Some(first) = iter.next() {
             first.set_height(workspace.height());
             first.set_width(primary_width);
-            first.set_x(workspace.x() + primary_x);
+            first.set_x(primary_x);
             first.set_y(workspace.y());
         }
     }

--- a/src/layouts/center_main.rs
+++ b/src/layouts/center_main.rs
@@ -66,13 +66,13 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
 
     let primary_width = match window_count {
         1 => workspace.width() as i32,
-        _ => (workspace.width() as f32 / 2.0).floor() as i32,
+        _ => ((workspace.width() as f32 / 100.0) * workspace.main_width(tags)).floor() as i32
     };
 
     let secondary_width = match window_count {
         1 => 0,
-        2 => (workspace.width() as f32 / 2.0).floor() as i32,
-        _ => (workspace.width() as f32 / 4.0).floor() as i32,
+        2 => workspace.width() - primary_width,
+        _ => ((workspace.width() - primary_width) as f32 / 2.0).floor() as i32,
     };
 
     let (primary_x, secondary_x, stack_x) = match window_count {
@@ -83,13 +83,13 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
                 px = workspace.x();
                 sx = workspace.x() + primary_width;
             } else {
-                px = (workspace.width() as f32 / 2.0).floor() as i32;
+                px = workspace.x() + secondary_width;
                 sx = workspace.x();
             }
             (px, sx, 0)
         }
         _ => {
-            let px = (workspace.width() as f32 / 4.0).floor() as i32;
+            let px = workspace.x() + secondary_width;
             let (sx, stx);
             if workspace.flipped_horizontal(tags) {
                 sx = workspace.x() + primary_width + secondary_width;

--- a/src/layouts/center_main.rs
+++ b/src/layouts/center_main.rs
@@ -76,7 +76,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
     };
 
     let (primary_x, secondary_x, stack_x) = match window_count {
-        1 => (0, 0, 0),
+        1 => (workspace.x(), 0, 0),
         2 => {
             let (px, sx);
             if workspace.flipped_horizontal(tags) {

--- a/src/layouts/center_main.rs
+++ b/src/layouts/center_main.rs
@@ -66,7 +66,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
 
     let primary_width = match window_count {
         1 => workspace.width() as i32,
-        _ => ((workspace.width() as f32 / 100.0) * workspace.main_width(tags)).floor() as i32
+        _ => ((workspace.width() as f32 / 100.0) * workspace.main_width(tags)).floor() as i32,
     };
 
     let secondary_width = match window_count {

--- a/src/layouts/center_main_balanced.rs
+++ b/src/layouts/center_main_balanced.rs
@@ -160,14 +160,18 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
 
     let primary_width = match window_count {
         1 => workspace.width() as i32,
-        2 => (workspace.width() as f32 / 2.0).floor() as i32,
-        _ => (workspace.width() as f32 / 3.0).floor() as i32,
+        _ => ((workspace.width() as f32 / 100.0) * workspace.main_width(tags)).floor() as i32,
+    };
+
+    let secondary_width = match window_count {
+        1 => 0_i32,
+        2 => workspace.width() - primary_width,
+        _ => ((workspace.width() - primary_width) as f32 / 2.0).floor() as i32,
     };
 
     let primary_x = match window_count {
         1 => 0_i32,
-        2 => (workspace.width() as f32 / 2.0).floor() as i32,
-        _ => (workspace.width() as f32 / 3.0).floor() as i32,
+        _ => workspace.x() + secondary_width,
     };
 
     let mut iter = windows.iter_mut();
@@ -176,7 +180,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
     if let Some(first) = iter.next() {
         first.set_height(workspace.height());
         first.set_width(primary_width);
-        first.set_x(workspace.x() + primary_x);
+        first.set_x(primary_x);
         first.set_y(workspace.y());
     }
 
@@ -184,7 +188,7 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
     if window_count < 3 {
         if let Some(second) = iter.next() {
             second.set_height(workspace.height());
-            second.set_width(primary_width);
+            second.set_width(secondary_width);
             second.set_x(workspace.x());
             second.set_y(workspace.y());
         }
@@ -219,14 +223,14 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>, tags: &mut 
         workspace.x(),
         workspace.y(),
         workspace.height(),
-        primary_width,
+        secondary_width,
     );
     update_fibonacci(
         right_windows,
-        workspace.x() + 2 * primary_width,
+        workspace.x() + secondary_width + primary_width,
         workspace.y(),
         workspace.height(),
-        primary_width,
+        secondary_width,
     );
 }
 


### PR DESCRIPTION
This PR partly addresses issue #96.

With this update, changing the main-width (`IncreaseMainWidth` and `DecreaseMainWidth`) is now possible in the `CenterMain` layout.

![output](https://user-images.githubusercontent.com/3533648/132966330-0aede747-5ae0-43cb-8776-a975a5eda7af.gif)

Having an ultra-ultra wide 49' inch monitor, this feature is a lifesaver for me :)

**Update 2021/09/12**
I made an update to the code:
- Fixed a pre-existing bug in the `x` positioning of the primary window, when two windows were open on a workspace where `workspace.x()` is **not** `0`.
- Added the same feature to the `CenterMainBalanced` layout.

![output](https://user-images.githubusercontent.com/3533648/133002892-9b0df7c5-22c9-4e4a-9194-8f4434b24074.gif)