### PR TITLE
Add commands to move window to next/previous workspace

### DIFF
--- a/src/bin/common/command.rs
+++ b/src/bin/common/command.rs
@@ -28,6 +28,8 @@ pub enum BaseCommand {
     FocusWorkspacePrevious,
     MoveToTag,
     MoveToLastWorkspace,
+    MoveWindowToNextWorkspace,
+    MoveWindowToPreviousWorkspace,
     MouseMoveWindow,
     NextLayout,
     PreviousLayout,

--- a/src/bin/common/config.rs
+++ b/src/bin/common/config.rs
@@ -66,6 +66,10 @@ impl TryFrom<Keybind> for leftwm::Keybind {
                     .context("invalid index value for SendWindowToTag")?,
             ),
             BaseCommand::MoveToLastWorkspace => leftwm::Command::MoveWindowToLastWorkspace,
+            BaseCommand::MoveWindowToNextWorkspace => leftwm::Command::MoveWindowToNextWorkspace,
+            BaseCommand::MoveWindowToPreviousWorkspace => {
+                leftwm::Command::MoveWindowToPreviousWorkspace
+            }
             BaseCommand::MouseMoveWindow => leftwm::Command::MouseMoveWindow,
             BaseCommand::NextLayout => leftwm::Command::NextLayout,
             BaseCommand::PreviousLayout => leftwm::Command::PreviousLayout,

--- a/src/command.rs
+++ b/src/command.rs
@@ -23,6 +23,8 @@ pub enum Command {
     FocusWorkspacePrevious,
     SendWindowToTag(usize),
     MoveWindowToLastWorkspace,
+    MoveWindowToNextWorkspace,
+    MoveWindowToPreviousWorkspace,
     MouseMoveWindow,
     NextLayout,
     PreviousLayout,

--- a/src/handlers/command_handler.rs
+++ b/src/handlers/command_handler.rs
@@ -37,7 +37,8 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::ToggleFullScreen => toggle_fullscreen(manager),
 
         Command::SendWindowToTag(tag) => move_to_tag(*tag, manager),
-
+        Command::MoveWindowToNextWorkspace => move_window_to_workspace_change(manager, 1),
+        Command::MoveWindowToPreviousWorkspace => move_window_to_workspace_change(manager, -1),
         Command::MoveWindowUp => move_focus_common_vars(move_window_change, manager, -1),
         Command::MoveWindowDown => move_focus_common_vars(move_window_change, manager, 1),
         Command::MoveWindowTop => move_focus_common_vars(move_window_top, manager, 0),
@@ -187,6 +188,21 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
         manager.focus_window(&new_handle);
     }
     Some(true)
+}
+
+fn move_window_to_workspace_change<C: Config, SERVER: DisplayServer>(
+    manager: &mut Manager<C, SERVER>,
+    delta: i32,
+) -> Option<bool> {
+    let current = manager.focused_workspace()?;
+    let workspace =
+        helpers::relative_find(&manager.state.workspaces, |w| w == current, delta, true)?.clone();
+    let tag_num = manager
+        .state
+        .tags
+        .iter()
+        .position(|t| workspace.has_tag(&t.id))?;
+    move_to_tag(tag_num + 1, manager)
 }
 
 fn goto_tag<C: Config, SERVER: DisplayServer>(

--- a/src/utils/command_pipe.rs
+++ b/src/utils/command_pipe.rs
@@ -83,6 +83,8 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),
         "SwapScreens" => Ok(Command::SwapScreens),
         "MoveWindowToLastWorkspace" => Ok(Command::MoveWindowToLastWorkspace),
+        "MoveWindowToNextWorkspace" => Ok(Command::MoveWindowToNextWorkspace),
+        "MoveWindowToPreviousWorkspace" => Ok(Command::MoveWindowToPreviousWorkspace),
         "FloatingToTile" => Ok(Command::FloatingToTile),
         "MoveWindowUp" => Ok(Command::MoveWindowUp),
         "MoveWindowDown" => Ok(Command::MoveWindowDown),


### PR DESCRIPTION
Adds command MoveWindowToNextWorkspace and MoveWindowToPreviousWorkspace. 
Should focus follow the window?
Thanks.