### PR TITLE
fix #552

### DIFF
--- a/leftwm-core/src/display_event.rs
+++ b/leftwm-core/src/display_event.rs
@@ -9,14 +9,14 @@ use crate::Command;
 pub enum DisplayEvent {
     Movement(WindowHandle, i32, i32),
     KeyCombo(ModMask, XKeysym),
-    KeyGrabReload, // Reloads keys for when keyboard changes
+    KeyGrabReload, // Reloads keys for when keyboard changes.
     MouseCombo(ModMask, Button, WindowHandle),
     WindowCreate(Window, i32, i32),
     WindowChange(WindowChange),
     WindowDestroy(WindowHandle),
     MouseEnteredWindow(WindowHandle),
-    VerifyFocusedAt(WindowHandle), //Request focus validation at this point
-    MoveFocusTo(i32, i32),         //Focus the nearest window to this point
+    VerifyFocusedAt(WindowHandle), // Request focus validation for this window.
+    MoveFocusTo(i32, i32),         // Focus the nearest window to this point.
     MoveWindow(WindowHandle, c_ulong, i32, i32),
     ResizeWindow(WindowHandle, c_ulong, i32, i32),
     ScreenCreate(Screen),

--- a/leftwm-core/src/display_event.rs
+++ b/leftwm-core/src/display_event.rs
@@ -15,8 +15,8 @@ pub enum DisplayEvent {
     WindowChange(WindowChange),
     WindowDestroy(WindowHandle),
     MouseEnteredWindow(WindowHandle),
-    VerifyFocusedAt(i32, i32), //Request focus validation at this point
-    MoveFocusTo(i32, i32),     //Focus the nearest window to this point
+    VerifyFocusedAt(WindowHandle), //Request focus validation at this point
+    MoveFocusTo(i32, i32),         //Focus the nearest window to this point
     MoveWindow(WindowHandle, c_ulong, i32, i32),
     ResizeWindow(WindowHandle, c_ulong, i32, i32),
     ScreenCreate(Screen),

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -26,7 +26,7 @@ impl DisplayServer for MockDisplayServer {
         unimplemented!()
     }
 
-    fn verify_focused_window(&self) -> Vec<DisplayEvent> {
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
         unimplemented!()
     }
 }

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -33,5 +33,5 @@ pub trait DisplayServer {
 
     fn flush(&self);
 
-    fn verify_focused_window(&self) -> Vec<DisplayEvent>;
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent>;
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -133,9 +133,7 @@ fn from_enter_notify(xw: &XWrap, raw_event: xlib::XEvent) -> Option<DisplayEvent
     };
     let event = xlib::XEnterWindowEvent::from(raw_event);
     let crossing = xlib::XCrossingEvent::from(raw_event);
-    if (crossing.mode != xlib::NotifyNormal || crossing.detail == xlib::NotifyInferior)
-        && crossing.window != xw.get_default_root()
-    {
+    if crossing.detail == xlib::NotifyInferior && crossing.window != xw.get_default_root() {
         return None;
     }
     let h = WindowHandle::XlibHandle(event.window);

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -240,8 +240,10 @@ impl DisplayServer for XlibDisplayServer {
         self.xw.flush();
     }
 
-    fn verify_focused_window(&self) -> Vec<DisplayEvent> {
-        self.verify_focused_window_work().unwrap_or_default()
+    /// Creates a verify focus event for the cursors current window.
+    fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
+        let handle = self.xw.get_cursor_window().ok()?;
+        Some(DisplayEvent::VerifyFocusedAt(handle))
     }
 }
 
@@ -274,11 +276,6 @@ impl XlibDisplayServer {
         });
 
         events
