### PR TITLE
Rename branch master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ simple black screen on login.  For a more customized look, install a theme.
 1.  Now if you want to get the newest version of leftwm run this command from your build directory:  
 
 ```bash
-git pull origin master
+git pull origin main
 ```
 
 2. Build leftwm
@@ -287,7 +287,7 @@ LeftWM comes packaged with a couple of default themes. There is also a
 For more information about themes check out our [theme guide][theme-guide] or the [wiki].
 
 [community-repo]: https://github.com/leftwm/leftwm-community-themes
-[theme-guide]: https://github.com/leftwm/leftwm/tree/master/themes
+[theme-guide]: https://github.com/leftwm/leftwm/tree/main/themes
 [wiki]: https://github.com/leftwm/leftwm/wiki/Themes
 
 # Configuring


### PR DESCRIPTION
I thought we should rename our main branch to `main` instead of `master`.

Every new projects on GitHub now uses "main" by default and to be honest it feels weird now when I read "master".

More on the subject: https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main

After merging this you need to go to the settings of the project and rename the branch there too and that's all.

Locally though, everybody who don't want to re-clone the project needs to update the default branch using this command:

```
git remote set-head origin --auto
```

It's `origin` if the remote is origin but it can be `upstream` depending on your local set up:

```
git remote set-head upstream --auto
```

**Note:** re-cloning the repo will default to main and no action is needed.