### PR TITLE
Fix margin parser

### DIFF
--- a/src/bin/common/theme_setting.rs
+++ b/src/bin/common/theme_setting.rs
@@ -70,15 +70,39 @@ impl std::convert::TryFrom<CustomMargins> for Margins {
                 left: size,
             }),
             CustomMargins::Vec(vec) => {
-                if vec.len() > 4 {
-                    Err("too many values for margin (max is 4)")
-                } else {
-                    Ok(Self {
-                        top: *vec.get(0).unwrap_or(&0),
-                        right: *vec.get(1).unwrap_or(&0),
-                        bottom: *vec.get(2).unwrap_or(&0),
-                        left: *vec.get(3).unwrap_or(&0),
-                    })
+                match vec.len() {
+                    1 => Ok(Self::new(vec[0])),
+                    2 => Ok(Self {
+                        top: *vec[0],
+                        right: *vec[0],
+                        bottom: *vec[1],
+                        left: *vec[1],
+                    }),
+                    3 => Ok(Self {
+                        top: *vec[0],
+                        right: *vec[1],
+                        bottom: *vec[2],
+                        left: *vec[2],
+                    }),
+                    4 => Ok(Self {
+                        top: *vec[0],
+                        right: *vec[1],
+                        bottom: *vec[2],
+                        left: *vec[3],
+                    }),
+                    0 => {
+                        log::error!("Empty margin or border array");
+                        Self::new(10) //assume 10 px borders for now
+                    }
+                    _ => {
+                        log::error!("Too many entries in margin or border array");
+                        Ok(Self {
+                            top: *vec[0],
+                            right: *vec[1],
+                            bottom: *vec[2],
+                            left: *vec[3],
+                        })
+                    }
                 }
             }
         }

--- a/src/bin/common/theme_setting.rs
+++ b/src/bin/common/theme_setting.rs
@@ -63,12 +63,7 @@ impl std::convert::TryFrom<CustomMargins> for Margins {
 
     fn try_from(c: CustomMargins) -> Result<Self, Self::Error> {
         match c {
-            CustomMargins::Int(size) => Ok(Self {
-                top: size,
-                right: size,
-                bottom: size,
-                left: size,
-            }),
+            CustomMargins::Int(size) => Ok(Self::new(size)),
             CustomMargins::Vec(vec) => {
                 match vec.len() {
                     1 => Ok(Self::new(vec[0])),


### PR DESCRIPTION
As mention by @AethanFoot https://github.com/leftwm/leftwm/pull/472#issuecomment-932315027 I accidentally broke the parsing behavior of Margins.

Existing behavior before my change:
 - no values: gives a warning, assume 10px on all side
 - 1 value: assume that value on all side (match CSS)
 - 2 values: assume the first value for top and right and the second value for bottom and left :warning: This is contradicting CSS where 2 values means: first value for top and bottom and second value for right and left
 - 3 values: assume the first value for top, second value for right, third value for bottom and left :warning: This is contradicting CSS where 3 values means: first value for top, second value for right and left, third value for bottom
 - 4 values: top, right, bottom, left (match CSS)
 - more than 4 values: gives a warning, assume 4 values

What I implemented:
- no values: assume 0 on all side, no warning ❌
- 1 value: assume that value on all side (match CSS) :heavy_check_mark: 
- 2 to 4 values: assign value to top, right, bottom and left, use 0 if one is missing ❌
- more than 4 values: does not parse (fatal) ❌

This PR restore the original behavior but I think we should modify it to comply with CSS so it will feel more intuitive.

Let me know your opinion.