### PR TITLE
Make path to state_file configurable

### DIFF
--- a/src/bin/common/config.rs
+++ b/src/bin/common/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
+    pub state_file: Option<String>,
 }
 
 #[must_use]
@@ -196,6 +197,15 @@ impl leftwm::config::Config for Config {
 
     fn mousekey(&self) -> &str {
         &self.mousekey
+    }
+
+    fn get_state_file_path(&self) -> &str {
+        let state_file_path = &self.state_file.clone().unwrap();
+        if std::path::Path::new(&state_file_path).exists() {
+            &self.state_file.unwrap()
+        } else {
+            crate::common::state::STATE_FILE
+        }
     }
 
     fn disable_current_tag_swap(&self) -> bool {
@@ -416,6 +426,7 @@ impl Default for Config {
             modkey: "Mod4".to_owned(), //win key
             mousekey: "Mod4".to_owned(), //win key
             keybind: commands,
+            state_file: Some(crate::common::state::STATE_FILE.to_string()),
         }
     }
 }

--- a/src/bin/common/config.rs
+++ b/src/bin/common/config.rs
@@ -200,7 +200,7 @@ impl leftwm::config::Config for Config {
     }
 
     fn get_state_file_path(&self) -> &str {
-        return &self.state_file.as_ref().unwrap();
+        self.state_file.as_ref().unwrap()
     }
 
     fn disable_current_tag_swap(&self) -> bool {

--- a/src/bin/common/config.rs
+++ b/src/bin/common/config.rs
@@ -200,12 +200,7 @@ impl leftwm::config::Config for Config {
     }
 
     fn get_state_file_path(&self) -> &str {
-        let state_file_path = &self.state_file.clone().unwrap();
-        if std::path::Path::new(&state_file_path).exists() {
-            &self.state_file.unwrap()
-        } else {
-            crate::common::state::STATE_FILE
-        }
+        return &self.state_file.as_ref().unwrap();
     }
 
     fn disable_current_tag_swap(&self) -> bool {

--- a/src/bin/common/state.rs
+++ b/src/bin/common/state.rs
@@ -22,7 +22,7 @@ impl leftwm::State for State {
     fn load(&self, manager: &mut Manager, config: &dyn Config) {
         let state_path = Path::new(config.get_state_file_path()).to_str();
         log::info!("Read statefile: {:?}", &state_path);
-        match load_old_state(&state_path.unwrap()) {
+        match load_old_state(state_path.unwrap()) {
             Ok(old_manager) => restore_state(manager, &old_manager),
             Err(err) => log::error!("Cannot load old state: {}", err),
         }

--- a/src/bin/common/state.rs
+++ b/src/bin/common/state.rs
@@ -2,30 +2,26 @@
 
 use leftwm::config::Config;
 use leftwm::errors::Result;
-use leftwm::{DisplayAction, Manager};
+use leftwm::Manager;
 use std::fs::File;
 use std::path::Path;
 
-<<<<<<< Updated upstream
-// TODO: make configurable
-/// Path to file where state will be dumper upon soft reload.
-const STATE_FILE: &str = "/tmp/leftwm.state";
-=======
 /// Path to file where state will be dumped upon soft reload.
 pub const STATE_FILE: &str = "/tmp/leftwm.state";
->>>>>>> Stashed changes
 
 pub struct State;
 
 impl leftwm::State for State {
-    fn save(&self, manager: &Manager) -> Result<()> {
-        let state_file = File::create(STATE_FILE)?;
-        serde_json::to_writer(state_file, &manager)?;
+    fn save(&self, manager: &Manager, config: &dyn Config) -> Result<()> {
+        let state_file = File::create(config.get_state_file_path())?;
+        log::info!("Write statefile: {:?}", state_file);
+        serde_json::to_writer(&state_file, &manager)?;
         Ok(())
     }
 
     fn load(&self, manager: &mut Manager, config: &dyn Config) {
         let state_path = Path::new(config.get_state_file_path()).to_str();
+        log::info!("Read statefile: {:?}", &state_path);
         match load_old_state(&state_path.unwrap()) {
             Ok(old_manager) => restore_state(manager, &old_manager),
             Err(err) => log::error!("Cannot load old state: {}", err),
@@ -69,22 +65,40 @@ fn restore_windows(manager: &mut Manager, old_manager: &Manager) {
     old_manager.windows.iter().for_each(|old| {
         if let Some((index, window)) = manager
             .windows
+            .clone()
             .iter_mut()
             .enumerate()
             .find(|w| w.1.handle == old.handle)
         {
             had_strut = old.strut.is_some() || had_strut;
-            if let Some(tag) = old.tags.first() {
-                let act = DisplayAction::SetWindowTags(window.handle, tag.clone());
-                manager.actions.push_back(act);
-            }
 
             window.set_floating(old.floating());
             window.set_floating_offsets(old.get_floating_offsets());
             window.apply_margin_multiplier(old.margin_multiplier);
             window.pid = old.pid;
             window.normal = old.normal;
-            window.tags = old.tags.clone();
+            if manager.tags.eq(&old_manager.tags) {
+                window.tags = old.tags.clone();
+            } else {
+                old.tags.iter().for_each(|t| {
+                    let manager_tags = &manager.tags.clone();
+                    let tag_index = &old_manager
+                        .tags
+                        .clone()
+                        .iter()
+                        .position(|o| &o.id == t)
+                        .unwrap();
+                    window.clear_tags();
+                    // if the config prior reload had more tags then the current one
+                    // we want to move windows of 'lost tags' to the 'first' tag
+                    // also we want to ignore the `NSP` tag for length check
+                    if tag_index < &(manager_tags.len() - 1) || t == "NSP" {
+                        window.tag(&manager_tags[*tag_index].id);
+                    } else {
+                        window.tag(&manager_tags.first().unwrap().id);
+                    }
+                });
+            }
             window.strut = old.strut;
             window.set_states(old.states());
             ordered.push(window.clone());

--- a/src/bin/common/state.rs
+++ b/src/bin/common/state.rs
@@ -1,13 +1,19 @@
 //! Save and restore manager state.
 
+use leftwm::config::Config;
 use leftwm::errors::Result;
 use leftwm::{DisplayAction, Manager};
 use std::fs::File;
 use std::path::Path;
 
+<<<<<<< Updated upstream
 // TODO: make configurable
 /// Path to file where state will be dumper upon soft reload.
 const STATE_FILE: &str = "/tmp/leftwm.state";
+=======
+/// Path to file where state will be dumped upon soft reload.
+pub const STATE_FILE: &str = "/tmp/leftwm.state";
+>>>>>>> Stashed changes
 
 pub struct State;
 
@@ -18,23 +24,22 @@ impl leftwm::State for State {
         Ok(())
     }
 
-    fn load(&self, manager: &mut Manager) {
-        if Path::new(STATE_FILE).exists() {
-            match load_old_state() {
-                Ok(old_manager) => restore_state(manager, &old_manager),
-                Err(err) => log::error!("Cannot load old state: {}", err),
-            }
-            // Clean old state.
-            if let Err(err) = std::fs::remove_file(STATE_FILE) {
-                log::error!("Cannot remove old state file: {}", err);
-            }
+    fn load(&self, manager: &mut Manager, config: &dyn Config) {
+        let state_path = Path::new(config.get_state_file_path()).to_str();
+        match load_old_state(&state_path.unwrap()) {
+            Ok(old_manager) => restore_state(manager, &old_manager),
+            Err(err) => log::error!("Cannot load old state: {}", err),
+        }
+        // Clean old state.
+        if let Err(err) = std::fs::remove_file(&state_path.unwrap()) {
+            log::error!("Cannot remove old state file: {}", err);
         }
     }
 }
 
 /// Read old state from a state file.
-fn load_old_state() -> Result<Manager> {
-    let file = File::open(STATE_FILE)?;
+fn load_old_state(path: &str) -> Result<Manager> {
+    let file = File::open(path)?;
     let old_manager = serde_json::from_reader(file)?;
     Ok(old_manager)
 }

--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -33,7 +33,6 @@ fn main() {
         let _rt_guard = rt.enter();
 
         let config = common::config::load();
-        log::info!("Complete config: {:?}", &config.state_file);
         let state = common::state::State;
         let theme_loader = common::theme_setting::ThemeLoader;
         let default_theme = Arc::new(theme_loader.default());

--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -33,6 +33,7 @@ fn main() {
         let _rt_guard = rt.enter();
 
         let config = common::config::load();
+        log::info!("Complete config: {:?}", &config.state_file);
         let state = common::state::State;
         let theme_loader = common::theme_setting::ThemeLoader;
         let default_theme = Arc::new(theme_loader.default());
@@ -60,15 +61,15 @@ fn main() {
             scratchpads: config.create_list_of_scratchpads(),
             layouts: config.layouts.clone(),
             theme_setting: default_theme.clone(),
-            screens: Default::default(),
-            windows: Default::default(),
-            workspaces: Default::default(),
-            mode: Default::default(),
-            active_scratchpads: Default::default(),
-            actions: Default::default(),
+            screens: std::vec::Vec::default(),
+            windows: std::vec::Vec::default(),
+            workspaces: std::vec::Vec::default(),
+            mode: leftwm::Mode::default(),
+            active_scratchpads: std::collections::HashMap::default(),
+            actions: std::collections::VecDeque::default(),
             frame_rate_limitor: Default::default(),
-            children: Default::default(),
-            reap_requested: Default::default(),
+            children: leftwm::child_process::Children::default(),
+            reap_requested: std::sync::Arc::default(),
             reload_requested: Default::default(),
         };
 
@@ -211,7 +212,7 @@ async fn event_loop(
                 Err(err) => log::error!("Theme loading failed: {}", err),
             }
 
-            state.load(manager, config);
+            state.load(manager, &config);
         });
 
         if manager.reap_requested.swap(false, Ordering::SeqCst) {

--- a/src/bin/leftwm-worker.rs
+++ b/src/bin/leftwm-worker.rs
@@ -211,7 +211,7 @@ async fn event_loop(
                 Err(err) => log::error!("Theme loading failed: {}", err),
             }
 
-            state.load(manager);
+            state.load(manager, config);
         });
 
         if manager.reap_requested.swap(false, Ordering::SeqCst) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,8 @@ pub trait Config {
 
     fn mousekey(&self) -> &str;
 
+    fn get_state_file_path(&self) -> &str;
+
     //of you are on tag "1" and you goto tag "1" this takes you to the previous tag
     fn disable_current_tag_swap(&self) -> bool;
 }
@@ -48,6 +50,10 @@ where
 
     fn mousekey(&self) -> &str {
         C::mousekey(self)
+    }
+
+    fn get_state_file_path(&self) -> &str {
+        C::get_state_file_path(self)
     }
 
     fn disable_current_tag_swap(&self) -> bool {

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -71,7 +71,7 @@ pub fn process_internal(
         Command::MouseMoveWindow => None,
 
         Command::SoftReload => {
-            if let Err(err) = state.save(manager) {
+            if let Err(err) = state.save(manager, config) {
                 log::error!("Cannot save state: {}", err);
             }
             manager.hard_reload();

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -520,6 +520,9 @@ mod tests {
         fn mousekey(&self) -> &str {
             unimplemented!()
         }
+        fn get_state_file_path(&self) -> &str {
+            unimplemented!()
+        }
         fn disable_current_tag_swap(&self) -> bool {
             false
         }
@@ -528,10 +531,10 @@ mod tests {
     struct TestState;
 
     impl State for TestState {
-        fn save(&self, _manager: &Manager) -> Result<()> {
+        fn save(&self, _manager: &Manager, _config: &dyn Config) -> Result<()> {
             unimplemented!()
         }
-        fn load(&self, _manager: &mut Manager) {
+        fn load(&self, _manager: &mut Manager, _config: &dyn Config) {
             unimplemented!()
         }
     }

--- a/src/models/manager.rs
+++ b/src/models/manager.rs
@@ -24,7 +24,6 @@ pub struct Manager {
     pub focus_manager: FocusManager,
     pub mode: Mode,
     pub theme_setting: Arc<ThemeSetting>,
-    #[serde(skip)]
     pub tags: Vec<Tag>, //list of all known tags
     pub layouts: Vec<Layout>,
     pub scratchpads: Vec<ScratchPad>,

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -3,15 +3,12 @@
 #![allow(clippy::module_name_repetitions)]
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tag {
     pub id: String,
     pub hidden: bool,
-    #[serde(skip)]
     pub main_width_percentage: u8,
-    #[serde(skip)]
     pub flipped_horizontal: bool,
-    #[serde(skip)]
     pub flipped_vertical: bool,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,9 @@
 //! Save and restore manager state.
+mod common;
 
-use crate::config::Config;
 use crate::errors::Result;
 use crate::Manager;
+use common::config::Config;
 
 pub trait State {
     /// Write current state to a file.
@@ -14,8 +15,8 @@ pub trait State {
     /// if unable to serialize the text.
     /// May be caused by inadequate permissions, not enough
     /// space on drive, or other typical filesystem issues.
-    fn save(&self, manager: &Manager) -> Result<()>;
+    fn save(&self, manager: &Manager, config: &Config) -> Result<()>;
 
     /// Load saved state if it exists.
-    fn load(&self, manager: &mut Manager, config: &dyn Config);
+    fn load(&self, manager: &mut Manager, config: &Config);
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,8 @@
 //! Save and restore manager state.
-mod common;
 
+use crate::config::Config;
 use crate::errors::Result;
 use crate::Manager;
-use common::config::Config;
 
 pub trait State {
     /// Write current state to a file.
@@ -15,8 +14,8 @@ pub trait State {
     /// if unable to serialize the text.
     /// May be caused by inadequate permissions, not enough
     /// space on drive, or other typical filesystem issues.
-    fn save(&self, manager: &Manager, config: &Config) -> Result<()>;
+    fn save(&self, manager: &Manager, config: &dyn Config) -> Result<()>;
 
     /// Load saved state if it exists.
-    fn load(&self, manager: &mut Manager, config: &Config);
+    fn load(&self, manager: &mut Manager, config: &dyn Config);
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 //! Save and restore manager state.
 
+use crate::config::Config;
 use crate::errors::Result;
 use crate::Manager;
 
@@ -16,5 +17,5 @@ pub trait State {
     fn save(&self, manager: &Manager) -> Result<()>;
 
     /// Load saved state if it exists.
-    fn load(&self, manager: &mut Manager);
+    fn load(&self, manager: &mut Manager, config: &dyn Config);
 }


### PR DESCRIPTION
First of, as I once again butchered my git tree this PR depends on #473 to be merged. Sorry.

In order to set a custom path just add `state_file = /home/username/.cache/leftwm.state` to your `config.toml`.
When none is present I default to `pub const STATE_FILE: &str = "/tmp/leftwm.state" in `common/state.rs`. I felt I would like to keep this here for clarity.

I am still working on a bug that relative paths cant be handled, so gonna mark this 'draft' for now.

Also not sure what to think about the `&dyn Config` with the `State::save()` and `State::load()`? There is a warning, that this will be needed in Rust2021, but it feels like this is not the proper way how to handle this then, at least to me. So, if anyone has a hint on how to handle this properly, would be very welcome.