### PR TITLE
Various fixes

### DIFF
--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -38,7 +38,7 @@ pub enum DisplayAction {
     DestroyedWindow(WindowHandle),
 
     /// Tell a window that it is to become focused.
-    WindowTakeFocus(Window),
+    WindowTakeFocus(Window, Option<WindowHandle>),
 
     /// Remove focus on any visible window by focusing the root window.
     Unfocus,

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -38,7 +38,10 @@ pub enum DisplayAction {
     DestroyedWindow(WindowHandle),
 
     /// Tell a window that it is to become focused.
-    WindowTakeFocus(Window, Option<WindowHandle>),
+    WindowTakeFocus {
+        window: Window,
+        previous_handle: WindowHandle,
+    },
 
     /// Remove focus on any visible window by focusing the root window.
     Unfocus,

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -40,7 +40,7 @@ pub enum DisplayAction {
     /// Tell a window that it is to become focused.
     WindowTakeFocus {
         window: Window,
-        previous_handle: WindowHandle,
+        previous_handle: Option<WindowHandle>,
     },
 
     /// Remove focus on any visible window by focusing the root window.

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -44,7 +44,7 @@ pub enum DisplayAction {
     },
 
     /// Remove focus on any visible window by focusing the root window.
-    Unfocus,
+    Unfocus(Option<WindowHandle>),
 
     /// To the window under the cursor to take the focus.
     FocusWindowUnderCursor,

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -49,6 +49,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             }
             xlib::ButtonRelease => {
                 if xw.mode == models::Mode::Normal {
+                    xw.click_event = None;
                     return None;
                 }
                 Some(DisplayEvent::ChangeToNormalMode)

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -47,13 +47,10 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                 mod_mask &= !(xlib::Mod2Mask | xlib::LockMask);
                 Some(DisplayEvent::MouseCombo(mod_mask, event.button, h))
             }
-            xlib::ButtonRelease => {
-                if xw.mode == models::Mode::Normal {
-                    xw.click_event = None;
-                    return None;
-                }
-                Some(DisplayEvent::ChangeToNormalMode)
-            }
+            xlib::ButtonRelease => match xw.mode {
+                models::Mode::Normal => None,
+                _ => Some(DisplayEvent::ChangeToNormalMode),
+            },
 
             xlib::EnterNotify => from_enter_notify(xw, raw_event),
 

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -48,7 +48,10 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
                 Some(DisplayEvent::MouseCombo(mod_mask, event.button, h))
             }
             xlib::ButtonRelease => match xw.mode {
-                models::Mode::Normal => None,
+                models::Mode::Normal => {
+                    xw.click_event = None;
+                    None
+                }
                 _ => Some(DisplayEvent::ChangeToNormalMode),
             },
 

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -92,6 +92,7 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
     let mut can_resize = actions.contains(&xw.atoms.NetWMActionResize);
     let trans = xw.get_transient_for(event.window);
     let sizing_hint = xw.get_hint_sizing_as_xyhw(event.window);
+    let wm_hint = xw.get_wmhints(event.window);
 
     // Build the new window, and fill in info about it.
     let mut w = Window::new(handle, name, pid);
@@ -113,6 +114,9 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
         w.requested = Some(hint_xyhw);
     }
     w.can_resize = can_resize;
