### PR TITLE
Fix missing trait boundary for custom command handler

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -2,6 +2,7 @@ mod keybind;
 mod scratchpad;
 mod workspace_config;
 
+use crate::display_servers::DisplayServer;
 use crate::layouts::Layout;
 pub use crate::models::{FocusBehaviour, Gutter, Margins, Size};
 use crate::models::{LayoutMode, Manager};
@@ -35,6 +36,7 @@ pub trait Config {
 
     fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
     where
+        SERVER: DisplayServer,
         Self: Sized;
 
     fn always_float(&self) -> bool;
@@ -100,8 +102,14 @@ impl Config for TestConfig {
     fn focus_new_windows(&self) -> bool {
         false
     }
-    fn command_handler<SERVER>(_command: &str, _manager: &mut Manager<Self, SERVER>) -> bool {
-        unimplemented!()
+    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
+    where
+        SERVER: DisplayServer,
+    {
+        match command {
+            "GotoTag2" => manager.command_handler(&crate::Command::GotoTag(2)),
+            _ => unimplemented!("custom command handler: {:?}", command),
+        }
     }
     fn always_float(&self) -> bool {
         false
@@ -147,5 +155,19 @@ impl Config for TestConfig {
     }
     fn load_state(&self, _state: &mut State) {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Screen;
+
+    #[test]
+    fn ensure_command_handler_trait_boundary() {
+        let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
+        manager.screen_create_handler(Screen::default());
+        assert!(TestConfig::command_handler("GotoTag2", &mut manager));
+        assert_eq!(manager.state.focus_manager.tag_history, &[2, 1]);
     }
 }


### PR DESCRIPTION
Without the `DisplayServer` trait boundary, it is not possible to call the function `command_handler` from inside a custom command handler:

```
error[E0599]: the method `command_handler` exists for mutable reference `&mut Manager<Config, SERVER>`, but its trait bounds were not satisfied
   --> leftwm/src/cecile.rs:224:35
    |
224 |                 let res = manager.command_handler(Command::GotoTag(i));
    |                                   ^^^^^^^^^^^^^^^ this is an associated function, not a method
    |
    = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
note: the candidate is defined in the trait `leftwm_core::Config`
   --> /home/cecile/repos/leftwm/leftwm-core/src/config/mod.rs:36:5
    |
36  | /     fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
37  | |     where
38  | |         Self: Sized;
    | |____________________^
    = note: the following trait bounds were not satisfied:
            `SERVER: DisplayServer`
```

Hello :wave:

So, now that the issue with xterm is fixed I'm now looking at making my config and see if I can make a custom command that does something. Unfortunately it is not possible at the moment because of a missing trait boundary.

I added a test to make sure we won't forget it in the future.