### PR TITLE
Reduce passing manager

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -63,10 +63,9 @@ pub trait Config {
         Self: Sized;
 
     /// Load saved state if it exists.
-    fn load_state<SERVER>(manager: &mut Manager<Self, SERVER>)
+    fn load_state(state: &mut State<Self>)
     where
-        Self: Sized,
-        SERVER: DisplayServer;
+        Self: Sized;
 }
 
 #[cfg(test)]

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -4,8 +4,8 @@ mod workspace_config;
 
 use crate::layouts::Layout;
 pub use crate::models::{FocusBehaviour, Gutter, Margins, Size};
-use crate::Manager;
 use crate::{display_servers::DisplayServer, models::LayoutMode};
+use crate::{state::State, Manager};
 pub use keybind::Keybind;
 pub use scratchpad::ScratchPad;
 pub use workspace_config::Workspace;
@@ -58,10 +58,9 @@ pub trait Config {
     /// if unable to serialize the text.
     /// May be caused by inadequate permissions, not enough
     /// space on drive, or other typical filesystem issues.
-    fn save_state<SERVER>(manager: &Manager<Self, SERVER>)
+    fn save_state(state: &State<Self>)
     where
-        Self: Sized,
-        SERVER: DisplayServer;
+        Self: Sized;
 
     /// Load saved state if it exists.
     fn load_state<SERVER>(manager: &mut Manager<Self, SERVER>)

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -1,8 +1,8 @@
 use crate::config::Config;
 use crate::display_action::DisplayAction;
-use crate::models::Manager;
 use crate::models::Window;
 use crate::models::Workspace;
+use crate::state::State;
 use crate::DisplayEvent;
 #[cfg(test)]
 mod mock_display_server;
@@ -25,7 +25,7 @@ pub trait DisplayServer {
         &self,
         _windows: Vec<&Window>,
         _focused: Option<&Window>,
-        _manager: &Manager<C, Self>,
+        _state: &State<C>,
     ) where
         Self: Sized,
     {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -60,7 +60,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     Mode::Normal => {
                         let windows: Vec<&Window> = self.state.windows.iter().collect();
                         let focused = self.state.focus_manager.window(&self.state.windows);
-                        self.display_server.update_windows(windows, focused, &self);
+                        self.display_server
+                            .update_windows(windows, focused, &self.state);
                         let workspaces: Vec<&Workspace> = self.state.workspaces.iter().collect();
                         let focused = self.state.focus_manager.workspace(&self.state.workspaces);
                         self.display_server.update_workspaces(workspaces, focused);
@@ -72,7 +73,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                             .iter()
                             .filter(|w| w.handle == h)
                             .collect();
-                        self.display_server.update_windows(windows, focused, &self);
+                        self.display_server
+                            .update_windows(windows, focused, &self.state);
                     }
                 }
             }
@@ -102,7 +104,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     Err(err) => log::error!("Theme loading failed: {}", err),
                 }
 
