### PR TITLE
Allow scratchpad sizing at 100% (aka "Q3 console")

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -440,7 +440,7 @@ fn sane_dimension(config_value: Option<Size>, default_percent: f32, max_pixel: i
     match config_value {
         Some(size) => match size {
             Size::Percentage(percentage) if (0.0..=1.0).contains(&percentage) => {
-                size.into_absolute(100.0) as i32 * max_pixel / 100
+                size.into_absolute(max_pixel as f32) as i32
             }
             Size::Pixel(pixel) if (0..=max_pixel).contains(&pixel) => pixel,
             _ => (default_percent * max_pixel as f32) as i32,

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -439,10 +439,10 @@ pub fn scratchpad_xyhw(xyhw: &Xyhw, scratch_pad: &ScratchPad) -> Xyhw {
 fn sane_dimension(config_value: Option<Size>, default_percent: f32, max_pixel: i32) -> i32 {
     match config_value {
         Some(size) => match size {
-            Size::Percentage(percentage) if (0.0..0.9).contains(&percentage) => {
+            Size::Percentage(percentage) if (0.0..=1.0).contains(&percentage) => {
                 size.into_absolute(100.0) as i32 * max_pixel / 100
             }
-            Size::Pixel(pixel) if (0..(max_pixel as f32 * 0.9) as i32).contains(&pixel) => pixel,
+            Size::Pixel(pixel) if (0..=max_pixel).contains(&pixel) => pixel,
             _ => (default_percent * max_pixel as f32) as i32,
         },
         _ => (default_percent * max_pixel as f32) as i32,

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -438,13 +438,10 @@ pub fn scratchpad_xyhw(xyhw: &Xyhw, scratch_pad: &ScratchPad) -> Xyhw {
 
 fn sane_dimension(config_value: Option<Size>, default_percent: f32, max_pixel: i32) -> i32 {
     match config_value {
-        Some(size) => match size {
-            Size::Percentage(percentage) if (0.0..=1.0).contains(&percentage) => {
-                size.into_absolute(max_pixel as f32) as i32
-            }
-            Size::Pixel(pixel) if (0..=max_pixel).contains(&pixel) => pixel,
-            _ => (default_percent * max_pixel as f32) as i32,
-        },
+        Some(size @ Size::Percentage(percentage)) if (0.0..=1.0).contains(&percentage) => {
+            size.into_absolute(max_pixel as f32) as i32
+        }
+        Some(Size::Pixel(pixel)) if (0..=max_pixel).contains(&pixel) => pixel,
         _ => (default_percent * max_pixel as f32) as i32,
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -436,12 +436,12 @@ pub fn scratchpad_xyhw(xyhw: &Xyhw, scratch_pad: &ScratchPad) -> Xyhw {
     .into()
 }
 
-fn sane_dimension(config_value: Option<Size>, default_percent: f32, max_pixel: i32) -> i32 {
+fn sane_dimension(config_value: Option<Size>, default_ratio: f32, max_pixel: i32) -> i32 {
     match config_value {
-        Some(size @ Size::Percentage(percentage)) if (0.0..=1.0).contains(&percentage) => {
-            size.into_absolute(max_pixel as f32) as i32
+        Some(size @ Size::Ratio(percentage)) if (0.0..=1.0).contains(&percentage) => {
+            size.into_absolute(max_pixel)
         }
         Some(Size::Pixel(pixel)) if (0..=max_pixel).contains(&pixel) => pixel,
-        _ => (default_percent * max_pixel as f32) as i32,
+        _ => Size::Ratio(default_ratio).into_absolute(max_pixel),
     }
 }

--- a/leftwm-core/src/models/size.rs
+++ b/leftwm-core/src/models/size.rs
@@ -6,19 +6,19 @@ use serde::{Deserialize, Serialize};
 #[serde(untagged)]
 pub enum Size {
     Pixel(i32),
-    Percentage(f32),
+    Ratio(f32),
 }
 
 impl Size {
-    /// Turn the size into an absolute value, the pixel value
-    /// will be returned as is, the percentage value will be
-    /// multiplied by the provided `whole` to calculate
-    /// the absolute value
+    /// Turn the size into an absolute value.
+    ///
+    /// The pixel value will be returned as is, the ratio value will be multiplied by the provided
+    /// `whole` to calculate the absolute value.
     #[must_use]
-    pub fn into_absolute(self, whole: f32) -> f32 {
+    pub fn into_absolute(self, whole: i32) -> i32 {
         match self {
-            Size::Pixel(x) => x as f32,
-            Size::Percentage(x) => whole * x,
+            Size::Pixel(x) => x,
+            Size::Ratio(x) => (whole as f32 * x).floor() as i32,
         }
     }
 }

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -184,12 +184,10 @@ impl Workspace {
     /// while accounting for the optional `max_window_width` configuration
     #[must_use]
     pub fn width_limited(&self, column_count: usize) -> i32 {
+        let width = self.width();
         match self.max_window_width {
-            Some(size) => std::cmp::min(
-                (size.into_absolute(self.width() as f32) * column_count as f32).floor() as i32,
-                self.width(),
-            ),
-            None => self.width(),
+            Some(size) => std::cmp::min(size.into_absolute(width) * column_count as i32, width),
+            None => width,
         }
     }
 


### PR DESCRIPTION
I have no idea why those have been limited to 90% but I can assure you it works fine. I made a scratchpad with xterm at 0,0 of size 100%x50% and it just looks like quake3

:thinking: .... I wonder if this could be related to window border and gaps... In my config I have 0 border and 0 gap so I can actually use 100% safely.

cc @tramhao @VuiMuich @hertg @AethanFoot 

Related to #493 