### PR TITLE
fix eww

### DIFF
--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -648,6 +648,14 @@ impl XWrap {
     pub fn update_window(&self, window: &Window, is_focused: bool, hide_offset: i32) {
         if let WindowHandle::XlibHandle(h) = window.handle {
             if window.visible() {
+                // If type dock we only need to move it
+                // Also fixes issues with eww
+                if window.type_ == WindowType::Dock {
+                    unsafe {
+                        (self.xlib.XMoveWindow)(self.display, h, window.x(), window.y());
+                    }
+                    return;
+                }
                 let mut changes = xlib::XWindowChanges {
                     x: window.x(),
                     y: window.y(),
@@ -688,7 +696,6 @@ impl XWrap {
             } else {
                 unsafe {
                     //if not visible x is <---- way over there <----
-                    //(self.xlib.XMoveWindow)(self.display, h, window.width() * -2, window.y());
                     (self.xlib.XMoveWindow)(self.display, h, hide_offset, window.y());
                 }
             }

--- a/src/display_servers/xlib_display_server/xwrap.rs
+++ b/src/display_servers/xlib_display_server/xwrap.rs
@@ -650,7 +650,7 @@ impl XWrap {
             if window.visible() {
                 // If type dock we only need to move it
                 // Also fixes issues with eww
-                if window.type_ == WindowType::Dock {
+                if window.is_unmanaged() {
                     unsafe {
                         (self.xlib.XMoveWindow)(self.display, h, window.x(), window.y());
                     }


### PR DESCRIPTION
This fixes a weird bug with eww, when resizing it (accidentally as eww is using a dummy area to fix windows overlapping it, which leftwm was using to size it). I don't know if there an any other issues with eww, as it doesn't seem to like my setup.

This fix has the knock on affect of less work when updating docks which isn't needed. Someone who uses eww my want to create an around the bar itself not showing a height in _NET_WM_STRUT_PARTIAL(CARDINAL), which I presume causes the issue overlapping (and which reserve fixes but causes issues like the this is fixing, where the wm doesn't know the actual size of the window). Also eww doesn't react well to being externally resized which leftwm was doing.

Thanks.