### PR TITLE
Fix broken keybinds when keyboard layout changes

### DIFF
--- a/src/display_action.rs
+++ b/src/display_action.rs
@@ -1,3 +1,4 @@
+use crate::config::Keybind;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use serde::{Deserialize, Serialize};
@@ -57,4 +58,7 @@ pub enum DisplayAction {
     /// Tell the DM to return to normal mode if it is not (ie resize a
     /// window or moving a window).
     NormalMode,
+
+    /// Reload keygrabs, needed when keyboard changes
+    ReloadKeyGrabs(Vec<Keybind>),
 }

--- a/src/display_event.rs
+++ b/src/display_event.rs
@@ -9,6 +9,7 @@ use crate::Command;
 pub enum DisplayEvent {
     Movement(WindowHandle, i32, i32),
     KeyCombo(ModMask, XKeysym),
+    KeyGrabReload, // Reloads keys for when keyboard changes
     MouseCombo(ModMask, Button, WindowHandle),
     WindowCreate(Window, i32, i32),
     WindowChange(WindowChange),

--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -111,7 +111,7 @@ fn from_mapping_notify(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEve
     if event.request == xlib::MappingModifier || event.request == xlib::MappingKeyboard {
         // refresh keyboard
         log::info!("Updating keyboard");
-        xw.refresh_keyboard(&mut event).unwrap();
+        xw.refresh_keyboard(&mut event).ok()?;
 
         // Reload keybinds
         Some(DisplayEvent::KeyGrabReload)

--- a/src/display_servers/xlib_display_server/event_translate.rs
+++ b/src/display_servers/xlib_display_server/event_translate.rs
@@ -22,6 +22,9 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             // new window is created
             xlib::MapRequest => from_map_request(raw_event, xw),
 
+            // listen for keyboard changes
+            xlib::MappingNotify => from_mapping_notify(raw_event, xw),
+
             // window is deleted
             xlib::UnmapNotify | xlib::DestroyNotify => Some(from_unmap_event(raw_event)),
 
@@ -101,6 +104,20 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent>
     w.type_ = xw.get_window_type(event.window);
     let cursor = xw.get_cursor_point().unwrap_or_default();
     Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1))
+}
+
+fn from_mapping_notify(raw_event: xlib::XEvent, xw: &XWrap) -> Option<DisplayEvent> {
+    let mut event = xlib::XMappingEvent::from(raw_event);
+    if event.request == xlib::MappingModifier || event.request == xlib::MappingKeyboard {
+        // refresh keyboard
+        log::info!("Updating keyboard");
+        xw.refresh_keyboard(&mut event).unwrap();
+
+        // Reload keybinds
+        Some(DisplayEvent::KeyGrabReload)
+    } else {
+        None
+    }
 }
 
 fn from_unmap_event(raw_event: xlib::XEvent) -> DisplayEvent {

--- a/src/display_servers/xlib_display_server/mod.rs
+++ b/src/display_servers/xlib_display_server/mod.rs
@@ -207,6 +207,10 @@ where
                 }
                 None
             }
+            DisplayAction::ReloadKeyGrabs(keybinds) => {
+                self.xw.reset_grabs(&keybinds);
+                None
+            }
         };
         if event.is_some() {
             log::trace!("DisplayEvent: {:?}", event);

--- a/src/handlers/display_event_handler.rs
+++ b/src/handlers/display_event_handler.rs
@@ -28,6 +28,13 @@ impl<C: Config> DisplayEventHandler<C> {
                 _ => return false,
             },
 
+            DisplayEvent::KeyGrabReload => {
+                manager
+                    .actions
+                    .push_back(DisplayAction::ReloadKeyGrabs(self.config.mapped_bindings()));
+                false
+            }
+
             DisplayEvent::MoveFocusTo(x, y) => focus_handler::move_focus_to_point(manager, x, y),
 
             //This is a request to validate focus. Double check that we are focused the correct


### PR DESCRIPTION
Hi,

Lately I changed my keyboard layout to `dvorak`, but Leftwm wouldn't pick up the changes resulting in me not being able to use the keybindings. The symptoms and temporary solution, `pkill lefwm-worker` on startup, were similar to issue #163 (this pull request possibly fixes this issue).

**The fix:**
- Leftwm did not refresh the key mapping on a `MappingNotify` event -> added an extra `match` case
- After the remapping, the keys needed to be regrabbed
- Some plumbing to get all necessary information together for the regrabbing

Kind regards,

SamClercky

Ps. Some useful links:
- [Stackoverflow xlib keyboard changes](https://stackoverflow.com/questions/35569562/how-to-catch-keyboard-layout-change-event-and-get-current-new-keyboard-layout-on)
- [Example implementation in sxhkd](https://github.com/baskerville/sxhkd/blob/fe241b0d2d70c9c483b23cf3cd14f1383f0953a2/src/sxhkd.c#L260)
- Useful xlib documentation: [`XRefreshKeyboardMapping`](https://tronche.com/gui/x/xlib/utilities/keyboard/XRefreshKeyboardMapping.html) and [`MappingNotify`](https://tronche.com/gui/x/xlib/events/window-state-change/mapping.html)