### PR TITLE
fix regression from #557, restore tag state on reload

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -285,7 +285,7 @@ fn swap_tags(state: &mut State) -> Option<bool> {
         state.update_static();
         state
             .layout_manager
-            .update_layouts(&mut state.workspaces, &mut state.tags.all());
+            .update_layouts(&mut state.workspaces, state.tags.all_mut());
 
         return Some(true);
     }

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -26,7 +26,7 @@ impl State {
         self.focus_tag(&tag_num);
         self.update_static();
         self.layout_manager
-            .update_layouts(&mut self.workspaces, &mut self.tags.all());
+            .update_layouts(&mut self.workspaces, self.tags.all_mut());
         Some(true)
     }
 }

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -58,7 +58,7 @@ impl LayoutManager {
     pub fn update_layouts(
         &self,
         workspaces: &mut Vec<Workspace>,
-        tags: &mut Vec<Tag>,
+        mut tags: Vec<&mut Tag>,
     ) -> Option<bool> {
         for workspace in workspaces {
             let tag = tags.iter_mut().find(|t| t.id == workspace.tags[0])?;

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -115,12 +115,23 @@ impl Tags {
         &self.normal
     }
 
-    /// Get all tags, including hidden ones.
-    /// The hidden tags are appended at the end of the list.
-    pub fn all(&self) -> Vec<Tag> {
-        let mut result: Vec<Tag> = vec![];
-        result.append(&mut self.normal.clone());
-        result.append(&mut self.hidden.clone());
+    /// Get a list of all tags, including hidden ones.
+    /// The hidden tags are at the end of the list.
+    pub fn all(&self) -> Vec<&Tag> {
+        //&self.normal.append(&self.hidden)
+        let mut result: Vec<&Tag> = vec![];
+        self.normal.iter().for_each(|tag| result.push(tag));
+        self.hidden.iter().for_each(|tag| result.push(tag));
+        result
+    }
+
+    /// Get a list of all tags as mutable, including hidden ones.
+    /// The hidden tags are at the end of the list
+    pub fn all_mut(&mut self) -> Vec<&mut Tag> {
+        //&self.normal.append(&self.hidden)
+        let mut result: Vec<&mut Tag> = vec![];
+        self.normal.iter_mut().for_each(|tag| result.push(tag));
+        self.hidden.iter_mut().for_each(|tag| result.push(tag));
         result
     }
 

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -151,8 +151,8 @@ impl State {
             }
         }
 
-        for tag in &mut self.tags.all() {
-            if let Some(old_tag) = state.tags.get(tag.id) {
+        for old_tag in state.tags.all() {
+            if let Some(tag) = self.tags.get_mut(old_tag.id) {
                 tag.hidden = old_tag.hidden;
                 tag.layout = old_tag.layout;
                 tag.layout_rotation = old_tag.layout_rotation;


### PR DESCRIPTION
Fixes a regression reported by aethan in #557.

The `all()` methods returned a clone of the tag-list, mutating it did therefore not affect the actual state.
I rewrote so `all()` returns actual borrowed values, rather than cloned ones and introduced `all_mut()` in case the tags should be mutable.

I'm not a 100% sure if that's the best way to do it, please let me know if you have any opinions on that.