-    }
-
-    fn verify_focused_window_work(&self) -> Option<Vec<DisplayEvent>> {
-        let handle = self.xw.get_cursor_window().ok()?;
-        Some(vec![DisplayEvent::VerifyFocusedAt(handle)])
     }
 
     fn find_all_windows(&self) -> Vec<Window> {

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -277,8 +277,8 @@ impl XlibDisplayServer {
     }
 
     fn verify_focused_window_work(&self) -> Option<Vec<DisplayEvent>> {
-        let point = self.xw.get_cursor_point().ok()?;
-        Some(vec![DisplayEvent::VerifyFocusedAt(point.0, point.1)])
+        let handle = self.xw.get_cursor_window().ok()?;
+        Some(vec![DisplayEvent::VerifyFocusedAt(handle)])
     }
 
     fn find_all_windows(&self) -> Vec<Window> {

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -32,7 +32,7 @@ const NORMAL_STATE: WindowStateConst = 1;
 // const ICONIC_STATE: WindowStateConst = 2;
 const MAX_PROPERTY_VALUE_LEN: c_long = 4096;
 
-const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask;
+const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask | xlib::ButtonMotionMask;
 const MOUSEMASK: c_long = BUTTONMASK | xlib::PointerMotionMask;
 
 pub struct Colors {
@@ -210,6 +210,8 @@ impl XWrap {
         let root_event_mask: c_long = xlib::SubstructureRedirectMask
             | xlib::SubstructureNotifyMask
             | xlib::ButtonPressMask
+            | xlib::ButtonReleaseMask
+            | xlib::ButtonMotionMask
             | xlib::PointerMotionMask
             | xlib::EnterWindowMask
             | xlib::LeaveWindowMask

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -32,7 +32,7 @@ const NORMAL_STATE: WindowStateConst = 1;
 // const ICONIC_STATE: WindowStateConst = 2;
 const MAX_PROPERTY_VALUE_LEN: c_long = 4096;
 
-const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask | xlib::ButtonMotionMask;
+const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask;
 const MOUSEMASK: c_long = BUTTONMASK | xlib::PointerMotionMask;
 
 pub struct Colors {
@@ -210,8 +210,6 @@ impl XWrap {
         let root_event_mask: c_long = xlib::SubstructureRedirectMask
             | xlib::SubstructureNotifyMask
             | xlib::ButtonPressMask
-            | xlib::ButtonReleaseMask
-            | xlib::ButtonMotionMask
             | xlib::PointerMotionMask
             | xlib::EnterWindowMask
             | xlib::LeaveWindowMask

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -36,11 +36,14 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     event_buffer.append(&mut self.display_server.get_next_events());
                     continue;
                 }
-                //Once in a blue moon we miss the focus event,
-                //This is to double check that we know which window is currently focused
-                _ = timeout(100), if event_buffer.is_empty() && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy => {
-                    let mut focus_event = self.display_server.verify_focused_window();
-                    event_buffer.append(&mut focus_event);
+                // When a mouse button is pressed enter/motion notifies are blocked and only appear
+                // once the button is released. This is to double check that we know which window
+                // is currently focused.
+                _ = timeout(100), if event_buffer.is_empty()
+                    && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy => {
+                    if let Some(verify_event) = self.display_server.generate_verify_focus_event() {
+                        event_buffer.push(verify_event);
+                    }
                     continue;
                 }
                 Some(cmd) = command_pipe.read_command(), if event_buffer.is_empty() => {

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -26,8 +26,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::MoveFocusTo(x, y) => self.state.move_focus_to_point(x, y),
 
-            //This is a request to validate focus. Double check that we are focused the correct
-            //thing under this point.
+            // This is a request to validate focus. Double check that we are focused on the correct
+            // window.
             DisplayEvent::VerifyFocusedAt(handle) => match self.state.focus_manager.behaviour {
                 FocusBehaviour::Sloppy => return self.state.validate_focus_at(&handle),
                 _ => return false,

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -28,8 +28,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             //This is a request to validate focus. Double check that we are focused the correct
             //thing under this point.
-            DisplayEvent::VerifyFocusedAt(x, y) => match self.state.focus_manager.behaviour {
-                FocusBehaviour::Sloppy => return self.state.validate_focus_at(x, y),
+            DisplayEvent::VerifyFocusedAt(handle) => match self.state.focus_manager.behaviour {
+                FocusBehaviour::Sloppy => return self.state.validate_focus_at(&handle),
                 _ => return false,
             },
 

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -107,7 +107,7 @@ impl State {
         true
     }
 
-    pub fn validate_focus_at(&mut self, x: i32, y: i32) -> bool {
+    pub fn validate_focus_at(&mut self, handle: &WindowHandle) -> bool {
         let current = match self.focus_manager.window(&self.windows) {
             Some(w) => w,
             None => return false,
@@ -117,7 +117,7 @@ impl State {
             .windows
             .iter()
             .filter(|x| x.can_focus())
-            .find(|w| w.contains_point(x, y))
+            .find(|w| &w.handle == handle)
             .cloned();
         match found {
             Some(window) => {

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -108,28 +108,21 @@ impl State {
     }
 
     pub fn validate_focus_at(&mut self, handle: &WindowHandle) -> bool {
-        let current = match self.focus_manager.window(&self.windows) {
-            Some(w) => w,
-            None => return false,
-        };
-        //only look at windows we can focus
-        let found: Option<Window> = self
+        // If the window is already focused do nothing.
+        if let Some(current) = self.focus_manager.window(&self.windows) {
+            if &current.handle == handle {
+                return false;
+            }
+        }
+        // Focus the window only if it is also focusable.
+        if self
             .windows
             .iter()
-            .filter(|x| x.can_focus())
-            .find(|w| &w.handle == handle)
-            .cloned();
-        match found {
-            Some(window) => {
-                //only do the focus if we need to
-                let handle = window.handle;
-                if current.handle == handle {
-                    return false;
-                }
-                self.focus_window(&handle)
-            }
-            None => false,
+            .any(|w| w.can_focus() && &w.handle == handle)
+        {
+            return self.focus_window(handle);
         }
+        false
     }
 
     pub fn move_focus_to_point(&mut self, x: i32, y: i32) -> bool {


### PR DESCRIPTION
Fixes #552. Instead of using the point we just use the window the cursor is reporting. Also changed it so the notify mode doesn't have to be normal (so it can be grab and ungrab), this eliminates half the reason window focus events get missed.

To add the reason I have found where focus events are missed are when a mouse button is pushed we don't receive any motion or enter notifies. So when you move the mouse to a window when holding a button the focus didnt change (this is without the validate focus), as the notify mode is classed as a grab. So allowing these events means the focus would update once the button is released (However this is probably unneeded with the updated validate focus)

Thanks!
ps I gonna add some comments tomorrow, have cant let hertg show me up :stuck_out_tongue_winking_eye: 