### PR TITLE
Fix wrong _NET_CURRENT_DESKTOP index.

### DIFF
--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -25,7 +25,7 @@ impl XWrap {
     pub fn set_current_desktop(&self, current_tags: &[TagId]) {
         let mut indexes: Vec<u32> = current_tags
             .iter()
-            .map(|tag| tag.to_owned() as u32)
+            .map(|tag| tag.to_owned() as u32 - 1)
             .collect();
         if indexes.is_empty() {
             indexes.push(0);


### PR DESCRIPTION
As discussed on Discord, commit 589dc71d2a98500c83c2a94210d4d2e80773bc7b introduced a minor regression where _NET_CURRENT_DESKTOP started at `1` instead of `0`. This PR should fix this as suggested by @hertg :)