### PR TITLE
readme: mention journalctl command to debug leftwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ cd leftwm
 # Without systemd logging
 cargo build --release
 
-# OR with systemd logging
+# OR with systemd logging (view with 'journalctl -f -t leftwm-worker')
 cargo build --release --features=journald
 ```
 
@@ -247,7 +247,7 @@ git pull origin master
 # Without systemd logging
 cargo build --release
 
-# With systemd logging which can be used with `journalctl -f` for debug purpose
+# OR with systemd logging (view with 'journalctl -f -t leftwm-worker')
 cargo build --release --features=journald
 ```
 


### PR DESCRIPTION
Just a stupid simple addition to the readme, mentioning how to view the leftwm logs when using journald.
Might not be as obvious to new contributors :)