### PR TITLE
refactor window-snapping

### DIFF
--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -50,6 +50,16 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::ChangeToNormalMode => {
                 self.state.mode = Mode::Normal;
+
+                // every window that has `is_snapping` set to true, should be tiled 
+                // to the workspace it currently is displayed on.
+                let workspaces = &self.state.workspaces;
+                let _ = self.state.windows.iter_mut()
+                    .filter(|window| window.is_snapping)
+                    .for_each(|window| {
+                        window.snap_to_current_workspace(workspaces);
+                    });
+
                 //look through the config and build a command if its defined in the config
                 let act = DisplayAction::NormalMode;
                 self.state.actions.push_back(act);

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -51,10 +51,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::ChangeToNormalMode => {
                 self.state.mode = Mode::Normal;
 
-                // every window that has `is_snapping` set to true, should be tiled 
+                // every window that has `is_snapping` set to true, should be tiled
                 // to the workspace it currently is displayed on.
                 let workspaces = &self.state.workspaces;
-                let _ = self.state.windows.iter_mut()
+                self.state
+                    .windows
+                    .iter_mut()
                     .filter(|window| window.is_snapping)
                     .for_each(|window| {
                         window.snap_to_current_workspace(workspaces);

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -157,8 +157,37 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 }
 
 impl Window {
+
+    /// Snap the window to the workspace where it's currently positioned.
+    /// This will calculate the center coordinate where the window is currently displayed
+    /// and search for the workspace containing this coordinate.
+    /// 
+    /// Returns true if the window was tiled.
+    /// 
+    /// ## Arguments
+    /// * workspaces - All workspaces, required to find out on which the window is positioned
+    pub fn snap_to_current_workspace(&mut self, workspaces: &Vec<Workspace>) -> bool {
+        let pos = self.calculated_xyhw();
+        let (center_x, center_y) = pos.center();
+        if let Some(workspace) = workspaces
+            .iter()
+            .find(|ws| ws.contains_point(center_x, center_y)) 
+        {
+            self.snap_to_workspace(workspace)
+        } else {
+            false
+        }
+    }
+
+    /// Snap the window to the provided workspace.
+    /// 
+    /// Returns true if the window was tiled.
+    /// 
+    /// ## Arguments
+    /// + workspace - The workspace on which the window should be tiled
     pub fn snap_to_workspace(&mut self, workspace: &Workspace) -> bool {
         self.set_floating(false);
+        self.is_snapping = false;
 
         //we are reparenting
         if self.tags != workspace.tags {

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -157,32 +157,27 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 }
 
 impl Window {
-
     /// Snap the window to the workspace where it's currently positioned.
     /// This will calculate the center coordinate where the window is currently displayed
     /// and search for the workspace containing this coordinate.
-    /// 
+    ///
     /// Returns true if the window was tiled.
-    /// 
+    ///
     /// ## Arguments
     /// * workspaces - All workspaces, required to find out on which the window is positioned
-    pub fn snap_to_current_workspace(&mut self, workspaces: &Vec<Workspace>) -> bool {
+    pub fn snap_to_current_workspace(&mut self, workspaces: &[Workspace]) -> bool {
         let pos = self.calculated_xyhw();
         let (center_x, center_y) = pos.center();
-        if let Some(workspace) = workspaces
+        workspaces
             .iter()
-            .find(|ws| ws.contains_point(center_x, center_y)) 
-        {
-            self.snap_to_workspace(workspace)
-        } else {
-            false
-        }
+            .find(|workspace| workspace.contains_point(center_x, center_y))
+            .map_or(false, |workspace| self.snap_to_workspace(workspace))
     }
 
     /// Snap the window to the provided workspace.
-    /// 
+    ///
     /// Returns true if the window was tiled.
-    /// 
+    ///
     /// ## Arguments
     /// + workspace - The workspace on which the window should be tiled
     pub fn snap_to_workspace(&mut self, workspace: &Workspace) -> bool {

--- a/leftwm-core/src/handlers/window_move_handler.rs
+++ b/leftwm-core/src/handlers/window_move_handler.rs
@@ -52,13 +52,15 @@ fn should_snap_to_workspace(window: &mut Window, workspace: &Workspace) -> bool 
     if window.must_float() {
         return false;
     }
-    let loc = window.calculated_floating_xyhw().unwrap_or(window.calculated_xyhw());
+    let loc = window
+        .calculated_floating_xyhw()
+        .unwrap_or_else(|| window.calculated_xyhw());
     //get window sides
     let win_left = loc.x();
     let win_right = win_left + loc.w();
     let win_top = loc.y();
     let win_bottom = win_top + loc.h();
-    
+
     //check for conatins
     let (center_x, center_y) = loc.center();
     if !workspace.contains_point(center_x, center_y) {
@@ -71,7 +73,7 @@ fn should_snap_to_workspace(window: &mut Window, workspace: &Workspace) -> bool 
     let ws_right = workspace.x() + workspace.width();
     let ws_top = workspace.y();
     let ws_bottom = workspace.y() + workspace.height();
-    
+
     let snap_top = (win_top - ws_top).abs() < dist;
     let snap_bottom = (win_bottom - ws_bottom).abs() < dist;
     let snap_left = (win_left - ws_left).abs() < dist;

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -44,7 +44,7 @@ pub struct Window {
     pub requested: Option<XyhwChange>,
     pub normal: Xyhw,
     pub start_loc: Option<Xyhw>,
-    
+
     /// Whether the window should snap to a workspace (from floating to tiled).
     /// This may be set to true if the window is currently moved/resized,
     /// it will be set to false automatically after it has snapped to a workspace.
@@ -312,7 +312,8 @@ impl Window {
             x: absolute.x(),
             y: absolute.y(),
             ..XyhwBuilder::default()
-        }.into();
+        }
+        .into();
         Some(xyhw)
     }
 


### PR DESCRIPTION
:warning: This is a work in progress, PR is not ready to be merged yet

This PR addresses the issue #486, it fixes the rough behavior by always considering the `floating` position of a window in the `should_snap()` method, even if it currently is displayed as snapped/tiled.

It does not actually re-position the window if the user hasn't let go of it yet. Instead the boolean field `is_snapping` is set to true, which is then considered when calculating the **displayed** `Xyhw`. The window will eventually snap to the workspace after the user let's go of the window (when Mode changes to `Normal`).

**TODO**
- [ ] Window should be displayed at position/size where it will actually end up after it snaps, currently it's displayed over the whole workspace