### PR TITLE
Hotfix: missing windows update after command

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -54,6 +54,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             //if we need to update the displayed state
             if needs_update {
+                self.update_windows();
+
                 match self.state.mode {
                     Mode::Normal => {
                         let windows: Vec<&Window> = self.state.windows.iter().collect();


### PR DESCRIPTION
So who wants more Windows update :grin: 

I checked the code and I think this code was triggered almost every time after a command from CommandPipe **except** for the commands called from `display_event_handler.rs` (key combos).

In this PR I'm **not** restoring that exact behavior. I am updating the windows systematically after any command no matter the origin (from pipe or from key binding) as suggested by @AethanFoot https://github.com/leftwm/leftwm/pull/472#issuecomment-932345059

My reasoning is that it is better to have consistency across command handling. The commands triggered by `display_event_handler.rs` are for when a key combo occurs while the ones triggered in the event loop are for when a command is received via the command pipe. It seems more predictable and consistent that they both behave the same: update the windows right after any command no matter which origin.