-                C::load_state(&mut self);
+                C::load_state(&mut self.state);
             });
 
             if self.reap_requested.swap(false, Ordering::SeqCst) {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -59,15 +59,15 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 match self.state.mode {
                     Mode::Normal => {
                         let windows: Vec<&Window> = self.state.windows.iter().collect();
-                        let focused = self.focused_window();
+                        let focused = self.state.focus_manager.window(&self.state.windows);
                         self.display_server.update_windows(windows, focused, &self);
                         let workspaces: Vec<&Workspace> = self.state.workspaces.iter().collect();
-                        let focused = self.focused_workspace();
+                        let focused = self.state.focus_manager.workspace(&self.state.workspaces);
                         self.display_server.update_workspaces(workspaces, focused);
                     }
                     //when (resizing / moving) only deal with the single window
                     Mode::ResizingWindow(h) | Mode::MovingWindow(h) => {
-                        let focused = self.focused_window();
+                        let focused = self.state.focus_manager.window(&self.state.windows);
                         let windows: Vec<&Window> = (&self.state.windows)
                             .iter()
                             .filter(|w| w.handle == h)

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -26,7 +26,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         let mut event_buffer = vec![];
         loop {
             if self.state.mode == Mode::Normal {
-                state_socket.write_manager_state(&self).await.ok();
+                state_socket.write_manager_state(&self.state).await.ok();
             }
             self.display_server.flush();
 

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -8,13 +8,13 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Returns true if changes need to be rendered.
     pub fn display_event_handler(&mut self, event: DisplayEvent) -> bool {
         let update_needed = match event {
-            DisplayEvent::ScreenCreate(s) => self.screen_create_handler(s),
+            DisplayEvent::ScreenCreate(s) => self.state.screen_create_handler(s),
             DisplayEvent::WindowCreate(w, x, y) => self.window_created_handler(w, x, y),
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
 
             //The window has been focused, do we want to do anything about it?
             DisplayEvent::MouseEnteredWindow(handle) => match self.state.focus_manager.behaviour {
-                FocusBehaviour::Sloppy => return self.focus_window(&handle),
+                FocusBehaviour::Sloppy => return self.state.focus_window(&handle),
                 _ => return false,
             },
 
@@ -25,12 +25,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 false
             }
 
-            DisplayEvent::MoveFocusTo(x, y) => self.move_focus_to_point(x, y),
+            DisplayEvent::MoveFocusTo(x, y) => self.state.move_focus_to_point(x, y),
 
             //This is a request to validate focus. Double check that we are focused the correct
             //thing under this point.
             DisplayEvent::VerifyFocusedAt(x, y) => match self.state.focus_manager.behaviour {
-                FocusBehaviour::Sloppy => return self.validate_focus_at(x, y),
+                FocusBehaviour::Sloppy => return self.state.validate_focus_at(x, y),
                 _ => return false,
             },
 
@@ -47,7 +47,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::MouseCombo(mod_mask, button, handle) => {
                 let mouse_key = utils::xkeysym_lookup::into_mod(self.state.config.mousekey());
-                self.mouse_combo_handler(mod_mask, button, handle, mouse_key)
+                self.state
+                    .mouse_combo_handler(mod_mask, button, handle, mouse_key)
             }
 
             DisplayEvent::ChangeToNormalMode => {
@@ -62,7 +63,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 if self.state.screens.iter().any(|s| s.root == handle)
                     && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy
                 {
-                    return self.focus_workspace_under_cursor(x, y);
+                    return self.state.focus_workspace_under_cursor(x, y);
                 }
                 false
             }

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -1,18 +1,17 @@
 #![allow(clippy::wildcard_imports)]
 
 use super::*;
-use crate::display_servers::DisplayServer;
 use crate::state::State;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
-impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+impl<C: Config> State<C> {
     /// Marks a workspace as the focused workspace.
     //NOTE: should only be called externally from this file
     pub fn focus_workspace(&mut self, workspace: &Workspace) -> bool {
-        if focus_workspace_work(&mut self.state, workspace.id).is_some() {
+        if focus_workspace_work(self, workspace.id).is_some() {
             //make sure this workspaces tag is focused
             workspace.tags.iter().for_each(|t| {
-                focus_tag_work(&mut self.state, t);
+                focus_tag_work(self, t);
             });
             // create an action to inform the DM
             self.update_current_tags();
@@ -23,42 +22,37 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
     /// Create a `DisplayAction` to cause this window to become focused
     pub fn focus_window(&mut self, handle: &WindowHandle) -> bool {
-        let window = match focus_window_by_handle_work(&mut self.state, handle) {
+        let window = match focus_window_by_handle_work(self, handle) {
             Some(w) => w,
             None => return false,
         };
 
         //make sure the focused window's workspace is focused
-        let (focused_window_tag, workspace_id) = match self
-            .state
-            .workspaces
-            .iter()
-            .find(|ws| ws.is_displaying(&window))
-        {
-            Some(ws) => (
-                ws.tags.iter().find(|t| window.has_tag(t)).cloned(),
-                Some(ws.id),
-            ),
-            None => (None, None),
-        };
+        let (focused_window_tag, workspace_id) =
+            match self.workspaces.iter().find(|ws| ws.is_displaying(&window)) {
+                Some(ws) => (
+                    ws.tags.iter().find(|t| window.has_tag(t)).cloned(),
+                    Some(ws.id),
+                ),
+                None => (None, None),
+            };
         if let Some(workspace_id) = workspace_id {
-            let _ = focus_workspace_work(&mut self.state, workspace_id);
+            let _ = focus_workspace_work(self, workspace_id);
         }
 
         //make sure the focused window's tag is focused
         if let Some(tag) = focused_window_tag {
-            let _ = focus_tag_work(&mut self.state, &tag);
+            let _ = focus_tag_work(self, &tag);
         }
         true
     }
 
     pub fn focus_workspace_under_cursor(&mut self, x: i32, y: i32) -> bool {
-        let focused_id = match self.state.focus_manager.workspace(&self.state.workspaces) {
+        let focused_id = match self.focus_manager.workspace(&self.workspaces) {
             Some(fws) => fws.id,
             None => None,
         };
         if let Some(w) = self
-            .state
             .workspaces
             .iter()
             .find(|ws| ws.contains_point(x, y) && ws.id != focused_id)
@@ -72,56 +66,53 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// marks a tag as the focused tag
     //NOTE: should only be called externally from this file
     pub fn focus_tag(&mut self, tag: &str) -> bool {
-        if focus_tag_work(&mut self.state, tag).is_none() {
+        if focus_tag_work(self, tag).is_none() {
             return false;
         }
         // check each workspace, if its displaying this tag it should be focused too
         let to_focus: Vec<Workspace> = self
-            .state
             .workspaces
             .iter()
             .filter(|w| w.has_tag(tag))
             .cloned()
             .collect();
         for ws in &to_focus {
-            focus_workspace_work(&mut self.state, ws.id);
+            focus_workspace_work(self, ws.id);
         }
         //make sure the focused window is on this workspace
-        if self.state.focus_manager.behaviour == FocusBehaviour::Sloppy {
+        if self.focus_manager.behaviour == FocusBehaviour::Sloppy {
             let act = DisplayAction::FocusWindowUnderCursor;
-            self.state.actions.push_back(act);
-        } else if let Some(handle) = self.state.focus_manager.tags_last_window.get(tag).copied() {
-            focus_window_by_handle_work(&mut self.state, &handle);
+            self.actions.push_back(act);
+        } else if let Some(handle) = self.focus_manager.tags_last_window.get(tag).copied() {
+            focus_window_by_handle_work(self, &handle);
         } else if let Some(ws) = to_focus.first() {
             let handle = self
-                .state
                 .windows
                 .iter()
                 .find(|w| ws.is_managed(w))
                 .map(|w| w.handle);
             if let Some(h) = handle {
-                focus_window_by_handle_work(&mut self.state, &h);
+                focus_window_by_handle_work(self, &h);
             }
         }
 
         // Unfocus last window if the target tag is empty
-        if let Some(window) = self.state.focus_manager.window(&self.state.windows) {
+        if let Some(window) = self.focus_manager.window(&self.windows) {
             if !window.tags.contains(&tag.to_owned()) {
-                self.state.actions.push_back(DisplayAction::Unfocus);
-                self.state.focus_manager.window_history.push_front(None);
+                self.actions.push_back(DisplayAction::Unfocus);
+                self.focus_manager.window_history.push_front(None);
             }
         }
         true
     }
 
     pub fn validate_focus_at(&mut self, x: i32, y: i32) -> bool {
-        let current = match self.state.focus_manager.window(&self.state.windows) {
+        let current = match self.focus_manager.window(&self.windows) {
             Some(w) => w,
             None => return false,
         };
         //only look at windows we can focus
         let found: Option<Window> = self
-            .state
             .windows
             .iter()
             .filter(|x| x.can_focus())
@@ -142,7 +133,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
     pub fn move_focus_to_point(&mut self, x: i32, y: i32) -> bool {
         let handle_found: Option<WindowHandle> = self
-            .state
             .windows
             .iter()
             .filter(|x| x.can_focus())
@@ -157,11 +147,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
     /// Create an action to inform the DM of the new current tags.
     pub fn update_current_tags(&mut self) {
-        if let Some(workspace) = self.state.focus_manager.workspace(&self.state.workspaces) {
+        if let Some(workspace) = self.focus_manager.workspace(&self.workspaces) {
             if let Some(tag) = workspace.tags.first().cloned() {
-                self.state
-                    .actions
-                    .push_back(DisplayAction::SetCurrentTags(tag));
+                self.actions.push_back(DisplayAction::SetCurrentTags(tag));
             }
         }
     }
@@ -211,22 +199,12 @@ fn focus_window_by_handle_work<C: Config>(
     Some(found.clone())
 }
 
-fn focus_closest_window<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
-    x: i32,
-    y: i32,
-) -> bool {
-    let ws = match manager
-        .state
-        .workspaces
-        .iter()
-        .find(|ws| ws.contains_point(x, y))
-    {
+fn focus_closest_window<C: Config>(state: &mut State<C>, x: i32, y: i32) -> bool {
+    let ws = match state.workspaces.iter().find(|ws| ws.contains_point(x, y)) {
         Some(ws) => ws,
         None => return false,
     };
-    let mut dists: Vec<(i32, &Window)> = manager
-        .state
+    let mut dists: Vec<(i32, &Window)> = state
         .windows
         .iter()
         .filter(|x| ws.is_managed(x) && x.can_focus())
@@ -235,7 +213,7 @@ fn focus_closest_window<C: Config, SERVER: DisplayServer>(
     dists.sort_by(|a, b| (a.0).cmp(&b.0));
     if let Some(first) = dists.get(0) {
         let handle = first.1.handle;
-        return manager.focus_window(&handle);
+        return state.focus_window(&handle);
     }
     false
 }
@@ -272,7 +250,7 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
-        let expected = manager.state.workspaces[0].clone();
+        let expected = state.workspaces[0].clone();
         manager.focus_workspace(&expected);
         let actual = manager.focused_workspace().unwrap();
         assert_eq!(Some(0), actual.id);
@@ -283,11 +261,11 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
-        let ws = manager.state.workspaces[0].clone();
+        let ws = state.workspaces[0].clone();
         manager.focus_workspace(&ws);
-        let start_length = manager.state.focus_manager.workspace_history.len();
+        let start_length = state.focus_manager.workspace_history.len();
         manager.focus_workspace(&ws);
-        let end_length = manager.state.focus_manager.workspace_history.len();
+        let end_length = state.focus_manager.workspace_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
 
@@ -305,7 +283,7 @@ mod tests {
             -1,
             -1,
         );
-        let expected = manager.state.windows[0].clone();
+        let expected = state.windows[0].clone();
         manager.focus_window(&expected.handle);
         let actual = manager.focused_window().unwrap().handle;
         assert_eq!(expected.handle, actual);
@@ -318,10 +296,10 @@ mod tests {
         let window = Window::new(WindowHandle::MockHandle(1), None, None);
         manager.window_created_handler(window.clone(), -1, -1);
         manager.focus_window(&window.handle);
-        let start_length = manager.state.focus_manager.workspace_history.len();
+        let start_length = state.focus_manager.workspace_history.len();
         manager.window_created_handler(window.clone(), -1, -1);
         manager.focus_window(&window.handle);
-        let end_length = manager.state.focus_manager.workspace_history.len();
+        let end_length = state.focus_manager.workspace_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
 
@@ -331,7 +309,7 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         let expected = "Bla".to_owned();
         manager.focus_tag(&expected);
-        let accual = manager.state.focus_manager.tag(0).unwrap();
+        let accual = state.focus_manager.tag(0).unwrap();
         assert_eq!(accual, expected);
     }
 
@@ -341,9 +319,9 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         let tag = "Bla".to_owned();
         manager.focus_tag(&tag);
-        let start_length = manager.state.focus_manager.tag_history.len();
+        let start_length = state.focus_manager.tag_history.len();
         manager.focus_tag(&tag);
-        let end_length = manager.state.focus_manager.tag_history.len();
+        let end_length = state.focus_manager.tag_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
 
@@ -364,9 +342,9 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
         manager.screen_create_handler(Screen::default());
-        let ws = manager.state.workspaces[1].clone();
+        let ws = state.workspaces[1].clone();
         manager.focus_workspace(&ws);
-        let actual = manager.state.focus_manager.tag(0).unwrap();
+        let actual = state.focus_manager.tag(0).unwrap();
         assert_eq!("2", actual);
     }
 
@@ -378,9 +356,9 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2");
-        manager.state.windows.push(window.clone());
+        state.windows.push(window.clone());
         manager.focus_window(&window.handle);
-        let actual = manager.state.focus_manager.tag(0).unwrap();
+        let actual = state.focus_manager.tag(0).unwrap();
         assert_eq!("2", actual);
     }
 
@@ -392,10 +370,10 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2");
-        manager.state.windows.push(window.clone());
+        state.windows.push(window.clone());
         manager.focus_window(&window.handle);
         let actual = manager.focused_workspace().unwrap().id;
-        let expected = manager.state.workspaces[1].id;
+        let expected = state.workspaces[1].id;
         assert_eq!(expected, actual);
     }
 
@@ -405,7 +383,7 @@ mod tests {
         manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("1");
-        manager.state.windows.push(window.clone());
+        state.windows.push(window.clone());
         manager.focus_window(&window.handle);
         manager.focus_tag("2");
         let focused = manager.focused_window();

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -11,8 +11,18 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         let tag_id = self.state.tags[tag_num - 1].id.clone();
         let new_tags = vec![tag_id.clone()];
         //no focus safety check
-        let old_tags = self.focused_workspace()?.tags.clone();
-        if let Some(handle) = self.focused_window().map(|w| w.handle) {
+        let old_tags = self
+            .state
+            .focus_manager
+            .workspace(&self.state.workspaces)?
+            .tags
+            .clone();
+        if let Some(handle) = self
+            .state
+            .focus_manager
+            .window(&self.state.windows)
+            .map(|w| w.handle)
+        {
             let old_handle = self
                 .state
                 .focus_manager
@@ -30,7 +40,10 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             ws.tags = old_tags;
         }
 
-        self.focused_workspace_mut()?.tags = new_tags;
+        self.state
+            .focus_manager
+            .workspace_mut(&mut self.state.workspaces)?
+            .tags = new_tags;
         self.focus_tag(&tag_id);
         self.update_static();
         self.state

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -48,10 +48,10 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
         // tell the WM the new display order of the windows
         //new windows should be on the top of the stack
-        self.sort_windows();
+        self.state.sort_windows();
 
         if (self.state.focus_manager.focus_new_windows || is_first) && on_same_tag {
-            self.focus_window(&window.handle);
+            self.state.focus_window(&window.handle);
         }
 
         if let Some(cmd) = &self.state.config.on_new_window_cmd() {
@@ -82,7 +82,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 let act = DisplayAction::FocusWindowUnderCursor;
                 self.state.actions.push_back(act);
             } else if let Some(h) = new_handle {
-                self.focus_window(&h);
+                self.state.focus_window(&h);
             }
         }
 
@@ -107,7 +107,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             }
         }
         if strut_changed {
-            self.update_static();
+            self.state.update_static();
         }
         changed
     }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -4,6 +4,7 @@ use crate::display_action::DisplayAction;
 use crate::display_servers::DisplayServer;
 use crate::layouts::Layout;
 use crate::models::{Size, WindowHandle, WindowState, Xyhw, XyhwBuilder};
+use crate::state::State;
 use crate::utils::helpers;
 use crate::{child_process::exec_shell, models::FocusBehaviour};
 use std::env;
@@ -23,14 +24,14 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         //Random value
         let mut layout: Layout = Layout::MainAndVertStack;
         setup_window(
-            self,
+            &mut self.state,
             &mut window,
             (x, y),
             &mut layout,
             &mut is_first,
             &mut on_same_tag,
         );
-        insert_window(self, &mut window, layout);
+        insert_window(&mut self.state, &mut window, layout);
 
         let follow_mouse = self.state.focus_manager.focus_new_windows
             && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy
@@ -54,7 +55,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         }
 
         if let Some(cmd) = &self.state.config.on_new_window_cmd() {
-            exec_shell(cmd, self);
+            exec_shell(cmd, &mut self.children);
         }
 
         true
@@ -179,8 +180,8 @@ impl Window {
     }
 }
 
-fn setup_window<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
+fn setup_window<C: Config>(
+    state: &mut State<C>,
     window: &mut Window,
     xy: (i32, i32),
     layout: &mut Layout,
@@ -190,30 +191,20 @@ fn setup_window<C: Config, SERVER: DisplayServer>(
     //When adding a window we add to the workspace under the cursor, This isn't necessarily the
     //focused workspace. If the workspace is empty, it might not have received focus. This is so
     //the workspace that has windows on its is still active not the empty workspace.
-    let ws: Option<&Workspace> = manager
-        .state
+    let ws: Option<&Workspace> = state
         .workspaces
         .iter()
         .find(|ws| {
             ws.xyhw.contains_point(xy.0, xy.1)
-                && manager.state.focus_manager.behaviour == FocusBehaviour::Sloppy
+                && state.focus_manager.behaviour == FocusBehaviour::Sloppy
         })
-        .or_else(|| {
-            manager
-                .state
-                .focus_manager
-                .workspace(&manager.state.workspaces)
-        }); //backup plan
+        .or_else(|| state.focus_manager.workspace(&state.workspaces)); //backup plan
 
     if let Some(ws) = ws {
         let for_active_workspace =
             |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
-        *is_first = !manager
-            .state
-            .windows
-            .iter()
-            .any(|w| for_active_workspace(w));
-        window.tags = find_terminal(manager, window.pid).map_or_else(
+        *is_first = !state.windows.iter().any(|w| for_active_workspace(w));
+        window.tags = find_terminal(state, window.pid).map_or_else(
             || ws.tags.clone(),
             |terminal| {
                 *on_same_tag = ws.tags == terminal.tags;
@@ -222,16 +213,14 @@ fn setup_window<C: Config, SERVER: DisplayServer>(
         );
         *layout = ws.layout;
 
-        if is_scratchpad(manager, window) {
+        if is_scratchpad(state, window) {
             window.set_floating(true);
-            if let Some((scratchpad_name, _)) = manager
-                .state
+            if let Some((scratchpad_name, _)) = state
                 .active_scratchpads
                 .iter()
                 .find(|(_, &id)| id == window.pid)
             {
-                if let Some(s) = manager
-                    .state
+                if let Some(s) = state
                     .scratchpads
                     .iter()
                     .find(|s| *scratchpad_name == s.name)
@@ -267,47 +256,42 @@ fn setup_window<C: Config, SERVER: DisplayServer>(
             }
         }
     } else {
-        window.tags = vec![manager.state.tags[0].id.clone()];
-        if is_scratchpad(manager, window) {
+        window.tags = vec![state.tags[0].id.clone()];
+        if is_scratchpad(state, window) {
             window.tag("NSP");
             window.set_floating(true);
         }
     }
 
-    if let Some(parent) = find_transient_parent(manager, window) {
+    if let Some(parent) = find_transient_parent(state, window) {
         window.set_floating(true);
         let new_float_exact = parent.calculated_xyhw().center_halfed();
         window.normal = parent.normal;
         window.set_floating_exact(new_float_exact);
     }
 
-    window.update_for_theme(&manager.state.config);
+    window.update_for_theme(&state.config);
 }
 
-fn insert_window<C: Config, SERVER: DisplayServer>(
-    manager: &mut Manager<C, SERVER>,
-    window: &mut Window,
-    layout: Layout,
-) {
+fn insert_window<C: Config>(state: &mut State<C>, window: &mut Window, layout: Layout) {
     // If the tag contains a fullscreen window, minimize it
     let for_active_workspace =
         |x: &Window| -> bool { helpers::intersect(&window.tags, &x.tags) && !x.is_unmanaged() };
     let mut was_fullscreen = false;
-    if let Some(fsw) = manager
-        .state
+    if let Some(fsw) = state
         .windows
         .iter_mut()
         .find(|w| for_active_workspace(w) && w.is_fullscreen())
     {
         let act =
             DisplayAction::SetState(fsw.handle, !fsw.is_fullscreen(), WindowState::Fullscreen);
-        manager.state.actions.push_back(act);
+        state.actions.push_back(act);
         was_fullscreen = true;
     }
 
     if matches!(layout, Layout::Monocle | Layout::MainAndDeck) && window.type_ == WindowType::Normal
     {
-        let mut to_reorder = helpers::vec_extract(&mut manager.state.windows, for_active_workspace);
+        let mut to_reorder = helpers::vec_extract(&mut state.windows, for_active_workspace);
         if layout == Layout::Monocle || to_reorder.is_empty() {
             if was_fullscreen {
                 let act = DisplayAction::SetState(
@@ -315,39 +299,32 @@ fn insert_window<C: Config, SERVER: DisplayServer>(
                     !window.is_fullscreen(),
                     WindowState::Fullscreen,
                 );
-                manager.state.actions.push_back(act);
+                state.actions.push_back(act);
             }
             to_reorder.insert(0, window.clone());
         } else {
             to_reorder.insert(1, window.clone());
         }
-        manager.state.windows.append(&mut to_reorder);
+        state.windows.append(&mut to_reorder);
     } else if window.type_ == WindowType::Dialog
         || window.type_ == WindowType::Splash
-        || is_scratchpad(manager, window)
+        || is_scratchpad(state, window)
     {
         //Slow
-        manager.state.windows.insert(0, window.clone());
+        state.windows.insert(0, window.clone());
     } else {
-        manager.state.windows.push(window.clone());
+        state.windows.push(window.clone());
     }
 }
 
-fn is_scratchpad<C: Config, SERVER: DisplayServer>(
-    manager: &Manager<C, SERVER>,
-    window: &Window,
-) -> bool {
-    manager
-        .state
+fn is_scratchpad<C: Config>(state: &State<C>, window: &Window) -> bool {
+    state
         .active_scratchpads
         .iter()
         .any(|(_, &id)| window.pid == id)
 }
 
-fn find_terminal<C: Config, SERVER: DisplayServer>(
-    manager: &Manager<C, SERVER>,
-    pid: Option<u32>,
-) -> Option<&Window> {
+fn find_terminal<C: Config>(state: &State<C>, pid: Option<u32>) -> Option<&Window> {
     // Get $SHELL, e.g. /bin/zsh
     let shell_path = env::var("SHELL").ok()?;
     // Remove /bin/
@@ -372,24 +349,19 @@ fn find_terminal<C: Config, SERVER: DisplayServer>(
     let shell_id = get_parent(pid)?;
     if is_terminal(shell_id)? {
         let terminal = get_parent(shell_id)?;
-        return manager
-            .state
-            .windows
-            .iter()
-            .find(|w| w.pid == Some(terminal));
+        return state.windows.iter().find(|w| w.pid == Some(terminal));
     }
 
     None
 }
 
-fn find_transient_parent<'w, C: Config, SERVER: DisplayServer>(
-    manager: &'w Manager<C, SERVER>,
+fn find_transient_parent<'w, C: Config>(
+    state: &'w State<C>,
     window: &Window,
 ) -> Option<&'w Window> {
     let mut transient = window.transient?;
     loop {
-        transient = if let Some(found) = manager
-            .state
+        transient = if let Some(found) = state
             .windows
             .iter()
             .find(|x| x.handle == transient)
@@ -397,7 +369,7 @@ fn find_transient_parent<'w, C: Config, SERVER: DisplayServer>(
         {
             found
         } else {
-            return manager.state.windows.iter().find(|x| x.handle == transient);
+            return state.windows.iter().find(|x| x.handle == transient);
         };
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -139,7 +139,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     //Find the next or previous window on the workspace
     pub fn get_next_or_previous(&mut self, handle: &WindowHandle) -> Option<WindowHandle> {
         if self.state.focus_manager.behaviour != FocusBehaviour::Sloppy {
-            let ws = self.focused_workspace().cloned()?;
+            let ws = self.state.focus_manager.workspace(&self.state.workspaces)?;
             let for_active_workspace = |x: &Window| -> bool { ws.is_managed(x) };
             let mut windows = helpers::vec_extract(&mut self.state.windows, for_active_workspace);
             let is_handle = |x: &Window| -> bool { &x.handle == handle };
@@ -198,7 +198,12 @@ fn setup_window<C: Config, SERVER: DisplayServer>(
             ws.xyhw.contains_point(xy.0, xy.1)
                 && manager.state.focus_manager.behaviour == FocusBehaviour::Sloppy
         })
-        .or_else(|| manager.focused_workspace()); //backup plan
+        .or_else(|| {
+            manager
+                .state
+                .focus_manager
+                .workspace(&manager.state.workspaces)
+        }); //backup plan
 
     if let Some(ws) = ws {
         let for_active_workspace =

--- a/leftwm-core/src/handlers/window_move_handler.rs
+++ b/leftwm-core/src/handlers/window_move_handler.rs
@@ -13,7 +13,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             .state
             .windows
             .iter()
-            .find(|other| other.has_tag(&self.focused_tag(0).unwrap_or_default()))
+            .find(|other| other.has_tag(&self.state.focus_manager.tag(0).unwrap_or_default()))
         {
             Some(w) => w.margin_multiplier(),
             None => 1.0,

--- a/leftwm-core/src/lib.rs
+++ b/leftwm-core/src/lib.rs
@@ -25,7 +25,7 @@ mod event_loop;
 mod handlers;
 pub mod layouts;
 pub mod models;
-mod state;
+pub mod state;
 pub mod utils;
 
 use utils::xkeysym_lookup::Button;

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -125,11 +125,15 @@ impl<C: Config, SERVER: DisplayServer> From<&Manager<C, SERVER>> for ManagerStat
                 layout: ws.layout,
             });
         }
-        let active_desktop = match manager.focused_workspace() {
+        let active_desktop = match manager
+            .state
+            .focus_manager
+            .workspace(&manager.state.workspaces)
+        {
             Some(ws) => ws.tags.clone(),
             None => vec!["".to_owned()],
         };
-        let window_title = match manager.focused_window() {
+        let window_title = match manager.state.focus_manager.window(&manager.state.windows) {
             Some(win) => win.name.clone(),
             None => None,
         };

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -1,7 +1,6 @@
 use crate::config::Config;
-use crate::display_servers::DisplayServer;
 use crate::layouts::Layout;
-use crate::models::Manager;
+use crate::state::State;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -105,17 +104,17 @@ fn viewport_into_display_workspace(
     }
 }
 
-impl<C: Config, SERVER: DisplayServer> From<&Manager<C, SERVER>> for ManagerState {
-    fn from(manager: &Manager<C, SERVER>) -> Self {
+impl<C: Config> From<&State<C>> for ManagerState {
+    fn from(state: &State<C>) -> Self {
         let mut viewports: Vec<Viewport> = vec![];
-        let mut tags_len = manager.state.tags.len();
+        let mut tags_len = state.tags.len();
         tags_len = if tags_len == 0 { 0 } else { tags_len - 1 };
-        let working_tags = manager.state.tags[0..tags_len]
+        let working_tags = state.tags[0..tags_len]
             .iter()
-            .filter(|tag| manager.state.windows.iter().any(|w| w.has_tag(&tag.id)))
+            .filter(|tag| state.windows.iter().any(|w| w.has_tag(&tag.id)))
             .map(|t| t.id.clone())
             .collect();
-        for ws in &manager.state.workspaces {
+        for ws in &state.workspaces {
             viewports.push(Viewport {
                 tags: ws.tags.clone(),
                 x: ws.xyhw.x(),
@@ -125,21 +124,17 @@ impl<C: Config, SERVER: DisplayServer> From<&Manager<C, SERVER>> for ManagerStat
                 layout: ws.layout,
             });
         }
-        let active_desktop = match manager
-            .state
-            .focus_manager
-            .workspace(&manager.state.workspaces)
-        {
+        let active_desktop = match state.focus_manager.workspace(&state.workspaces) {
             Some(ws) => ws.tags.clone(),
             None => vec!["".to_owned()],
         };
-        let window_title = match manager.state.focus_manager.window(&manager.state.windows) {
+        let window_title = match state.focus_manager.window(&state.windows) {
             Some(win) => win.name.clone(),
             None => None,
         };
         Self {
             window_title,
-            desktop_names: manager.state.tags[0..tags_len]
+            desktop_names: state.tags[0..tags_len]
                 .iter()
                 .map(|t| t.id.clone())
                 .collect(),

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -1,6 +1,5 @@
 use crate::config::Config;
-use crate::display_servers::DisplayServer;
-use crate::{models::TagId, models::WindowHandle, Manager, Window, Workspace};
+use crate::{models::TagId, models::WindowHandle, Window, Workspace};
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -44,15 +43,12 @@ impl FocusManager {
 
     /// Return the currently focused workspace.
     #[must_use]
-    pub fn workspace<'a, 'b, C: Config, SERVER: DisplayServer>(
-        &self,
-        manager: &'a Manager<C, SERVER>,
-    ) -> Option<&'b Workspace>
+    pub fn workspace<'a, 'b>(&self, workspaces: &'a [Workspace]) -> Option<&'b Workspace>
     where
         'a: 'b,
     {
         let index = *self.workspace_history.get(0)?;
-        manager.state.workspaces.get(index)
+        workspaces.get(index)
     }
 
     /// Return the currently focused workspace.
@@ -77,16 +73,13 @@ impl FocusManager {
 
     /// Return the currently focused window.
     #[must_use]
-    pub fn window<'a, 'b, C: Config, SERVER: DisplayServer>(
-        &self,
-        manager: &'a Manager<C, SERVER>,
-    ) -> Option<&'b Window>
+    pub fn window<'a, 'b>(&self, windows: &'a [Window]) -> Option<&'b Window>
     where
         'a: 'b,
     {
         let handle = *self.window_history.get(0)?;
         if let Some(handle) = handle {
-            return manager.state.windows.iter().find(|w| w.handle == handle);
+            return windows.iter().find(|w| w.handle == handle);
         }
         None
     }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -3,7 +3,6 @@ use crate::display_action::DisplayAction;
 use crate::display_servers::DisplayServer;
 use crate::models::Window;
 use crate::models::WindowHandle;
-use crate::models::Workspace;
 use crate::state::State;
 use crate::utils::child_process::Children;
 use std::sync::{atomic::AtomicBool, Arc};
@@ -40,41 +39,10 @@ where
         crate::child_process::register_child_hook(self.reap_requested.clone());
     }
 
-    /// Return the currently focused workspace.
-    #[must_use]
-    pub fn focused_workspace(&self) -> Option<&Workspace> {
-        self.state.focus_manager.workspace(self)
-    }
-
-    /// Return the currently focused workspace.
-    pub fn focused_workspace_mut(&mut self) -> Option<&mut Workspace> {
-        self.state
-            .focus_manager
-            .workspace_mut(&mut self.state.workspaces)
-    }
-
-    /// Return the currently focused tag if the offset is 0.
-    /// Offset is used to reach further down the history.
-    #[must_use]
-    pub fn focused_tag(&self, offset: usize) -> Option<String> {
-        self.state.focus_manager.tag(offset)
-    }
-
     /// Return the index of a given tag.
     #[must_use]
     pub fn tag_index(&self, tag: &str) -> Option<usize> {
         Some(self.state.tags.iter().position(|t| t.id == tag)).unwrap_or(None)
-    }
-
-    /// Return the currently focused window.
-    #[must_use]
-    pub fn focused_window(&self) -> Option<&Window> {
-        self.state.focus_manager.window(self)
-    }
-
-    /// Return the currently focused window.
-    pub fn focused_window_mut(&mut self) -> Option<&mut Window> {
-        self.state.focus_manager.window_mut(&mut self.state.windows)
     }
 
     pub fn update_static(&mut self) {
@@ -148,7 +116,7 @@ where
     #[must_use]
     pub fn workspaces_display(&self) -> String {
         let mut focused_id = None;
-        if let Some(f) = self.focused_workspace() {
+        if let Some(f) = self.state.focus_manager.workspace(&self.state.workspaces) {
             focused_id = f.id;
         }
         let list: Vec<String> = self

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -1,8 +1,5 @@
 use crate::config::Config;
-use crate::display_action::DisplayAction;
 use crate::display_servers::DisplayServer;
-use crate::models::Window;
-use crate::models::WindowHandle;
 use crate::state::State;
 use crate::utils::child_process::Children;
 use std::sync::{atomic::AtomicBool, Arc};
@@ -39,129 +36,9 @@ where
         crate::child_process::register_child_hook(self.reap_requested.clone());
     }
 
-    /// Return the index of a given tag.
-    #[must_use]
-    pub fn tag_index(&self, tag: &str) -> Option<usize> {
-        Some(self.state.tags.iter().position(|t| t.id == tag)).unwrap_or(None)
-    }
-
-    pub fn update_static(&mut self) {
-        let workspaces = self.state.workspaces.clone();
-        self.state
-            .windows
-            .iter_mut()
-            .filter(|w| w.strut.is_some() || w.is_sticky())
-            .for_each(|w| {
-                let (x, y) = match w.strut {
-                    Some(strut) => strut.center(),
-                    None => w.calculated_xyhw().center(),
-                };
-                if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
-                    w.tags = ws.tags.clone();
-                }
-            });
-    }
-
-    //sorts the windows and puts them in order of importance
-    //keeps the order for each importance level
-    pub fn sort_windows(&mut self) {
-        use crate::models::WindowType;
-        //first dialogs and modals
-        let (level1, other): (Vec<&Window>, Vec<&Window>) =
-            self.state.windows.iter().partition(|w| {
-                w.type_ == WindowType::Dialog
-                    || w.type_ == WindowType::Splash
-                    || w.type_ == WindowType::Utility
-                    || w.type_ == WindowType::Menu
-            });
-
-        //next floating
-        let (level2, other): (Vec<&Window>, Vec<&Window>) = other
-            .iter()
-            .partition(|w| w.type_ == WindowType::Normal && w.floating());
-
-        //then normal windows
-        let (level3, other): (Vec<&Window>, Vec<&Window>) =
-            other.iter().partition(|w| w.type_ == WindowType::Normal);
-
-        //last docks
-        //other is all the reset
-
-        //build the updated window list
-        let windows: Vec<Window> = level1
-            .iter()
-            .chain(level2.iter())
-            .chain(level3.iter())
-            .chain(other.iter())
-            .map(|&w| w.clone())
-            .collect();
-        self.state.windows = windows;
-        let order: Vec<_> = self.state.windows.iter().map(|w| w.handle).collect();
-        let act = DisplayAction::SetWindowOrder(order);
-        self.state.actions.push_back(act);
-    }
-
-    pub fn move_to_top(&mut self, handle: &WindowHandle) -> Option<()> {
-        let index = self
-            .state
-            .windows
-            .iter()
-            .position(|w| &w.handle == handle)?;
-        let window = self.state.windows.remove(index);
-        self.state.windows.insert(0, window);
-        self.sort_windows();
-        Some(())
-    }
-
-    #[must_use]
-    pub fn workspaces_display(&self) -> String {
-        let mut focused_id = None;
-        if let Some(f) = self.state.focus_manager.workspace(&self.state.workspaces) {
-            focused_id = f.id;
-        }
-        let list: Vec<String> = self
-            .state
-            .workspaces
-            .iter()
-            .map(|w| {
-                let tags = w.tags.join(",");
-                if w.id == focused_id {
-                    format!("({})", tags)
-                } else {
-                    format!(" {} ", tags)
-                }
-            })
-            .collect();
-        list.join(" ")
-    }
-
-    #[must_use]
-    pub fn windows_display(&self) -> String {
-        let list: Vec<String> = self
-            .state
-            .windows
-            .iter()
-            .map(|w| {
-                let tags = w.tags.join(",");
-                format!("[{:?}:{}]", w.handle, tags)
-            })
-            .collect();
-        list.join(" ")
-    }
-
     /// Soft reload the worker without saving state.
     pub fn hard_reload(&mut self) {
         self.reload_requested = true;
-    }
-
-    pub fn update_for_theme(&mut self) -> bool {
-        for win in &mut self.state.windows {
-            win.update_for_theme(&self.state.config);
-        }
-        for ws in &mut self.state.workspaces {
-            ws.update_for_theme(&self.state.config);
-        }
-        true
     }
 }
 

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -2,13 +2,13 @@
 
 use crate::config::{Config, ScratchPad};
 use crate::layouts::Layout;
-use crate::models::Mode;
 use crate::models::Screen;
 use crate::models::Tag;
 use crate::models::Window;
 use crate::models::Workspace;
 use crate::models::{FocusManager, LayoutManager};
-use crate::{DisplayAction, DisplayServer, Manager};
+use crate::models::{Mode, WindowHandle};
+use crate::DisplayAction;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::os::raw::c_ulong;
@@ -66,17 +66,123 @@ where
             config,
         }
     }
-}
 
-impl<C, SERVER> Manager<C, SERVER>
-where
-    C: Config,
-    SERVER: DisplayServer,
-{
+    //sorts the windows and puts them in order of importance
+    //keeps the order for each importance level
+    pub fn sort_windows(&mut self) {
+        use crate::models::WindowType;
+        //first dialogs and modals
+        let (level1, other): (Vec<&Window>, Vec<&Window>) = self.windows.iter().partition(|w| {
+            w.type_ == WindowType::Dialog
+                || w.type_ == WindowType::Splash
+                || w.type_ == WindowType::Utility
+                || w.type_ == WindowType::Menu
+        });
+
+        //next floating
+        let (level2, other): (Vec<&Window>, Vec<&Window>) = other
+            .iter()
+            .partition(|w| w.type_ == WindowType::Normal && w.floating());
+
+        //then normal windows
+        let (level3, other): (Vec<&Window>, Vec<&Window>) =
+            other.iter().partition(|w| w.type_ == WindowType::Normal);
+
+        //last docks
+        //other is all the reset
+
+        //build the updated window list
+        let windows: Vec<Window> = level1
+            .iter()
+            .chain(level2.iter())
+            .chain(level3.iter())
+            .chain(other.iter())
+            .map(|&w| w.clone())
+            .collect();
+        self.windows = windows;
+        let order: Vec<_> = self.windows.iter().map(|w| w.handle).collect();
+        let act = DisplayAction::SetWindowOrder(order);
+        self.actions.push_back(act);
+    }
+
+    pub fn move_to_top(&mut self, handle: &WindowHandle) -> Option<()> {
+        let index = self.windows.iter().position(|w| &w.handle == handle)?;
+        let window = self.windows.remove(index);
+        self.windows.insert(0, window);
+        self.sort_windows();
+        Some(())
+    }
+
+    #[must_use]
+    pub fn workspaces_display(&self) -> String {
+        let mut focused_id = None;
+        if let Some(f) = self.focus_manager.workspace(&self.workspaces) {
+            focused_id = f.id;
+        }
+        let list: Vec<String> = self
+            .workspaces
+            .iter()
+            .map(|w| {
+                let tags = w.tags.join(",");
+                if w.id == focused_id {
+                    format!("({})", tags)
+                } else {
+                    format!(" {} ", tags)
+                }
+            })
+            .collect();
+        list.join(" ")
+    }
+
+    #[must_use]
+    pub fn windows_display(&self) -> String {
+        let list: Vec<String> = self
+            .windows
+            .iter()
+            .map(|w| {
+                let tags = w.tags.join(",");
+                format!("[{:?}:{}]", w.handle, tags)
+            })
+            .collect();
+        list.join(" ")
+    }
+
+    /// Return the index of a given tag.
+    #[must_use]
+    pub fn tag_index(&self, tag: &str) -> Option<usize> {
+        Some(self.tags.iter().position(|t| t.id == tag)).unwrap_or(None)
+    }
+
+    pub fn update_static(&mut self) {
+        let workspaces = self.workspaces.clone();
+        self.windows
+            .iter_mut()
+            .filter(|w| w.strut.is_some() || w.is_sticky())
+            .for_each(|w| {
+                let (x, y) = match w.strut {
+                    Some(strut) => strut.center(),
+                    None => w.calculated_xyhw().center(),
+                };
+                if let Some(ws) = workspaces.iter().find(|ws| ws.contains_point(x, y)) {
+                    w.tags = ws.tags.clone();
+                }
+            });
+    }
+
+    pub fn update_for_theme(&mut self) -> bool {
+        for win in &mut self.windows {
+            win.update_for_theme(&self.config);
+        }
+        for ws in &mut self.workspaces {
+            ws.update_for_theme(&self.config);
+        }
+        true
+    }
+
     /// Apply saved state to a running manager.
     pub fn restore_state(&mut self, state: &State<C>) {
         // restore workspaces
-        for workspace in &mut self.state.workspaces {
+        for workspace in &mut self.workspaces {
             if let Some(old_workspace) = state.workspaces.iter().find(|w| w.id == workspace.id) {
                 workspace.layout = old_workspace.layout;
                 workspace.margin_multiplier = old_workspace.margin_multiplier;
@@ -84,7 +190,7 @@ where
         }
 
         // restore tags
-        for tag in &mut self.state.tags {
+        for tag in &mut self.tags {
             if let Some(old_tag) = state.tags.iter().find(|t| t.id == tag.id) {
                 tag.hidden = old_tag.hidden;
                 tag.layout = old_tag.layout;
@@ -101,7 +207,6 @@ where
 
         state.windows.iter().for_each(|old| {
             if let Some((index, window)) = self
-                .state
                 .windows
                 .clone()
                 .iter_mut()
@@ -115,11 +220,11 @@ where
                 window.apply_margin_multiplier(old.margin_multiplier);
                 window.pid = old.pid;
                 window.normal = old.normal;
-                if self.state.tags.eq(&state.tags) {
+                if self.tags.eq(&state.tags) {
                     window.tags = old.tags.clone();
                 } else {
                     old.tags.iter().for_each(|t| {
-                        let manager_tags = &self.state.tags.clone();
+                        let manager_tags = &self.tags.clone();
                         if let Some(tag_index) = &state.tags.clone().iter().position(|o| &o.id == t)
                         {
                             window.clear_tags();
@@ -137,19 +242,17 @@ where
                 window.strut = old.strut;
                 window.set_states(old.states());
                 ordered.push(window.clone());
-                self.state.windows.remove(index);
+                self.windows.remove(index);
             }
         });
         if had_strut {
             self.update_static();
         }
-        self.state.windows.append(&mut ordered);
+        self.windows.append(&mut ordered);
 
         // restore scratchpads
         for (scratchpad, id) in &state.active_scratchpads {
-            self.state
-                .active_scratchpads
-                .insert(scratchpad.clone(), *id);
+            self.active_scratchpads.insert(scratchpad.clone(), *id);
         }
     }
 }

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -1,9 +1,6 @@
 //! Starts programs in autostart, runs global 'up' script, and boots theme. Provides function to
 //! boot other desktop files also.
-use crate::config::Config;
-use crate::display_servers::DisplayServer;
 use crate::errors::Result;
-use crate::models::Manager;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
@@ -302,10 +299,7 @@ pub fn register_child_hook(flag: Arc<AtomicBool>) {
 
 /// Sends command to shell for execution
 /// Assumes STDIN/STDOUT unwanted.
-pub fn exec_shell<C: Config, SERVER: DisplayServer>(
-    command: &str,
-    manager: &mut Manager<C, SERVER>,
-) -> Option<u32> {
+pub fn exec_shell(command: &str, children: &mut Children) -> Option<u32> {
     let child = Command::new("sh")
         .arg("-c")
         .arg(&command)
@@ -314,7 +308,7 @@ pub fn exec_shell<C: Config, SERVER: DisplayServer>(
         .spawn()
         .ok()?;
     let pid = child.id();
-    manager.children.insert(child);
+    children.insert(child);
     Some(pid)
 }
 

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -1,8 +1,6 @@
 use crate::config::Config;
-use crate::display_servers::DisplayServer;
 use crate::errors::{LeftError, Result};
 use crate::models::dto::ManagerState;
-use crate::models::Manager;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
@@ -58,12 +56,12 @@ impl StateSocket {
     /// # Errors
     /// Will return Err if a mut ref to the peer is unavailable.
     /// Will return error if state cannot be serialized
-    pub async fn write_manager_state<C: Config, SERVER: DisplayServer>(
+    pub async fn write_manager_state<C: Config>(
         &mut self,
-        manager: &Manager<C, SERVER>,
+        raw_state: &crate::state::State<C>,
     ) -> Result<()> {
         if self.listener.is_some() {
-            let state: ManagerState = manager.into();
+            let state: ManagerState = raw_state.into();
             let mut json = serde_json::to_string(&state)?;
             json.push('\n');
             let mut state = self.state.lock().await;

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -346,11 +346,11 @@ impl leftwm_core::Config for Config {
                     } else {
                         log::warn!("Path submitted does not exist.");
                     }
-                    return manager.update_for_theme();
+                    return manager.state.update_for_theme();
                 }
                 "UnloadTheme" => {
                     manager.state.config.theme_setting = Default::default();
-                    return manager.update_for_theme();
+                    return manager.state.update_for_theme();
                 }
                 _ => {
                     log::warn!("Command not recognized: {}", command);
@@ -430,12 +430,12 @@ impl leftwm_core::Config for Config {
         }
     }
 
-    fn load_state<SERVER: DisplayServer>(manager: &mut Manager<Self, SERVER>) {
-        let path = manager.state.config.state_file().to_owned();
+    fn load_state(state: &mut State<Self>) {
+        let path = state.config.state_file().to_owned();
         match File::open(&path) {
             Ok(file) => {
                 match serde_json::from_reader(file) {
-                    Ok(state) => manager.restore_state(&state),
+                    Ok(old_state) => state.restore_state(&old_state),
                     Err(err) => log::error!("Cannot load old state: {}", err),
                 }
                 // Clean old state.

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -6,6 +6,7 @@ use leftwm_core::{
     config::{ScratchPad, Workspace},
     layouts::{Layout, LAYOUTS},
     models::{FocusBehaviour, Gutter, LayoutMode, Margins, Size},
+    state::State,
     DisplayServer, Manager,
 };
 use serde::{Deserialize, Serialize};
@@ -415,8 +416,8 @@ impl leftwm_core::Config for Config {
         self.max_window_width
     }
 
-    fn save_state<SERVER: DisplayServer>(manager: &Manager<Self, SERVER>) {
-        let path = manager.state.config.state_file();
+    fn save_state(state: &State<Self>) {
+        let path = state.config.state_file();
         let state_file = match File::create(&path) {
             Ok(file) => file,
             Err(err) => {
@@ -424,7 +425,7 @@ impl leftwm_core::Config for Config {
                 return;
             }
         };
-        if let Err(err) = serde_json::to_writer(state_file, &manager.state) {
+        if let Err(err) = serde_json::to_writer(state_file, state) {
             log::error!("Cannot save state: {}", err);
         }
     }


### PR DESCRIPTION
This reduces the unneeded passes of manager, and moves any functions that just use state to State. This also means there is a lot less manager.state and we access things more directly.