### PR TITLE
feature: implement FocusWindowTop command

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -22,7 +22,7 @@ pub enum Command {
     FocusPreviousTag,
     FocusWindowUp,
     FocusWindowDown,
-    FocusWindowTop,
+    FocusWindowTop(bool),
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     SendWindowToTag(TagId),

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -22,6 +22,7 @@ pub enum Command {
     FocusPreviousTag,
     FocusWindowUp,
     FocusWindowDown,
+    FocusWindowTop,
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     SendWindowToTag(TagId),

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -82,7 +82,7 @@ impl Config for TestConfig {
         unimplemented!()
     }
     fn focus_behaviour(&self) -> FocusBehaviour {
-        FocusBehaviour::Sloppy
+        FocusBehaviour::ClickTo
     }
     fn mousekey(&self) -> String {
         "Mod4".to_string()

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -575,7 +575,7 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
     let next = state
         .windows
         .iter()
-        .find(|x| x.tags.contains(&tag) && !x.is_unmanaged())
+        .find(|x| x.tags.contains(&tag) && !x.floating() && !x.is_unmanaged())
         .map(|w| w.handle);
 
     match (next, cur, prev) {

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -773,4 +773,49 @@ mod tests {
         focus_tag_change(state, 13);
         assert_eq!(state.focus_manager.tag(0).unwrap(), 3);
     }
+
+    #[test]
+    fn focus_window_top() {
+        let mut manager = Manager::new_test(vec![]);
+        manager.screen_create_handler(Screen::default());
+
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(1), None, None),
+            -1,
+            -1,
+        );
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(2), None, None),
+            -1,
+            -1,
+        );
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(3), None, None),
+            -1,
+            -1,
+        );
+
+        let expected = manager.state.windows[0].clone();
+        let initial = manager.state.windows[1].clone();
+
+        assert!(manager.state.focus_window(&initial.handle));
+
+        assert!(manager.command_handler(&Command::FocusWindowTop));
+        let actual = manager
+            .state
+            .focus_manager
+            .window(&manager.state.windows)
+            .unwrap()
+            .handle;
+        assert_eq!(expected.handle, actual);
+
+        assert!(manager.state.focus_window(&initial.handle));
+        let actual = manager
+            .state
+            .focus_manager
+            .window(&manager.state.windows)
+            .unwrap()
+            .handle;
+        assert_eq!(initial.handle, actual);
+    }
 }

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -92,9 +92,10 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFloating" => Ok(Command::ToggleFloating),
         "MoveWindowUp" => Ok(Command::MoveWindowUp),
         "MoveWindowDown" => Ok(Command::MoveWindowDown),
-        "FocusWindowUp" => Ok(Command::FocusWindowUp),
         "MoveWindowTop" => Ok(Command::MoveWindowTop),
+        "FocusWindowUp" => Ok(Command::FocusWindowUp),
         "FocusWindowDown" => Ok(Command::FocusWindowDown),
+        "FocusWindowTop" => build_focus_window_top(s),
         "FocusNextTag" => Ok(Command::FocusNextTag),
         "FocusPreviousTag" => Ok(Command::FocusPreviousTag),
         "FocusWorkspaceNext" => Ok(Command::FocusWorkspaceNext),
@@ -149,6 +150,13 @@ fn build_set_margin_multiplier(raw: &str) -> Result<Command, Box<dyn std::error:
     let parts: Vec<&str> = headless.split(' ').collect();
     let margin_multiplier = f32::from_str(parts.get(0).ok_or("missing argument multiplier")?)?;
     Ok(Command::SetMarginMultiplier(margin_multiplier))
+}
+
+fn build_focus_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
+    let headless = without_head(raw, "FocusWindowTop ");
+    let parts: Vec<&str> = headless.split(' ').collect();
+    let toggle = bool::from_str(parts.get(0).unwrap_or(&"false"))?;
+    Ok(Command::FocusWindowTop(toggle))
 }
 
 fn without_head<'a, 'b>(s: &'a str, head: &'b str) -> &'a str {

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -58,9 +58,10 @@ async fn main() -> Result<()> {
         ToggleFloating
         MoveWindowUp
         MoveWindowDown
-        FocusWindowUp
         MoveWindowTop
+        FocusWindowUp
         FocusWindowDown
+        FocusWindowTop
         FocusNextTag
         FocusPreviousTag
         FocusWorkspaceNext

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -31,6 +31,7 @@ pub enum BaseCommand {
     FocusPreviousTag,
     FocusWindowUp,
     FocusWindowDown,
+    FocusWindowTop,
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     MoveToTag,

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -63,6 +63,7 @@ impl TryFrom<Keybind> for leftwm_core::Keybind {
             BaseCommand::FocusPreviousTag => leftwm_core::Command::FocusPreviousTag,
             BaseCommand::FocusWindowUp => leftwm_core::Command::FocusWindowUp,
             BaseCommand::FocusWindowDown => leftwm_core::Command::FocusWindowDown,
+            BaseCommand::FocusWindowTop => leftwm_core::Command::FocusWindowTop,
             BaseCommand::FocusWorkspaceNext => leftwm_core::Command::FocusWorkspaceNext,
             BaseCommand::FocusWorkspacePrevious => leftwm_core::Command::FocusWorkspacePrevious,
             BaseCommand::MoveToTag => leftwm_core::Command::SendWindowToTag(

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -63,7 +63,10 @@ impl TryFrom<Keybind> for leftwm_core::Keybind {
             BaseCommand::FocusPreviousTag => leftwm_core::Command::FocusPreviousTag,
             BaseCommand::FocusWindowUp => leftwm_core::Command::FocusWindowUp,
             BaseCommand::FocusWindowDown => leftwm_core::Command::FocusWindowDown,
-            BaseCommand::FocusWindowTop => leftwm_core::Command::FocusWindowTop,
+            BaseCommand::FocusWindowTop => leftwm_core::Command::FocusWindowTop(
+                bool::from_str(&k.value.unwrap_or_else(|| "false".to_string()))
+                    .context("invalid boolean value for FocusWindowTop")?,
+            ),
             BaseCommand::FocusWorkspaceNext => leftwm_core::Command::FocusWorkspaceNext,
             BaseCommand::FocusWorkspacePrevious => leftwm_core::Command::FocusWorkspacePrevious,
             BaseCommand::MoveToTag => leftwm_core::Command::SendWindowToTag(


### PR DESCRIPTION
This is a simple thing I was missing coming from XMonad, so figured I
would add it as it turned out to be fairly simple to do.

I'm not super fan of the implementation though, maybe the helper method
should be renamed to something else, or a new method added in
`command_handler`, e.g. `focus_window_top`.

Ideally, I would like to add the ability to go back to the previously
focused windowed by pressing the key again, just not sure how to do that
yet.
