### PR TITLE
relative_find helper: fix bug, add tests, add docs, remove duplicate code

### DIFF
--- a/leftwm-core/src/utils/helpers.rs
+++ b/leftwm-core/src/utils/helpers.rs
@@ -152,7 +152,7 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn find_relative_index_should_work_both_ways() {
+    fn relative_find_should_work_both_ways() {
         let list = vec!["hello", "world", "foo", "bar"];
         let result = relative_find(&list, |&e| e == "hello", 2, false);
         assert_eq!(result, Some(&"foo"));
@@ -161,14 +161,14 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn find_relative_with_inexistent_reference_must_return_none() {
+    fn relative_find_with_inexistent_reference_must_return_none() {
         let list = vec!["hello", "world", "foo", "bar"];
         let result = relative_find(&list, |&e| e == "inexistent", 2, false);
         assert_eq!(result, None);
     }
 
     #[test]
-    fn find_relative_index_should_be_able_to_loop() {
+    fn relative_find_should_be_able_to_loop() {
         let list = vec!["hello", "world", "foo", "bar"];
         let result = relative_find(&list, |&e| e == "hello", 4, true);
         assert_eq!(result, Some(&"hello"));
@@ -179,7 +179,7 @@ pub(crate) mod test {
     }
 
     #[test]
-    fn find_relative_index_loop_can_be_disabled() {
+    fn relative_find_loop_can_be_disabled() {
         let list = vec!["hello", "world", "foo", "bar"];
         let result = relative_find(&list, |&e| e == "hello", 9, false);
         assert_eq!(result, None);


### PR DESCRIPTION
I saw that the `relative_find` logic was implemented redundantly in `focus_tag_change`. The method now also uses the pre-existing helper method.

After looking at the code, I realized that it had some bugs, for example: on a list of length `1` the only element in the list was always returned, even if `should_loop` was set to false. I've re-implemented the method and added tests to verify the implementation. Please let me know if you think a test-case is missing.