+    if let Some(hint) = wm_hint {
+        w.never_focus = hint.flags & xlib::InputHint != 0 && hint.input == 0;
+    }
     // Is this needed? Made it so it doens't overwrite prior sizing.
     if w.floating() && sizing_hint.is_none() {
         if let Ok(geo) = xw.get_window_geometry(event.window) {

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -187,17 +187,25 @@ fn from_configure_request(xw: &XWrap, raw_event: xlib::XEvent) -> Option<Display
     };
     let event = xlib::XConfigureRequestEvent::from(raw_event);
     let window_type = xw.get_window_type(event.window);
-    if window_type == WindowType::Normal || window_type == WindowType::Dialog {
+    if window_type == WindowType::Normal {
         return None;
     }
     let handle = WindowHandle::XlibHandle(event.window);
     let mut change = WindowChange::new(handle);
-    let xyhw = XyhwChange {
-        w: Some(event.width),
-        h: Some(event.height),
-        x: Some(event.x),
-        y: Some(event.y),
-        ..XyhwChange::default()
+    let xyhw = match window_type {
+        // We want to handle the window positioning when it is a dialog.
+        WindowType::Dialog => XyhwChange {
+            w: Some(event.width),
+            h: Some(event.height),
+            ..XyhwChange::default()
+        },
+        _ => XyhwChange {
+            w: Some(event.width),
+            h: Some(event.height),
+            x: Some(event.x),
+            y: Some(event.y),
+            ..XyhwChange::default()
+        },
     };
     change.floating = Some(xyhw);
     if window_type == WindowType::Dock || window_type == WindowType::Desktop {

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -100,11 +100,14 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
     if let Some(trans) = trans {
         w.transient = Some(WindowHandle::XlibHandle(trans));
     }
-    let mut xyhw = XyhwChange::default();
-    xyhw.x = Some(attrs.x);
-    xyhw.y = Some(attrs.y);
-    xyhw.w = Some(attrs.width);
-    xyhw.h = Some(attrs.height);
+    // Initialise the windows floating we the pre-mapped settings.
+    let xyhw = XyhwChange {
+        x: Some(attrs.x),
+        y: Some(attrs.y),
+        w: Some(attrs.width),
+        h: Some(attrs.height),
+        ..XyhwChange::default()
+    };
     xyhw.update_window_floating(&mut w);
     let mut requested = Xyhw::default();
     xyhw.update(&mut requested);

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -108,7 +108,7 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
     if let Some(trans) = trans {
         w.transient = Some(WindowHandle::XlibHandle(trans));
     }
-    // Initialise the windows floating we the pre-mapped settings.
+    // Initialise the windows floating with the pre-mapped settings.
     let xyhw = XyhwChange {
         x: Some(attrs.x),
         y: Some(attrs.y),

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -155,8 +155,8 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.window_take_focus(&window, previous_handle);
                 None
             }
-            DisplayAction::Unfocus => {
-                self.xw.unfocus();
+            DisplayAction::Unfocus(handle) => {
+                self.xw.unfocus(handle);
                 None
             }
             DisplayAction::SetState(h, toggle_to, window_state) => {

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -148,8 +148,11 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.teardown_managed_window(&w);
                 None
             }
-            DisplayAction::WindowTakeFocus(window, previous) => {
-                self.xw.window_take_focus(&window, previous);
+            DisplayAction::WindowTakeFocus {
+                window,
+                previous_handle,
+            } => {
+                self.xw.window_take_focus(&window, previous_handle);
                 None
             }
             DisplayAction::Unfocus => {

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -148,8 +148,8 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.teardown_managed_window(&w);
                 None
             }
-            DisplayAction::WindowTakeFocus(w) => {
-                self.xw.window_take_focus(&w);
+            DisplayAction::WindowTakeFocus(window, previous) => {
+                self.xw.window_take_focus(&window, previous);
                 None
             }
             DisplayAction::Unfocus => {

--- a/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
@@ -11,6 +11,7 @@ pub struct XAtom {
     pub WMProtocols: xlib::Atom,
     pub WMDelete: xlib::Atom,
     pub WMState: xlib::Atom,
+    pub WMClass: xlib::Atom,
     pub WMTakeFocus: xlib::Atom,
     pub NetActiveWindow: xlib::Atom,
     pub NetSupported: xlib::Atom,
@@ -61,6 +62,8 @@ pub struct XAtom {
     pub NetWMDesktop: xlib::Atom,
     pub NetWMStrutPartial: xlib::Atom, //net version - Reserve Screen Space
     pub NetWMStrut: xlib::Atom,        //old version
+
+    pub UTF8String: xlib::Atom,
 }
 
 impl XAtom {
@@ -125,6 +128,9 @@ impl XAtom {
         }
         if atom == self.WMState {
             return "WM_STATE";
+        }
+        if atom == self.WMClass {
+            return "WM_CLASS";
         }
         if atom == self.WMTakeFocus {
             return "WM_TAKE_FOCUS";
@@ -246,6 +252,10 @@ impl XAtom {
         if atom == self.NetWMStrut {
             return "_NET_WM_STRUT";
         }
+
+        if atom == self.UTF8String {
+            return "UTF8_STRING";
+        }
         "(UNKNOWN)"
     }
 
@@ -254,6 +264,7 @@ impl XAtom {
             WMProtocols: from(xlib, dpy, "WM_PROTOCOLS"),
             WMDelete: from(xlib, dpy, "WM_DELETE_WINDOW"),
             WMState: from(xlib, dpy, "WM_STATE"),
+            WMClass: from(xlib, dpy, "WM_CLASS"),
             WMTakeFocus: from(xlib, dpy, "WM_TAKE_FOCUS"),
             NetActiveWindow: from(xlib, dpy, "_NET_ACTIVE_WINDOW"),
             NetSupported: from(xlib, dpy, "_NET_SUPPORTED"),
@@ -304,6 +315,8 @@ impl XAtom {
             NetWMDesktop: from(xlib, dpy, "_NET_WM_DESKTOP"),
             NetWMStrutPartial: from(xlib, dpy, "_NET_WM_STRUT_PARTIAL"),
             NetWMStrut: from(xlib, dpy, "_NET_WM_STRUT"),
+
+            UTF8String: from(xlib, dpy, "UTF8_STRING"),
         }
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -160,6 +160,9 @@ impl XWrap {
             // Make sure that width and height are not smaller than the min values.
             xyhw.w = std::cmp::max(xyhw.w, xyhw.minw);
             xyhw.h = std::cmp::max(xyhw.h, xyhw.minh);
+            // Ignore the sizing if the sizing is set to 0.
+            xyhw.w = if xyhw.w == Some(0) { None } else { xyhw.w };
+            xyhw.h = if xyhw.h == Some(0) { None } else { xyhw.h };
 
             if (size.flags & xlib::PPosition) != 0 || (size.flags & xlib::USPosition) != 0 {
                 // These are obsolete but are still used sometimes.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -161,8 +161,8 @@ impl XWrap {
             xyhw.w = std::cmp::max(xyhw.w, xyhw.minw);
             xyhw.h = std::cmp::max(xyhw.h, xyhw.minh);
             // Ignore the sizing if the sizing is set to 0.
-            xyhw.w = if xyhw.w == Some(0) { None } else { xyhw.w };
-            xyhw.h = if xyhw.h == Some(0) { None } else { xyhw.h };
+            xyhw.w = xyhw.w.filter(|w| w != 0);
+            xyhw.h = xyhw.h.filter(|h| h != 0);
 
             if (size.flags & xlib::PPosition) != 0 || (size.flags & xlib::USPosition) != 0 {
                 // These are obsolete but are still used sometimes.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -161,8 +161,8 @@ impl XWrap {
             xyhw.w = std::cmp::max(xyhw.w, xyhw.minw);
             xyhw.h = std::cmp::max(xyhw.h, xyhw.minh);
             // Ignore the sizing if the sizing is set to 0.
-            xyhw.w = xyhw.w.filter(|w| w != 0);
-            xyhw.h = xyhw.h.filter(|h| h != 0);
+            xyhw.w = xyhw.w.filter(|&w| w != 0);
+            xyhw.h = xyhw.h.filter(|&h| h != 0);
 
             if (size.flags & xlib::PPosition) != 0 || (size.flags & xlib::USPosition) != 0 {
                 // These are obsolete but are still used sometimes.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/keyboard.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/keyboard.rs
@@ -25,7 +25,7 @@ impl XWrap {
                     m,
                     root,
                     1,
-                    xlib::GrabModeAsync,
+                    xlib::GrabModeSync,
                     xlib::GrabModeAsync,
                 );
             }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/keyboard.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/keyboard.rs
@@ -25,7 +25,7 @@ impl XWrap {
                     m,
                     root,
                     1,
-                    xlib::GrabModeSync,
+                    xlib::GrabModeAsync,
                     xlib::GrabModeAsync,
                 );
             }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -67,7 +67,6 @@ pub struct XWrap {
     pub task_notify: Arc<Notify>,
     pub motion_event_limiter: c_ulong,
     pub refresh_rate: c_short,
-    pub click_event: Option<xlib::XEvent>,
 }
 
 impl Default for XWrap {
@@ -188,7 +187,6 @@ impl XWrap {
             task_notify,
             motion_event_limiter: 0,
             refresh_rate,
-            click_event: None,
         };
 
         // Check that another WM is not running.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -253,6 +253,7 @@ impl XWrap {
         let root_event_mask: c_long = xlib::SubstructureRedirectMask
             | xlib::SubstructureNotifyMask
             | xlib::ButtonPressMask
+            | xlib::ButtonReleaseMask
             | xlib::PointerMotionMask
             | xlib::EnterWindowMask
             | xlib::LeaveWindowMask

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -341,7 +341,9 @@ impl XWrap {
         }
 
         // Set the WM NAME.
-        self.set_desktop_prop_string("LeftWM", self.atoms.NetWMName);
+        self.set_desktop_prop_string("LeftWM", self.atoms.NetWMName, self.atoms.UTF8String);
+
+        self.set_desktop_prop_string("LeftWM", self.atoms.WMClass, xlib::XA_STRING);
 
         self.set_desktop_prop_c_ulong(
             self.root as c_ulong,

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -67,7 +67,7 @@ pub struct XWrap {
     pub task_notify: Arc<Notify>,
     pub motion_event_limiter: c_ulong,
     pub refresh_rate: c_short,
-    pub click_replayed: bool,
+    pub click_event: Option<xlib::XEvent>,
 }
 
 impl Default for XWrap {
@@ -188,7 +188,7 @@ impl XWrap {
             task_notify,
             motion_event_limiter: 0,
             refresh_rate,
-            click_replayed: false,
+            click_event: None,
         };
 
         // Check that another WM is not running.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -67,6 +67,7 @@ pub struct XWrap {
     pub task_notify: Arc<Notify>,
     pub motion_event_limiter: c_ulong,
     pub refresh_rate: c_short,
+    pub click_replayed: bool,
 }
 
 impl Default for XWrap {
@@ -187,6 +188,7 @@ impl XWrap {
             task_notify,
             motion_event_limiter: 0,
             refresh_rate,
+            click_replayed: false,
         };
 
         // Check that another WM is not running.
@@ -401,6 +403,18 @@ impl XWrap {
             return true;
         }
         false
+    }
+
+    pub fn send_xevent(
+        &self,
+        window: xlib::Window,
+        propogate: i32,
+        mask: c_long,
+        mut event: xlib::XEvent,
+    ) {
+        unsafe {
+            (self.xlib.XSendEvent)(self.display, window, propogate, mask, &mut event);
+        }
     }
 
     /// Returns whether a window can recieve a xevent atom.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -57,7 +57,7 @@ pub struct XWrap {
     pub atoms: XAtom,
     cursors: XCursor,
     colors: Colors,
-    managed_windows: Vec<xlib::Window>,
+    pub managed_windows: Vec<xlib::Window>,
     pub tag_labels: Vec<String>,
     pub mode: Mode,
     pub focus_behaviour: FocusBehaviour,

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -11,6 +11,7 @@ impl XWrap {
         self.ungrab_buttons(handle);
         if !is_focused {
             self.grab_buttons(handle, xlib::Button1, xlib::AnyModifier, xlib::GrabModeSync);
+            self.grab_buttons(handle, xlib::Button3, xlib::AnyModifier, xlib::GrabModeSync);
         }
         self.grab_buttons(
             handle,

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -122,6 +122,7 @@ impl XWrap {
 
     /// Replay a click on a window.
     // `XAllowEvents`: https://linux.die.net/man/3/xallowevents
+    //  `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     pub fn replay_click(&self) {
         unsafe {
             (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
@@ -129,6 +130,7 @@ impl XWrap {
         }
     }
 
+    /// Plays the currently stored click event.
     pub fn play_click(&mut self) {
         if let Some(mut event) = self.click_event {
             let window = unsafe { event.button.window };
@@ -141,7 +143,6 @@ impl XWrap {
             event.button.time = xlib::CurrentTime;
             self.send_xevent(window, 1, 0xfff, event);
             self.flush();
-            self.click_event = None;
         }
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -35,7 +35,7 @@ impl XWrap {
                     BUTTONMASK as u32,
                     xlib::GrabModeAsync,
                     xlib::GrabModeAsync,
-                    0,
+                    self.root,
                     0,
                 );
             }
@@ -125,21 +125,23 @@ impl XWrap {
     pub fn replay_click(&self) {
         unsafe {
             (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
+            (self.xlib.XSync)(self.display, xlib::False);
         }
-        self.flush();
     }
 
-    pub fn play_click(&self, window: xlib::Window) {
+    pub fn play_click(&mut self) {
         if let Some(mut event) = self.click_event {
+            let window = unsafe { event.button.window };
             event.type_ = xlib::ButtonPress;
             event.button.time = xlib::CurrentTime;
-            event.button.window = window;
             self.send_xevent(window, 1, 0xfff, event);
             self.flush();
+            std::thread::sleep(std::time::Duration::from_millis(5));
             event.type_ = xlib::ButtonRelease;
             event.button.time = xlib::CurrentTime;
             self.send_xevent(window, 1, 0xfff, event);
             self.flush();
+            self.click_event = None;
         }
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -136,12 +136,12 @@ impl XWrap {
             let window = unsafe { event.button.window };
             event.type_ = xlib::ButtonPress;
             event.button.time = xlib::CurrentTime;
-            self.send_xevent(window, 1, 0xfff, event);
+            self.send_xevent(window, 1, xlib::ButtonPressMask, event);
             self.flush();
             std::thread::sleep(std::time::Duration::from_millis(5));
             event.type_ = xlib::ButtonRelease;
             event.button.time = xlib::CurrentTime;
-            self.send_xevent(window, 1, 0xfff, event);
+            self.send_xevent(window, 1, xlib::ButtonReleaseMask, event);
             self.flush();
         }
     }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -133,6 +133,7 @@ impl XWrap {
         if let Some(mut event) = self.click_event {
             event.type_ = xlib::ButtonPress;
             event.button.time = xlib::CurrentTime;
+            event.button.window = window;
             self.send_xevent(window, 1, 0xfff, event);
             self.flush();
             event.type_ = xlib::ButtonRelease;

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -128,4 +128,17 @@ impl XWrap {
         }
         self.flush();
     }
+
+    pub fn play_click(&self, window: xlib::Window) {
+        if let Some(mut event) = self.click_event {
+            event.type_ = xlib::ButtonPress;
+            event.button.time = xlib::CurrentTime;
+            self.send_xevent(window, 1, 0xfff, event);
+            self.flush();
+            event.type_ = xlib::ButtonRelease;
+            event.button.time = xlib::CurrentTime;
+            self.send_xevent(window, 1, 0xfff, event);
+            self.flush();
+        }
+    }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -2,7 +2,6 @@
 use super::{XlibError, MOUSEMASK};
 use crate::display_servers::xlib_display_server::xwrap::BUTTONMASK;
 use crate::models::FocusBehaviour;
-use crate::utils::xkeysym_lookup::ModMask;
 use crate::XWrap;
 use std::os::raw::{c_int, c_ulong};
 use x11_dl::xlib;
@@ -125,13 +124,10 @@ impl XWrap {
     /// Replay a click on a window.
     // `XAllowEvents`: https://linux.die.net/man/3/xallowevents
     // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
-    pub fn replay_click(&self, mod_mask: ModMask) {
+    pub fn replay_click(&self) {
         // Only replay the click when in ClickToFocus and we are not trying to move/resize the
         // window.
-        if self.focus_behaviour == FocusBehaviour::ClickTo
-            && !(mod_mask == self.mouse_key_mask
-                || mod_mask == (self.mouse_key_mask | xlib::ShiftMask))
-        {
+        if self.focus_behaviour == FocusBehaviour::ClickTo {
             unsafe {
                 (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
                 (self.xlib.XSync)(self.display, 0);

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -1,7 +1,6 @@
 //! Xlib calls related to a mouse.
 use super::{XlibError, MOUSEMASK};
 use crate::display_servers::xlib_display_server::xwrap::BUTTONMASK;
-use crate::models::FocusBehaviour;
 use crate::XWrap;
 use std::os::raw::{c_int, c_ulong};
 use x11_dl::xlib;
@@ -34,7 +33,7 @@ impl XWrap {
                     window,
                     0,
                     BUTTONMASK as u32,
-                    xlib::GrabModeSync,
+                    xlib::GrabModeAsync,
                     xlib::GrabModeAsync,
                     0,
                     0,
@@ -123,15 +122,10 @@ impl XWrap {
 
     /// Replay a click on a window.
     // `XAllowEvents`: https://linux.die.net/man/3/xallowevents
-    // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     pub fn replay_click(&self) {
-        // Only replay the click when in ClickToFocus and we are not trying to move/resize the
-        // window.
-        if self.focus_behaviour == FocusBehaviour::ClickTo {
-            unsafe {
-                (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
-                (self.xlib.XSync)(self.display, 0);
-            }
+        unsafe {
+            (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
         }
+        self.flush();
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -147,6 +147,18 @@ impl XWrap {
         }
     }
 
+    pub fn set_window_config(
+        &self,
+        window: xlib::Window,
+        mut window_changes: xlib::XWindowChanges,
+        unlock: u32,
+    ) {
+        unsafe {
+            (self.xlib.XConfigureWindow)(self.display, window, unlock, &mut window_changes);
+            (self.xlib.XSync)(self.display, 0);
+        }
+    }
+
     /// Sets what desktop a window is on.
     pub fn set_window_desktop(&self, window: xlib::Window, current_tags: &[TagId]) {
         let mut indexes: Vec<c_long> = current_tags.iter().map(|tag| (tag - 1) as c_long).collect();

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -109,14 +109,14 @@ impl XWrap {
 
     /// Sets a desktop property with type string.
     // `XChangeProperty`: https://tronche.com/gui/x/xlib/window-information/XChangeProperty.html
-    pub fn set_desktop_prop_string(&self, value: &str, atom: c_ulong) {
+    pub fn set_desktop_prop_string(&self, value: &str, atom: c_ulong, encoding: xlib::Atom) {
         if let Ok(cstring) = CString::new(value) {
             unsafe {
                 (self.xlib.XChangeProperty)(
                     self.display,
                     self.root,
                     atom,
-                    xlib::XA_CARDINAL,
+                    encoding,
                     8,
                     xlib::PropModeReplace,
                     cstring.as_ptr().cast::<u8>(),

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -158,10 +158,9 @@ impl XWrap {
     // `XSetInputFocus`: https://tronche.com/gui/x/xlib/input/XSetInputFocus.html
     pub fn window_take_focus(&mut self, window: &Window) {
         if let WindowHandle::XlibHandle(handle) = window.handle {
-            // Only replay the click when in ClickToFocus.
+            // Play a click when in ClickToFocus.
             if self.focus_behaviour == FocusBehaviour::ClickTo {
-                // self.replay_click();
-                self.click_replayed = false;
+                self.play_click(handle);
             }
             self.grab_mouse_clicks(handle);
 

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -156,9 +156,13 @@ impl XWrap {
 
     /// Makes a window take focus.
     // `XSetInputFocus`: https://tronche.com/gui/x/xlib/input/XSetInputFocus.html
-    pub fn window_take_focus(&self, window: &Window) {
+    pub fn window_take_focus(&mut self, window: &Window) {
         if let WindowHandle::XlibHandle(handle) = window.handle {
-            self.replay_click();
+            // Only replay the click when in ClickToFocus.
+            if self.focus_behaviour == FocusBehaviour::ClickTo {
+                // self.replay_click();
+                self.click_replayed = false;
+            }
             self.grab_mouse_clicks(handle);
 
             if !window.never_focus {

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -161,6 +161,7 @@ impl XWrap {
             // Play a click when in ClickToFocus.
             if self.focus_behaviour == FocusBehaviour::ClickTo {
                 self.play_click(handle);
+                self.click_event = None;
             }
             self.grab_mouse_clicks(handle);
 

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -63,8 +63,9 @@ impl XWrap {
                     let _ = self.move_cursor_to_window(handle);
                 }
                 if self.focus_behaviour == FocusBehaviour::ClickTo {
-                    self.ungrab_buttons(handle);
-                    self.grab_buttons(handle, xlib::Button1, xlib::AnyModifier);
+                    // self.ungrab_buttons(handle);
+                    // self.grab_buttons(handle, xlib::Button1, xlib::AnyModifier);
+                    self.grab_mouse_clicks(handle, false);
                 }
             }
             // Make sure there is at least an empty list of _NET_WM_STATE.
@@ -156,14 +157,16 @@ impl XWrap {
         if let WindowHandle::XlibHandle(handle) = window.handle {
             // Play a click when in ClickToFocus.
             if self.focus_behaviour == FocusBehaviour::ClickTo {
-                self.play_click();
+                // self.play_click();
+                self.replay_click();
                 // Open up button1 clicking on the previously focused window.
                 if let Some(WindowHandle::XlibHandle(previous)) = previous {
-                    self.ungrab_buttons(previous);
-                    self.grab_buttons(previous, xlib::Button1, xlib::AnyModifier);
+                    // self.ungrab_buttons(previous);
+                    // self.grab_buttons(previous, xlib::Button1, xlib::AnyModifier);
+                    self.grab_mouse_clicks(previous, false);
                 }
             }
-            self.grab_mouse_clicks(handle);
+            self.grab_mouse_clicks(handle, true);
 
             if !window.never_focus {
                 // Mark this window as the `_NET_ACTIVE_WINDOW`

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -157,12 +157,9 @@ impl XWrap {
         if let WindowHandle::XlibHandle(handle) = window.handle {
             // Play a click when in ClickToFocus.
             if self.focus_behaviour == FocusBehaviour::ClickTo {
-                // self.play_click();
                 self.replay_click();
                 // Open up button1 clicking on the previously focused window.
                 if let Some(WindowHandle::XlibHandle(previous)) = previous {
-                    // self.ungrab_buttons(previous);
-                    // self.grab_buttons(previous, xlib::Button1, xlib::AnyModifier);
                     self.grab_mouse_clicks(previous, false);
                 }
             }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -195,10 +195,17 @@ impl XWrap {
 
     /// Unfocuses all windows.
     // `XSetInputFocus`: https://tronche.com/gui/x/xlib/input/XSetInputFocus.html
-    pub fn unfocus(&self) {
-        let handle = self.root;
+    pub fn unfocus(&self, handle: Option<WindowHandle>) {
+        if let Some(WindowHandle::XlibHandle(handle)) = handle {
+            self.grab_mouse_clicks(handle, false);
+        }
         unsafe {
-            (self.xlib.XSetInputFocus)(self.display, handle, xlib::RevertToNone, xlib::CurrentTime);
+            (self.xlib.XSetInputFocus)(
+                self.display,
+                self.root,
+                xlib::RevertToPointerRoot,
+                xlib::CurrentTime,
+            );
             self.replace_property_long(
                 self.root,
                 self.atoms.NetActiveWindow,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -127,6 +127,7 @@ fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
     if let Some(nsp_tag) = manager.state.tags.get_hidden_by_label("NSP") {
         if let Some(id) = manager.state.active_scratchpads.get(&scratchpad.name) {
             if let Some(window) = manager.state.windows.iter_mut().find(|w| w.pid == *id) {
+                let previous_tag = window.tags[0];
                 let is_visible = window.has_tag(current_tag);
                 window.clear_tags();
                 if is_visible {
@@ -143,6 +144,13 @@ fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
                         handle = Some(*prev);
                     }
                 } else {
+                    // Remove the entry for the previous tag to prevent the scratchpad being
+                    // refocused.
+                    manager
+                        .state
+                        .focus_manager
+                        .tags_last_window
+                        .remove(&previous_tag);
                     // Show the scratchpad.
                     window.tag(current_tag);
                     handle = Some(window.handle);

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -230,7 +230,7 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
     if let Some(new_handle) = new_handle {
         manager.state.focus_window(&new_handle);
     } else {
-        let act = DisplayAction::Unfocus;
+        let act = DisplayAction::Unfocus(Some(handle));
         manager.state.actions.push_back(act);
         manager.state.focus_manager.window_history.push_front(None);
     }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -72,6 +72,19 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::MouseMoveWindow => None,
 
         Command::SoftReload => {
+            // Make sure the currently focused window is saved for the tag.
+            if let Some((handle, tag)) = state
+                .focus_manager
+                .window(&state.windows)
+                .map(|w| (w.handle, w.tags[0]))
+            {
+                let old_handle = state
+                    .focus_manager
+                    .tags_last_window
+                    .entry(tag)
+                    .or_insert(handle);
+                *old_handle = handle;
+            }
             manager.config.save_state(&manager.state);
             manager.hard_reload();
             None

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -50,7 +50,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::ChangeToNormalMode => {
                 self.state.mode = Mode::Normal;
-                //look through the config and build a command if its defined in the config
                 let act = DisplayAction::NormalMode;
                 self.state.actions.push_back(act);
                 true

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -46,6 +46,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             }
 
             DisplayEvent::ChangeToNormalMode => {
+                match self.state.mode {
+                    Mode::MovingWindow(h) | Mode::ResizingWindow(h) => {
+                        let _ = self.state.focus_window(&h);
+                    }
+                    Mode::Normal => {}
+                }
                 self.state.mode = Mode::Normal;
                 let act = DisplayAction::NormalMode;
                 self.state.actions.push_back(act);

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -12,10 +12,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
 
             //The window has been focused, do we want to do anything about it?
-            DisplayEvent::MouseEnteredWindow(handle) => match self.state.focus_manager.behaviour {
-                FocusBehaviour::Sloppy => return self.state.focus_window(&handle),
-                _ => return false,
-            },
+            DisplayEvent::MouseEnteredWindow(handle) => self.state.focus_window(&handle),
 
             DisplayEvent::KeyGrabReload => {
                 self.state
@@ -56,9 +53,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             }
 
             DisplayEvent::Movement(handle, x, y) => {
-                if self.state.screens.iter().any(|s| s.root == handle)
-                    && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy
-                {
+                if self.state.screens.iter().any(|s| s.root == handle) {
                     return self.state.focus_workspace_under_cursor(x, y);
                 }
                 false

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -165,28 +165,26 @@ fn focus_workspace_work(state: &mut State, workspace_id: Option<i32>) -> Option<
     Some(())
 }
 fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Option<Window> {
-    //Docks don't want to get focus. If they do weird things happen. They don't get events...
-    //Do the focus, Add the action to the list of action
+    // Find the handle in our managed windows.
     let found: &Window = state.windows.iter().find(|w| &w.handle == handle)?;
+    // Docks don't want to get focus. If they do weird things happen. They don't get events...
     if found.is_unmanaged() {
         return None;
     }
-    //NOTE: we are intentionally creating the focus event even if we think this window
-    //is already in focus. This is to force the DM to update its knowledge of the focused window
-    let act = DisplayAction::WindowTakeFocus(found.clone());
-    state.actions.push_back(act);
-
-    //no new history if no change
+    // No new history if no change.
     if let Some(fw) = state.focus_manager.window(&state.windows) {
         if &fw.handle == handle {
-            //NOTE: we still made the action so return some
-            return Some(found.clone());
+            return None;
         }
     }
-    //clean old ones
+
+    // Clean old history.
     state.focus_manager.window_history.truncate(10);
-    //add this focus to the history
+    // Add this focus change to the history.
     state.focus_manager.window_history.push_front(Some(*handle));
+
+    let act = DisplayAction::WindowTakeFocus(found.clone());
+    state.actions.push_back(act);
 
     Some(found.clone())
 }

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -171,12 +171,14 @@ fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Opti
     if found.is_unmanaged() {
         return None;
     }
+    let mut previous = None;
     // No new history if no change.
     if let Some(fw) = state.focus_manager.window(&state.windows) {
         if &fw.handle == handle {
             // Return some so we still update the visuals.
             return Some(found.clone());
         }
+        previous = Some(fw.handle);
     }
 
     // Clean old history.
@@ -184,7 +186,7 @@ fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Opti
     // Add this focus change to the history.
     state.focus_manager.window_history.push_front(Some(*handle));
 
-    let act = DisplayAction::WindowTakeFocus(found.clone());
+    let act = DisplayAction::WindowTakeFocus(found.clone(), previous);
     state.actions.push_back(act);
 
     Some(found.clone())

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -70,7 +70,7 @@ impl State {
         if focus_tag_work(self, *tag).is_none() {
             return false;
         }
-        // check each workspace, if its displaying this tag it should be focused too
+        // Check each workspace, if its displaying this tag it should be focused too.
         let to_focus: Vec<Workspace> = self
             .workspaces
             .iter()
@@ -80,7 +80,7 @@ impl State {
         for ws in &to_focus {
             focus_workspace_work(self, ws.id);
         }
-        //make sure the focused window is on this workspace
+        // Make sure the focused window is on this workspace.
         if self.focus_manager.behaviour == FocusBehaviour::Sloppy {
             let act = DisplayAction::FocusWindowUnderCursor;
             self.actions.push_back(act);

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -28,7 +28,7 @@ impl State {
             None => return false,
         };
 
-        //make sure the focused window's workspace is focused
+        // Make sure the focused window's workspace is focused.
         let (focused_window_tag, workspace_id) =
             match self.workspaces.iter().find(|ws| ws.is_displaying(&window)) {
                 Some(ws) => (
@@ -41,7 +41,7 @@ impl State {
             let _ = focus_workspace_work(self, workspace_id);
         }
 
-        //make sure the focused window's tag is focused
+        // Make sure the focused window's tag is focused.
         if let Some(tag) = focused_window_tag {
             let _ = focus_tag_work(self, tag);
         }
@@ -157,9 +157,9 @@ fn focus_workspace_work(state: &mut State, workspace_id: Option<i32>) -> Option<
             return None;
         }
     }
-    //clean old ones
+    // Clean old history.
     state.focus_manager.workspace_history.truncate(10);
-    //add this focus to the history
+    // Add this focus to the history.
     let index = state.workspaces.iter().position(|x| x.id == workspace_id)?;
     state.focus_manager.workspace_history.push_front(index);
     Some(())

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -100,7 +100,8 @@ impl State {
         // Unfocus last window if the target tag is empty
         if let Some(window) = self.focus_manager.window(&self.windows) {
             if !window.tags.contains(&tag.to_owned()) {
-                self.actions.push_back(DisplayAction::Unfocus);
+                self.actions
+                    .push_back(DisplayAction::Unfocus(Some(window.handle)));
                 self.focus_manager.window_history.push_front(None);
             }
         }

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -186,7 +186,10 @@ fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Opti
     // Add this focus change to the history.
     state.focus_manager.window_history.push_front(Some(*handle));
 
-    let act = DisplayAction::WindowTakeFocus(found.clone(), previous);
+    let act = DisplayAction::WindowTakeFocus {
+        window: found.clone(),
+        previous_handle: previous,
+    };
     state.actions.push_back(act);
 
     Some(found.clone())

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -174,7 +174,8 @@ fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Opti
     // No new history if no change.
     if let Some(fw) = state.focus_manager.window(&state.windows) {
         if &fw.handle == handle {
-            return None;
+            // Return some so we still update the visuals.
+            return Some(found.clone());
         }
     }
 

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -8,7 +8,7 @@ impl State {
 
         //let tag_id = self.tags[tag_num - 1].label.clone();
         let new_tags = vec![tag_num];
-        //no focus safety check
+        // No focus safety check.
         let old_tags = self.focus_manager.workspace(&self.workspaces)?.tags.clone();
         if let Some(handle) = self.focus_manager.window(&self.windows).map(|w| w.handle) {
             let old_handle = self

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -66,12 +66,18 @@ impl State {
                 None
             }
             xlib::Button3 => {
-                let _ = self
-                    .windows
-                    .iter()
-                    .find(|w| w.handle == window && w.can_resize())?;
-                self.mode = Mode::ResizingWindow(window);
-                Some(DisplayAction::StartResizingWindow(window))
+                if self.focus_manager.behaviour == FocusBehaviour::ClickTo {
+                    self.focus_window(&window);
+                }
+                if mod_mask == modifier || mod_mask == (modifier | xlib::ShiftMask) {
+                    let _ = self
+                        .windows
+                        .iter()
+                        .find(|w| w.handle == window && w.can_resize())?;
+                    self.mode = Mode::ResizingWindow(window);
+                    return Some(DisplayAction::StartResizingWindow(window));
+                }
+                None
             }
             _ => None,
         }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -112,7 +112,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             log::debug!("WINDOW CHANGED {:?} {:?}", &window, change);
             changed = change.update(window);
             // Reposition a dialog after a resize.
-            if window.r#type == WindowType::Dialog && is_floating_change {
+            if window.r#type == WindowType::Dialog
+                || window.transient.is_some() && is_floating_change
+            {
                 if let Some(ws) = self
                     .state
                     .workspaces
@@ -265,7 +267,7 @@ fn setup_window(
             window.apply_margin_multiplier(ws.margin_multiplier);
         }
         // Center dialogs and modal in workspace
-        if window.r#type == WindowType::Dialog || window.states().contains(&WindowState::Modal) {
+        if window.r#type == WindowType::Dialog {
             if window.can_resize() {
                 window.set_floating(true);
                 let new_float_exact = ws.center_halfed();

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -97,7 +97,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         let mut changed = false;
         let mut fullscreen_changed = false;
         let strut_changed = change.strut.is_some();
-        if let Some(w) = self
+        let windows = self.state.windows.clone();
+        if let Some(window) = self
             .state
             .windows
             .iter_mut()
@@ -105,11 +106,28 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         {
             if let Some(ref states) = change.states {
                 let change_contains = states.contains(&WindowState::Fullscreen);
-                fullscreen_changed = change_contains || w.is_fullscreen();
+                fullscreen_changed = change_contains || window.is_fullscreen();
             }
-            log::debug!("WINDOW CHANGED {:?} {:?}", &w, change);
-            changed = change.update(w);
-            if w.r#type == WindowType::Dock {
+            let is_floating_change = change.floating.is_some();
+            log::debug!("WINDOW CHANGED {:?} {:?}", &window, change);
+            changed = change.update(window);
+            // Reposition a dialog after a resize.
+            if window.r#type == WindowType::Dialog && is_floating_change {
+                if let Some(ws) = self
+                    .state
+                    .workspaces
+                    .iter()
+                    .find(|ws| ws.has_tag(&window.tags[0]))
+                {
+                    let transient = window.transient;
+                    match find_transient_parent(&windows, transient) {
+                        Some(parent) => set_relative_floating(window, ws, parent.exact_xyhw()),
+                        None => set_relative_floating(window, ws, ws.xyhw),
+                    }
+                }
+            }
+
+            if window.r#type == WindowType::Dock {
                 self.update_workspace_avoid_list();
                 // Don't let changes from docks re-render the worker. This will result in an
                 // infinite loop. Just be patient a rerender will occur.
@@ -260,7 +278,7 @@ fn setup_window(
         if window.r#type == WindowType::Splash {
             set_relative_floating(window, ws, ws.xyhw);
         }
-        if let Some(parent) = find_transient_parent(state, window) {
+        if let Some(parent) = find_transient_parent(&state.windows, window.transient) {
             // This is currently for vlc, this probably will need to be more general if another
             // case comes up where we don't want to move the window.
             if window.r#type != WindowType::Utility {
@@ -384,18 +402,17 @@ fn find_terminal(state: &State, pid: Option<u32>) -> Option<&Window> {
     None
 }
 
-fn find_transient_parent<'w>(state: &'w State, window: &Window) -> Option<&'w Window> {
-    let mut transient = window.transient?;
+fn find_transient_parent(windows: &[Window], transient: Option<WindowHandle>) -> Option<&Window> {
+    let mut transient = transient?;
     loop {
-        transient = if let Some(found) = state
-            .windows
+        transient = if let Some(found) = windows
             .iter()
             .find(|x| x.handle == transient)
             .and_then(|x| x.transient)
         {
             found
         } else {
-            return state.windows.iter().find(|x| x.handle == transient);
+            return windows.iter().find(|x| x.handle == transient);
         };
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -84,7 +84,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             } else if let Some(h) = new_handle {
                 self.state.focus_window(&h);
             } else {
-                let act = DisplayAction::Unfocus;
+                let act = DisplayAction::Unfocus(Some(*handle));
                 self.state.actions.push_back(act);
                 self.state.focus_manager.window_history.push_front(None);
             }


### PR DESCRIPTION
Fixes #585, fixes #225 (happy accident), fixes #592, partial #560 (At least the steps found), partial #517. With #517 I feel that the issue with clickto specifically is (mostly) fixed, there are still times that we can freeze with the motion/resize and spam clicking and such. However if think these issues can be reproduced in other focusbehaviours with enough effort. In future we will want to optimise the events we read will in these modes to prevent them being "held up" by events less important to the user (e.g. visual responsiveness events), similar to what dwm does in their move/resize functions. This will be in the future though (especially as I currently don't have an idea of how to integrate it nicely into our structure).
Many Thanks!