### PR TITLE
Improve configuration soft reloading

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -3,8 +3,8 @@ mod scratchpad;
 mod workspace_config;
 
 use crate::layouts::Layout;
-use crate::models::LayoutMode;
 pub use crate::models::{FocusBehaviour, Gutter, Margins, Size};
+use crate::models::{LayoutMode, Manager};
 use crate::state::State;
 pub use keybind::Keybind;
 pub use scratchpad::ScratchPad;
@@ -16,11 +16,11 @@ pub trait Config {
 
     fn create_list_of_tags(&self) -> Vec<String>;
 
-    fn workspaces(&self) -> Option<&[Workspace]>;
+    fn workspaces(&self) -> Option<Vec<Workspace>>;
 
     fn focus_behaviour(&self) -> FocusBehaviour;
 
-    fn mousekey(&self) -> &str;
+    fn mousekey(&self) -> String;
 
     //of you are on tag "1" and you goto tag "1" this takes you to the previous tag
     fn disable_current_tag_swap(&self) -> bool;
@@ -33,7 +33,7 @@ pub trait Config {
 
     fn focus_new_windows(&self) -> bool;
 
-    fn command_handler(command: &str, state: &mut State<Self>) -> bool
+    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
     where
         Self: Sized;
 
@@ -41,30 +41,22 @@ pub trait Config {
     fn margin(&self) -> Margins;
     fn workspace_margin(&self) -> Option<Margins>;
     fn gutter(&self) -> Option<Vec<Gutter>>;
-    fn default_border_color(&self) -> &str;
-    fn floating_border_color(&self) -> &str;
-    fn focused_border_color(&self) -> &str;
+    fn default_border_color(&self) -> String;
+    fn floating_border_color(&self) -> String;
+    fn focused_border_color(&self) -> String;
     fn on_new_window_cmd(&self) -> Option<String>;
     fn get_list_of_gutters(&self) -> Vec<Gutter>;
     fn max_window_width(&self) -> Option<Size>;
 
-    /// Write current state to a file.
+    /// Attempt to write current state to a file.
+    ///
     /// It will be used to restore the state after soft reload.
     ///
-    /// # Errors
-    ///
-    /// Will return error if unable to create `state_file` or
-    /// if unable to serialize the text.
-    /// May be caused by inadequate permissions, not enough
-    /// space on drive, or other typical filesystem issues.
-    fn save_state(state: &State<Self>)
-    where
-        Self: Sized;
+    /// **Note:** this function cannot fail.
+    fn save_state(&self, state: &State);
 
     /// Load saved state if it exists.
-    fn load_state(state: &mut State<Self>)
-    where
-        Self: Sized;
+    fn load_state(&self, state: &mut State);
 }
 
 #[cfg(test)]
@@ -81,14 +73,14 @@ impl Config for TestConfig {
     fn create_list_of_tags(&self) -> Vec<String> {
         self.tags.clone()
     }
-    fn workspaces(&self) -> Option<&[Workspace]> {
+    fn workspaces(&self) -> Option<Vec<Workspace>> {
         unimplemented!()
     }
     fn focus_behaviour(&self) -> FocusBehaviour {
         FocusBehaviour::Sloppy
     }
-    fn mousekey(&self) -> &str {
-        unimplemented!()
+    fn mousekey(&self) -> String {
+        "Mod4".to_string()
     }
     fn disable_current_tag_swap(&self) -> bool {
         false
@@ -105,10 +97,7 @@ impl Config for TestConfig {
     fn focus_new_windows(&self) -> bool {
         false
     }
-    fn command_handler(_command: &str, _state: &mut State<Self>) -> bool
-    where
-        Self: Sized,
-    {
+    fn command_handler<SERVER>(_command: &str, _manager: &mut Manager<Self, SERVER>) -> bool {
         unimplemented!()
     }
     fn border_width(&self) -> i32 {
@@ -123,13 +112,13 @@ impl Config for TestConfig {
     fn gutter(&self) -> Option<Vec<Gutter>> {
         unimplemented!()
     }
-    fn default_border_color(&self) -> &str {
+    fn default_border_color(&self) -> String {
         unimplemented!()
     }
-    fn floating_border_color(&self) -> &str {
+    fn floating_border_color(&self) -> String {
         unimplemented!()
     }
-    fn focused_border_color(&self) -> &str {
+    fn focused_border_color(&self) -> String {
         unimplemented!()
     }
     fn on_new_window_cmd(&self) -> Option<String> {
@@ -141,17 +130,10 @@ impl Config for TestConfig {
     fn max_window_width(&self) -> Option<Size> {
         None
     }
-    fn save_state(_state: &State<Self>)
-    where
-        Self: Sized,
-    {
+    fn save_state(&self, _state: &State) {
         unimplemented!()
     }
-    /// Load saved state if it exists.
-    fn load_state(_state: &mut State<Self>)
-    where
-        Self: Sized,
-    {
+    fn load_state(&self, _state: &mut State) {
         unimplemented!()
     }
 }

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -19,7 +19,7 @@ pub trait DisplayServer {
 
     fn get_next_events(&mut self) -> Vec<DisplayEvent>;
 
-    fn reload_config(&mut self, _config: &impl Config) {}
+    fn load_config(&mut self, _config: &impl Config) {}
 
     fn update_windows(&self, _windows: Vec<&Window>, _focused: Option<&Window>, _state: &State) {}
 

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -19,17 +19,9 @@ pub trait DisplayServer {
 
     fn get_next_events(&mut self) -> Vec<DisplayEvent>;
 
-    fn update_theme_settings(&mut self, _config: &impl Config) {}
+    fn reload_config(&mut self, _config: &impl Config) {}
 
-    fn update_windows<C: Config>(
-        &self,
-        _windows: Vec<&Window>,
-        _focused: Option<&Window>,
-        _state: &State<C>,
-    ) where
-        Self: Sized,
-    {
-    }
+    fn update_windows(&self, _windows: Vec<&Window>, _focused: Option<&Window>, _state: &State) {}
 
     fn update_workspaces(&self, _windows: Vec<&Workspace>, _focused: Option<&Workspace>) {}
 

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -50,8 +50,8 @@ impl DisplayServer for XlibDisplayServer {
         }
     }
 
-    fn reload_config(&mut self, config: &impl Config) {
-        self.xw.reload_config(config);
+    fn load_config(&mut self, config: &impl Config) {
+        self.xw.load_config(config);
     }
 
     fn update_windows(

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -256,7 +256,7 @@ impl XlibDisplayServer {
                     events.push(e);
                 });
             } else {
-                for wsc in workspaces.iter() {
+                for wsc in &workspaces {
                     let mut screen = Screen::from(wsc);
                     screen.root = WindowHandle::XlibHandle(self.root);
                     let e = DisplayEvent::ScreenCreate(screen);

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -34,8 +34,6 @@ impl DisplayServer for XlibDisplayServer {
     fn new(config: &impl Config) -> Self {
         let mut wrap = XWrap::new();
 
-        wrap.focus_behaviour = config.focus_behaviour();
-        wrap.mouse_key_mask = utils::xkeysym_lookup::into_mod(config.mousekey());
         wrap.init(config); //setup events masks
 
         let root = wrap.get_default_root();
@@ -52,15 +50,15 @@ impl DisplayServer for XlibDisplayServer {
         }
     }
 
-    fn update_theme_settings(&mut self, config: &impl Config) {
-        self.xw.load_colors(config);
+    fn reload_config(&mut self, config: &impl Config) {
+        self.xw.reload_config(config);
     }
 
-    fn update_windows<C: Config>(
+    fn update_windows(
         &self,
         windows: Vec<&Window>,
         focused_window: Option<&Window>,
-        state: &State<C>,
+        state: &State,
     ) {
         let tags: Vec<&String> = state.workspaces.iter().flat_map(|w| &w.tags).collect();
 
@@ -310,10 +308,10 @@ impl XlibDisplayServer {
 }
 
 //return an offset to hide the window in the right, if it should be hidden on the right
-fn right_offset<C: Config>(
+fn right_offset(
     max_tag_index: Option<usize>,
     max_right_screen: Option<i32>,
-    state: &State<C>,
+    state: &State,
     window: &Window,
 ) -> Option<i32> {
     let max_tag_index = max_tag_index?;

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -34,7 +34,7 @@ impl XWrap {
     // `XDefaultScreen`: https://tronche.com/gui/x/xlib/display/display-macros.html#DefaultScreen
     // `XDefaultColormap`: https://tronche.com/gui/x/xlib/display/display-macros.html#DefaultColormap
     // `XAllocNamedColor`: https://tronche.com/gui/x/xlib/color/XAllocNamedColor.html
-    pub fn get_color(&self, color: &str) -> c_ulong {
+    pub fn get_color(&self, color: String) -> c_ulong {
         unsafe {
             let screen = (self.xlib.XDefaultScreen)(self.display);
             let cmap: xlib::Colormap = (self.xlib.XDefaultColormap)(self.display, screen);

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -190,7 +190,7 @@ impl XWrap {
         xw
     }
 
-    pub fn reload_config(&mut self, config: &impl Config) {
+    pub fn load_config(&mut self, config: &impl Config) {
         self.focus_behaviour = config.focus_behaviour();
         self.mouse_key_mask = utils::xkeysym_lookup::into_mod(&config.mousekey());
         self.load_colors(config);

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -204,6 +204,9 @@ impl XWrap {
     // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     // TODO: split into smaller functions
     pub fn init(&mut self, config: &impl Config) {
+        self.focus_behaviour = config.focus_behaviour();
+        self.mouse_key_mask = utils::xkeysym_lookup::into_mod(&config.mousekey());
+
         let root_event_mask: c_long = xlib::SubstructureRedirectMask
             | xlib::SubstructureNotifyMask
             | xlib::ButtonPressMask

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -190,6 +190,14 @@ impl XWrap {
         xw
     }
 
+    pub fn reload_config(&mut self, config: &impl Config) {
+        self.focus_behaviour = config.focus_behaviour();
+        self.mouse_key_mask = utils::xkeysym_lookup::into_mod(&config.mousekey());
+        self.load_colors(config);
+        self.tags = config.create_list_of_tags();
+        self.reset_grabs(&config.mapped_bindings());
+    }
+
     /// Initialize the xwrapper.
     // `XChangeWindowAttributes`: https://tronche.com/gui/x/xlib/window/XChangeWindowAttributes.html
     // `XDeleteProperty`: https://tronche.com/gui/x/xlib/window-information/XDeleteProperty.html

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -45,7 +45,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 }
                 Some(cmd) = command_pipe.read_command(), if event_buffer.is_empty() => {
                     needs_update = self.command_handler(&cmd) || needs_update;
-                    self.display_server.update_theme_settings(&self.state.config);
+                    self.display_server.reload_config(&self.config);
                 }
                 else => {
                     event_buffer.drain(..).for_each(|event| needs_update = self.display_event_handler(event) || needs_update);
@@ -104,7 +104,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     Err(err) => log::error!("Theme loading failed: {}", err),
                 }
 
-                C::load_state(&mut self.state);
+                self.config.load_state(&mut self.state);
             });
 
             if self.reap_requested.swap(false, Ordering::SeqCst) {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -45,7 +45,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 }
                 Some(cmd) = command_pipe.read_command(), if event_buffer.is_empty() => {
                     needs_update = self.command_handler(&cmd) || needs_update;
-                    self.display_server.reload_config(&self.config);
+                    self.display_server.load_config(&self.config);
                 }
                 else => {
                     event_buffer.drain(..).for_each(|event| needs_update = self.display_event_handler(event) || needs_update);

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -8,7 +8,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Returns true if changes need to be rendered.
     pub fn display_event_handler(&mut self, event: DisplayEvent) -> bool {
         let update_needed = match event {
-            DisplayEvent::ScreenCreate(s) => self.state.screen_create_handler(s),
+            DisplayEvent::ScreenCreate(s) => self.screen_create_handler(s),
             DisplayEvent::WindowCreate(w, x, y) => self.window_created_handler(w, x, y),
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
 
@@ -19,9 +19,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             },
 
             DisplayEvent::KeyGrabReload => {
-                self.state.actions.push_back(DisplayAction::ReloadKeyGrabs(
-                    self.state.config.mapped_bindings(),
-                ));
+                self.state
+                    .actions
+                    .push_back(DisplayAction::ReloadKeyGrabs(self.config.mapped_bindings()));
                 false
             }
 
@@ -38,7 +38,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::KeyCombo(mod_mask, xkeysym) => {
                 //look through the config and build a command if its defined in the config
-                let build = CommandBuilder::<C>::new(&self.state.config);
+                let build = CommandBuilder::<C>::new(&self.config);
                 let command = build.xkeyevent(mod_mask, xkeysym);
                 command.map_or(false, |cmd| self.command_handler(cmd))
             }
@@ -46,7 +46,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::SendCommand(command) => self.command_handler(&command),
 
             DisplayEvent::MouseCombo(mod_mask, button, handle) => {
-                let mouse_key = utils::xkeysym_lookup::into_mod(self.state.config.mousekey());
+                // TODO looks like this should be entirely in state
+                let mouse_key = utils::xkeysym_lookup::into_mod(&self.state.mousekey);
                 self.state
                     .mouse_combo_handler(mod_mask, button, handle, mouse_key)
             }

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -1,6 +1,5 @@
 use super::{CommandBuilder, Config, DisplayEvent, Manager, Mode};
 use crate::display_servers::DisplayServer;
-use crate::utils;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
 impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
@@ -46,10 +45,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::SendCommand(command) => self.command_handler(&command),
 
             DisplayEvent::MouseCombo(mod_mask, button, handle) => {
-                // TODO looks like this should be entirely in state
-                let mouse_key = utils::xkeysym_lookup::into_mod(&self.state.mousekey);
-                self.state
-                    .mouse_combo_handler(mod_mask, button, handle, mouse_key)
+                self.state.mouse_combo_handler(mod_mask, button, handle)
             }
 
             DisplayEvent::ChangeToNormalMode => {

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::state::State;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
-impl<C: Config> State<C> {
+impl State {
     /// Marks a workspace as the focused workspace.
     //NOTE: should only be called externally from this file
     pub fn focus_workspace(&mut self, workspace: &Workspace) -> bool {
@@ -155,7 +155,7 @@ impl<C: Config> State<C> {
     }
 }
 
-fn focus_workspace_work<C: Config>(state: &mut State<C>, workspace_id: Option<i32>) -> Option<()> {
+fn focus_workspace_work(state: &mut State, workspace_id: Option<i32>) -> Option<()> {
     //no new history if no change
     if let Some(fws) = state.focus_manager.workspace(&state.workspaces) {
         if fws.id == workspace_id {
@@ -169,10 +169,7 @@ fn focus_workspace_work<C: Config>(state: &mut State<C>, workspace_id: Option<i3
     state.focus_manager.workspace_history.push_front(index);
     Some(())
 }
-fn focus_window_by_handle_work<C: Config>(
-    state: &mut State<C>,
-    handle: &WindowHandle,
-) -> Option<Window> {
+fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Option<Window> {
     //Docks don't want to get focus. If they do weird things happen. They don't get events...
     //Do the focus, Add the action to the list of action
     let found: &Window = state.windows.iter().find(|w| &w.handle == handle)?;
@@ -199,7 +196,7 @@ fn focus_window_by_handle_work<C: Config>(
     Some(found.clone())
 }
 
-fn focus_closest_window<C: Config>(state: &mut State<C>, x: i32, y: i32) -> bool {
+fn focus_closest_window(state: &mut State, x: i32, y: i32) -> bool {
     let ws = match state.workspaces.iter().find(|ws| ws.contains_point(x, y)) {
         Some(ws) => ws,
         None => return false,
@@ -226,7 +223,8 @@ fn distance(window: &Window, x: i32, y: i32) -> i32 {
     (xs + ys).sqrt().abs().floor() as i32
 }
 
-fn focus_tag_work<C: Config>(state: &mut State<C>, tag: &str) -> Option<()> {
+// TODO move all functions starting with state to impl State
+fn focus_tag_work(state: &mut State, tag: &str) -> Option<()> {
     //no new history if no change
     if let Some(t) = state.focus_manager.tag(0) {
         if t == tag {
@@ -249,33 +247,35 @@ mod tests {
     #[test]
     fn focusing_a_workspace_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        let expected = state.workspaces[0].clone();
-        state.focus_workspace(&expected);
-        let actual = state.focus_manager.workspace(&state.workspaces).unwrap();
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        let expected = manager.state.workspaces[0].clone();
+        manager.state.focus_workspace(&expected);
+        let actual = manager
+            .state
+            .focus_manager
+            .workspace(&manager.state.workspaces)
+            .unwrap();
         assert_eq!(Some(0), actual.id);
     }
 
     #[test]
     fn focusing_the_same_workspace_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        let ws = state.workspaces[0].clone();
-        state.focus_workspace(&ws);
-        let start_length = state.focus_manager.workspace_history.len();
-        state.focus_workspace(&ws);
-        let end_length = state.focus_manager.workspace_history.len();
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        let ws = manager.state.workspaces[0].clone();
+        manager.state.focus_workspace(&ws);
+        let start_length = manager.state.focus_manager.workspace_history.len();
+        manager.state.focus_workspace(&ws);
+        let end_length = manager.state.focus_manager.workspace_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
 
     #[test]
     fn focusing_a_window_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        manager.state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn focusing_the_same_window_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        manager.state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let window = Window::new(WindowHandle::MockHandle(1), None, None);
         manager.window_created_handler(window.clone(), -1, -1);
         manager.state.focus_window(&window.handle);
@@ -314,35 +314,36 @@ mod tests {
     #[test]
     fn focusing_a_tag_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let expected = "Bla".to_owned();
-        state.focus_tag(&expected);
-        let actual = state.focus_manager.tag(0).unwrap();
+        manager.state.focus_tag(&expected);
+        let actual = manager.state.focus_manager.tag(0).unwrap();
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn focusing_the_same_tag_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let tag = "Bla".to_owned();
-        state.focus_tag(&tag);
-        let start_length = state.focus_manager.tag_history.len();
-        state.focus_tag(&tag);
-        let end_length = state.focus_manager.tag_history.len();
+        manager.state.focus_tag(&tag);
+        let start_length = manager.state.focus_manager.tag_history.len();
+        manager.state.focus_tag(&tag);
+        let end_length = manager.state.focus_manager.tag_history.len();
         assert_eq!(start_length, end_length, "expected no new history event");
     }
 
     #[test]
     fn focusing_a_tag_should_focus_its_workspace() {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        state.focus_tag(&"1".to_owned());
-        let actual = state.focus_manager.workspace(&state.workspaces).unwrap();
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.state.focus_tag(&"1".to_owned());
+        let actual = manager
+            .state
+            .focus_manager
+            .workspace(&manager.state.workspaces)
+            .unwrap();
         let expected = Some(0);
         assert_eq!(actual.id, expected);
     }
@@ -350,58 +351,59 @@ mod tests {
     #[test]
     fn focusing_a_workspace_should_focus_its_tag() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        let ws = state.workspaces[1].clone();
-        state.focus_workspace(&ws);
-        let actual = state.focus_manager.tag(0).unwrap();
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        let ws = manager.state.workspaces[1].clone();
+        manager.state.focus_workspace(&ws);
+        let actual = manager.state.focus_manager.tag(0).unwrap();
         assert_eq!("2", actual);
     }
 
     #[test]
     fn focusing_a_window_should_focus_its_tag() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2");
-        state.windows.push(window.clone());
-        state.focus_window(&window.handle);
-        let actual = state.focus_manager.tag(0).unwrap();
+        manager.state.windows.push(window.clone());
+        manager.state.focus_window(&window.handle);
+        let actual = manager.state.focus_manager.tag(0).unwrap();
         assert_eq!("2", actual);
     }
 
     #[test]
     fn focusing_a_window_should_focus_workspace() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("2");
-        state.windows.push(window.clone());
-        state.focus_window(&window.handle);
-        let actual = state.focus_manager.workspace(&state.workspaces).unwrap().id;
-        let expected = state.workspaces[1].id;
+        manager.state.windows.push(window.clone());
+        manager.state.focus_window(&window.handle);
+        let actual = manager
+            .state
+            .focus_manager
+            .workspace(&manager.state.workspaces)
+            .unwrap()
+            .id;
+        let expected = manager.state.workspaces[1].id;
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn focusing_an_empty_tag_should_unfocus_any_focused_window() {
         let mut manager = Manager::new_test(vec![]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag("1");
-        state.windows.push(window.clone());
-        state.focus_window(&window.handle);
-        state.focus_tag("2");
-        let focused = state.focus_manager.window(&state.windows);
+        manager.state.windows.push(window.clone());
+        manager.state.focus_window(&window.handle);
+        manager.state.focus_tag("2");
+        let focused = manager.state.focus_manager.window(&manager.state.windows);
         assert!(focused.is_none());
     }
 }

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -1,8 +1,6 @@
-#![allow(clippy::wildcard_imports)]
-use super::*;
 use crate::state::State;
 
-impl<C: Config> State<C> {
+impl State {
     pub fn goto_tag_handler(&mut self, tag_num: usize) -> Option<bool> {
         if tag_num > self.tags.len() || tag_num < 1 {
             return Some(false);
@@ -35,17 +33,16 @@ impl<C: Config> State<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::models::Screen;
     use crate::Manager;
 
     #[test]
     fn going_to_a_workspace_that_is_already_visible_should_not_duplicate_the_workspace() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        state.goto_tag_handler(1);
-        assert_eq!(state.workspaces[0].tags, ["2".to_owned()]);
-        assert_eq!(state.workspaces[1].tags, ["1".to_owned()]);
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        manager.state.goto_tag_handler(1);
+        assert_eq!(manager.state.workspaces[0].tags, ["2".to_owned()]);
+        assert_eq!(manager.state.workspaces[1].tags, ["1".to_owned()]);
     }
 }

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -1,6 +1,7 @@
 use crate::models::Mode;
 use crate::models::WindowHandle;
 use crate::state::State;
+use crate::utils;
 use crate::utils::xkeysym_lookup::Button;
 use crate::utils::xkeysym_lookup::ModMask;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
@@ -12,8 +13,8 @@ impl State {
         modmask: ModMask,
         button: Button,
         handle: WindowHandle,
-        modifier: ModMask,
     ) -> bool {
+        let modifier = utils::xkeysym_lookup::into_mod(&self.mousekey);
         //look through the config and build a command if its defined in the config
         let act = self.build_action(modmask, button, handle, modifier);
         if let Some(act) = act {

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -1,26 +1,27 @@
-use super::{Screen, Workspace};
+use super::{Manager, Screen, Workspace};
 use crate::config::Config;
+use crate::display_servers::DisplayServer;
 use crate::models::Tag;
-use crate::state::State;
 
-impl<C: Config> State<C> {
+impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Process a collection of events, and apply them changes to a manager.
     ///
     /// Returns `true` if changes need to be rendered.
     pub fn screen_create_handler(&mut self, screen: Screen) -> bool {
-        let tag_index = self.workspaces.len();
+        let tag_index = self.state.workspaces.len();
 
         let mut workspace = Workspace::new(
             screen.wsid,
             screen.bbox,
-            self.layout_manager.new_layout(),
+            self.state.layout_manager.new_layout(),
             screen
                 .max_window_width
-                .or_else(|| self.config.max_window_width()),
+                .or_else(|| self.state.max_window_width),
         );
         if workspace.id.is_none() {
             workspace.id = Some(
-                self.workspaces
+                self.state
+                    .workspaces
                     .iter()
                     .map(|ws| ws.id.unwrap_or(-1))
                     .max()
@@ -28,24 +29,25 @@ impl<C: Config> State<C> {
                     + 1,
             );
         }
-        if workspace.id.unwrap_or(0) as usize >= self.tags.len() {
+        if workspace.id.unwrap_or(0) as usize >= self.state.tags.len() {
             dbg!("Workspace ID needs to be less than or equal to the number of tags available.");
         }
-        workspace.update_for_theme(&self.config);
+        workspace.reload_config(&self.config);
         //make sure are enough tags for this new screen
-        if self.tags.len() <= tag_index {
+        if self.state.tags.len() <= tag_index {
             let id = (tag_index + 1).to_string();
-            self.tags
-                .push(Tag::new(&id, self.layout_manager.new_layout()));
+            self.state
+                .tags
+                .push(Tag::new(&id, self.state.layout_manager.new_layout()));
         }
-        let next_tag = self.tags[tag_index].clone();
-        self.focus_workspace(&workspace);
-        self.focus_tag(&next_tag.id);
+        let next_tag = self.state.tags[tag_index].clone();
+        self.state.focus_workspace(&workspace);
+        self.state.focus_tag(&next_tag.id);
         workspace.show_tag(&next_tag);
-        self.workspaces.push(workspace.clone());
-        self.workspaces.sort_by(|a, b| a.id.cmp(&b.id));
-        self.screens.push(screen);
-        self.focus_workspace(&workspace);
+        self.state.workspaces.push(workspace.clone());
+        self.state.workspaces.sort_by(|a, b| a.id.cmp(&b.id));
+        self.state.screens.push(screen);
+        self.state.focus_workspace(&workspace);
         false
     }
 }
@@ -58,11 +60,10 @@ mod tests {
     #[test]
     fn creating_two_screens_should_tag_them_with_first_and_second_tags() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        assert!(state.workspaces[0].has_tag("1"));
-        assert!(state.workspaces[1].has_tag("2"));
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        assert!(manager.state.workspaces[0].has_tag("1"));
+        assert!(manager.state.workspaces[1].has_tag("2"));
     }
 
     #[test]
@@ -72,10 +73,9 @@ mod tests {
             "console".to_string(),
             "code".to_string(),
         ]);
-        let state = &mut manager.state;
-        state.screen_create_handler(Screen::default());
-        state.screen_create_handler(Screen::default());
-        assert!(state.workspaces[0].has_tag("web"));
-        assert!(state.workspaces[1].has_tag("console"));
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+        assert!(manager.state.workspaces[0].has_tag("web"));
+        assert!(manager.state.workspaces[1].has_tag("console"));
     }
 }

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -32,7 +32,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         if workspace.id.unwrap_or(0) as usize >= self.state.tags.len() {
             dbg!("Workspace ID needs to be less than or equal to the number of tags available.");
         }
-        workspace.reload_config(&self.config);
+        workspace.load_config(&self.config);
         //make sure are enough tags for this new screen
         if self.state.tags.len() <= tag_index {
             let id = (tag_index + 1).to_string();

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -14,9 +14,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             screen.wsid,
             screen.bbox,
             self.state.layout_manager.new_layout(),
-            screen
-                .max_window_width
-                .or_else(|| self.state.max_window_width),
+            screen.max_window_width.or(self.state.max_window_width),
         );
         if workspace.id.is_none() {
             workspace.id = Some(

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -30,7 +30,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             &mut is_first,
             &mut on_same_tag,
         );
-        window.reload_config(&self.config);
+        window.load_config(&self.config);
         self.state.insert_window(&mut window, layout);
 
         let follow_mouse = self.state.focus_manager.focus_new_windows

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -1,4 +1,3 @@
-use crate::config::Config;
 use crate::layouts::Layout;
 use crate::state::State;
 use serde::{Deserialize, Serialize};
@@ -104,8 +103,8 @@ fn viewport_into_display_workspace(
     }
 }
 
-impl<C: Config> From<&State<C>> for ManagerState {
-    fn from(state: &State<C>) -> Self {
+impl From<&State> for ManagerState {
+    fn from(state: &State) -> Self {
         let mut viewports: Vec<Viewport> = vec![];
         let mut tags_len = state.tags.len();
         tags_len = if tags_len == 0 { 0 } else { tags_len - 1 };

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -7,7 +7,8 @@ use std::sync::{atomic::AtomicBool, Arc};
 /// Maintains current program state.
 #[derive(Debug)]
 pub struct Manager<C, SERVER> {
-    pub state: State<C>,
+    pub state: State,
+    pub config: C,
 
     pub(crate) children: Children,
     pub(crate) reap_requested: Arc<AtomicBool>,
@@ -21,17 +22,18 @@ where
     SERVER: DisplayServer,
 {
     pub fn new(config: C) -> Self {
-        let display_server = SERVER::new(&config);
-
         Self {
-            state: State::new(config),
+            display_server: SERVER::new(&config),
+            state: State::new(&config),
+            config,
             children: Default::default(),
             reap_requested: Default::default(),
             reload_requested: false,
-            display_server,
         }
     }
+}
 
+impl<C, SERVER> Manager<C, SERVER> {
     pub fn register_child_hook(&self) {
         crate::child_process::register_child_hook(self.reap_requested.clone());
     }
@@ -39,6 +41,16 @@ where
     /// Soft reload the worker without saving state.
     pub fn hard_reload(&mut self) {
         self.reload_requested = true;
+    }
+}
+
+impl<C, SERVER> Manager<C, SERVER>
+where
+    C: Config,
+{
+    pub fn reload_config(&mut self) -> bool {
+        self.state.reload_config(&self.config);
+        true
     }
 }
 

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -48,8 +48,9 @@ impl<C, SERVER> Manager<C, SERVER>
 where
     C: Config,
 {
+    /// Reload the configuration of the running [`Manager`].
     pub fn reload_config(&mut self) -> bool {
-        self.state.reload_config(&self.config);
+        self.state.load_config(&self.config);
         true
     }
 }

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -74,7 +74,7 @@ impl Window {
         }
     }
 
-    pub(crate) fn reload_config(&mut self, config: &impl Config) {
+    pub(crate) fn load_config(&mut self, config: &impl Config) {
         if self.type_ == WindowType::Normal {
             self.margin = config.margin();
             self.border = config.border_width();

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -74,7 +74,7 @@ impl Window {
         }
     }
 
-    pub fn update_for_theme(&mut self, config: &impl Config) {
+    pub(crate) fn reload_config(&mut self, config: &impl Config) {
         if self.type_ == WindowType::Normal {
             self.margin = config.margin();
             self.border = config.border_width();

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -77,7 +77,7 @@ impl Workspace {
         }
     }
 
-    pub fn reload_config(&mut self, config: &impl Config) {
+    pub fn load_config(&mut self, config: &impl Config) {
         self.margin = config.workspace_margin().unwrap_or_else(|| Margins::new(0));
         self.gutters = self.get_gutters_for_theme(config);
     }

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -77,7 +77,7 @@ impl Workspace {
         }
     }
 
-    pub fn update_for_theme(&mut self, config: &impl Config) {
+    pub fn reload_config(&mut self, config: &impl Config) {
         self.margin = config.workspace_margin().unwrap_or_else(|| Margins::new(0));
         self.gutters = self.get_gutters_for_theme(config);
     }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -181,7 +181,6 @@ impl State {
         }
     }
 
-    // TODO probably the state should be replace immutably instead of mutated
     /// Apply saved state to a running manager.
     pub fn restore_state(&mut self, state: &State) {
         // restore workspaces

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -170,14 +170,14 @@ impl State {
             });
     }
 
-    pub(crate) fn reload_config(&mut self, config: &impl Config) {
+    pub(crate) fn load_config(&mut self, config: &impl Config) {
         self.mousekey = config.mousekey();
         self.max_window_width = config.max_window_width();
         for win in &mut self.windows {
-            win.reload_config(config);
+            win.load_config(config);
         }
         for ws in &mut self.workspaces {
-            ws.reload_config(config);
+            ws.load_config(config);
         }
     }
 

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -3,6 +3,7 @@
 use crate::config::{Config, ScratchPad};
 use crate::layouts::Layout;
 use crate::models::Screen;
+use crate::models::Size;
 use crate::models::Tag;
 use crate::models::Window;
 use crate::models::Workspace;
@@ -14,15 +15,13 @@ use std::collections::{HashMap, VecDeque};
 use std::os::raw::c_ulong;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct State<C> {
+pub struct State {
     pub screens: Vec<Screen>,
     pub windows: Vec<Window>,
     pub workspaces: Vec<Workspace>,
     pub focus_manager: FocusManager,
     pub layout_manager: LayoutManager,
     pub mode: Mode,
-    // TODO should this really be saved in the state?
-    pub config: C,
     pub layouts: Vec<Layout>,
     pub scratchpads: Vec<ScratchPad>,
     pub active_scratchpads: HashMap<String, Option<u32>>,
@@ -31,14 +30,14 @@ pub struct State<C> {
     //this is used to limit framerate when resizing/moving windows
     pub frame_rate_limitor: c_ulong,
     pub tags: Vec<Tag>, //list of all known tags
+    pub disable_current_tag_swap: bool,
+    pub mousekey: String,
+    pub max_window_width: Option<Size>,
 }
 
-impl<C> State<C>
-where
-    C: Config,
-{
-    pub(crate) fn new(config: C) -> Self {
-        let layout_manager = LayoutManager::new(&config);
+impl State {
+    pub(crate) fn new(config: &impl Config) -> Self {
+        let layout_manager = LayoutManager::new(config);
         let mut tags: Vec<Tag> = config
             .create_list_of_tags()
             .iter()
@@ -51,7 +50,7 @@ where
         });
 
         Self {
-            focus_manager: FocusManager::new(&config),
+            focus_manager: FocusManager::new(config),
             layout_manager,
             scratchpads: config.create_list_of_scratchpads(),
             layouts: config.layouts(),
@@ -63,7 +62,9 @@ where
             actions: Default::default(),
             frame_rate_limitor: Default::default(),
             tags,
-            config,
+            disable_current_tag_swap: config.disable_current_tag_swap(),
+            max_window_width: config.max_window_width(),
+            mousekey: config.mousekey(),
         }
     }
 
@@ -169,18 +170,20 @@ where
             });
     }
 
-    pub fn update_for_theme(&mut self) -> bool {
+    pub(crate) fn reload_config(&mut self, config: &impl Config) {
+        self.mousekey = config.mousekey();
+        self.max_window_width = config.max_window_width();
         for win in &mut self.windows {
-            win.update_for_theme(&self.config);
+            win.reload_config(config);
         }
         for ws in &mut self.workspaces {
-            ws.update_for_theme(&self.config);
+            ws.reload_config(config);
         }
-        true
     }
 
+    // TODO probably the state should be replace immutably instead of mutated
     /// Apply saved state to a running manager.
-    pub fn restore_state(&mut self, state: &State<C>) {
+    pub fn restore_state(&mut self, state: &State) {
         // restore workspaces
         for workspace in &mut self.workspaces {
             if let Some(old_workspace) = state.workspaces.iter().find(|w| w.id == workspace.id) {

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -1,4 +1,3 @@
-use crate::config::Config;
 use crate::errors::{LeftError, Result};
 use crate::models::dto::ManagerState;
 use std::path::PathBuf;
@@ -56,10 +55,7 @@ impl StateSocket {
     /// # Errors
     /// Will return Err if a mut ref to the peer is unavailable.
     /// Will return error if state cannot be serialized
-    pub async fn write_manager_state<C: Config>(
-        &mut self,
-        raw_state: &crate::state::State<C>,
-    ) -> Result<()> {
+    pub async fn write_manager_state(&mut self, raw_state: &crate::state::State) -> Result<()> {
         if self.listener.is_some() {
             let state: ManagerState = raw_state.into();
             let mut json = serde_json::to_string(&state)?;

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -7,6 +7,7 @@ use leftwm_core::{
     layouts::{Layout, LAYOUTS},
     models::{FocusBehaviour, Gutter, LayoutMode, Margins, Size},
     state::State,
+    Manager,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -298,16 +299,16 @@ impl leftwm_core::Config for Config {
             .expect("we created it in the Default impl; qed")
     }
 
-    fn workspaces(&self) -> Option<&[Workspace]> {
-        self.workspaces.as_deref()
+    fn workspaces(&self) -> Option<Vec<Workspace>> {
+        self.workspaces.clone()
     }
 
     fn focus_behaviour(&self) -> FocusBehaviour {
         self.focus_behaviour
     }
 
-    fn mousekey(&self) -> &str {
-        &self.mousekey
+    fn mousekey(&self) -> String {
+        self.mousekey.clone()
     }
 
     fn disable_current_tag_swap(&self) -> bool {
@@ -333,20 +334,20 @@ impl leftwm_core::Config for Config {
         self.focus_new_windows
     }
 
-    fn command_handler(command: &str, state: &mut State<Self>) -> bool {
+    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool {
         if let Some((command, value)) = command.split_once(' ') {
             match command {
                 "LoadTheme" => {
                     if let Some(absolute) = absolute_path(value.trim()) {
-                        state.config.theme_setting.load(absolute);
+                        manager.config.theme_setting.load(absolute);
                     } else {
                         log::warn!("Path submitted does not exist.");
                     }
-                    return state.update_for_theme();
+                    return manager.reload_config();
                 }
                 "UnloadTheme" => {
-                    state.config.theme_setting = Default::default();
-                    return state.update_for_theme();
+                    manager.config.theme_setting = Default::default();
+                    return manager.reload_config();
                 }
                 _ => {
                     log::warn!("Command not recognized: {}", command);
@@ -388,16 +389,16 @@ impl leftwm_core::Config for Config {
         self.theme_setting.gutter.clone()
     }
 
-    fn default_border_color(&self) -> &str {
-        &self.theme_setting.default_border_color
+    fn default_border_color(&self) -> String {
+        self.theme_setting.default_border_color.clone()
     }
 
-    fn floating_border_color(&self) -> &str {
-        &self.theme_setting.floating_border_color
+    fn floating_border_color(&self) -> String {
+        self.theme_setting.floating_border_color.clone()
     }
 
-    fn focused_border_color(&self) -> &str {
-        &self.theme_setting.focused_border_color
+    fn focused_border_color(&self) -> String {
+        self.theme_setting.focused_border_color.clone()
     }
 
     fn on_new_window_cmd(&self) -> Option<String> {
@@ -412,8 +413,8 @@ impl leftwm_core::Config for Config {
         self.max_window_width
     }
 
-    fn save_state(state: &State<Self>) {
-        let path = state.config.state_file();
+    fn save_state(&self, state: &State) {
+        let path = self.state_file();
         let state_file = match File::create(&path) {
             Ok(file) => file,
             Err(err) => {
@@ -426,8 +427,8 @@ impl leftwm_core::Config for Config {
         }
     }
 
-    fn load_state(state: &mut State<Self>) {
-        let path = state.config.state_file().to_owned();
+    fn load_state(&self, state: &mut State) {
+        let path = self.state_file().to_owned();
         match File::open(&path) {
             Ok(file) => {
                 match serde_json::from_reader(file) {


### PR DESCRIPTION
This PR is an attempt to help doing "soft" reloading.

If I understand it properly. The current reloading system is to hard reload because soft reloading does not work properly for now. In This PR I will try to enumerate the issues and fix them.

### Checklist
- [x] Use owned type in `Config` trait: this change will allow the state to get owned type and not depend on a configuration to be loaded. My idea is that if the configuration changes but the state still use an old configuration, we should load only the state parameters for consistency.
- [x] Move `Config` from `State` to `Manager`: I wasn't sure why the config field was in the state but then I realized it is because it was part of the state. So to solve the previous point, I'm moving the `Config` to the `Manager`. `Manager` now has a `reload_config()` that takes no argument and spread the new configuration across the different states of the application
- [x] Reload config in XWrap should work now: I noticed a few lines of code were missing for it to work. I have not tested this yet but my hope is to fix it.
- [x] `screen_create_handler` is back to `Manager`: it made sense to move it to the State when config was there but now that I changed it it needs to go back to the Manager to be able to access the config. I did not touch the other functions that were moved to the state as I believe they were good :+1: 
- [x] Because `State` does not have the `Config` field, it now loses its generic... which is nice

### Future
- [ ] ~~I believe there is a startup script for theme that should be re-started when doing the reload_config somehow... maybe keeping track of widget processes... it does not sound trivial~~
