### PR TITLE
Fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ For conveniece we also have a Makefile with the following rules:
 
 Make sure this is at the end of your .xinitrc file:
 
-```
-bash .xinitrc
+```bash 
+# .xinitrc
 exec dbus-launch leftwm
 ```
 


### PR DESCRIPTION
I ran into this documentation error when setting up leftwm on my machine. This is just a quick markdown syntax fix to help alleviate any confusion. I believe this captures the original intent to indicate bash language and the .xinitrc file.