### PR TITLE
Change focus when mod key is held down (ClickTo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-/target
-**/*.rs.bk
-
-/target
+**/target
 **/*.rs.bk
 leftwm.logs
 

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -53,6 +53,9 @@ fn build_action<C: Config>(
 ) -> Option<DisplayAction> {
     match button {
         xlib::Button1 => {
+            if state.focus_manager.behaviour == FocusBehaviour::ClickTo {
+                state.focus_window(&window);
+            }
             if mod_mask == modifier || mod_mask == (modifier | xlib::ShiftMask) {
                 let _ = state
                     .windows
@@ -60,9 +63,6 @@ fn build_action<C: Config>(
                     .find(|w| w.handle == window && w.can_move())?;
                 state.mode = Mode::MovingWindow(window);
                 return Some(DisplayAction::StartMovingWindow(window));
-            }
-            if state.focus_manager.behaviour == FocusBehaviour::ClickTo {
-                state.focus_window(&window);
             }
             None
         }


### PR DESCRIPTION
This simple fix closes #518.

The `state.focus_window()` is now called before the method returns, so that the focus changes when moving an out-of-focus window in the `ClickTo` focus behavior.

---

I wanted to do the same for window resizing to allow resizing windows which are out-of-focus. This doesn't seem to be possible though, as no `XEvent` is emitted when an out-of-focus is right-clicked.

---

Also updated the `.gitignore` file after git tried to commit my `leftwm-core/target` directory :)