### PR TITLE
Properly handle focus when window is destroyed / moved to another tag

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -212,6 +212,9 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
     manager.state.sort_windows();
     if let Some(new_handle) = new_handle {
         manager.state.focus_window(&new_handle);
+    } else {
+        let act = DisplayAction::Unfocus;
+        manager.state.actions.push_back(act);
     }
     Some(true)
 }


### PR DESCRIPTION
This PR fixes #564 by addressing the following issues:
1. In the sloppy behavior, when the focus window moves to another (out of sight) tag, it may still keep the focus
1. In any focus-behavior, when the last window on a workspace is moved to another (out of sight) tag, it keeps focus
1. When the only window on a workspace is destroyed, the focus is just re-applied to it instead of unfocusing all windows

The issues 2 and 3 may not be fixed properly with this PR alone, it  also requires the fixes in #565 to be present. 
> In detail: before #565 the `relative_find()` method would always return the single element in the list if the list is of size `1`. In case of the `get_next_or_previous()` method, this means that on a workspace with only one window, the helper method always returned the window that was provided as parameter, even though `should_loop` was set to false.

I haven't made any big changes in `get_next_or_previous()`, just named some variables more verbosely to what they represent and slightly changed the docs.