### PR TITLE
Rotate grid horizontal

### DIFF
--- a/leftwm-core/src/layouts/grid_horizontal.rs
+++ b/leftwm-core/src/layouts/grid_horizontal.rs
@@ -1,3 +1,4 @@
+use crate::models::Tag;
 use crate::models::Window;
 use crate::models::Workspace;
 
@@ -20,7 +21,7 @@ use crate::models::Workspace;
 /// |   |   |   |
 /// +---+---+---+
 /// ```
-pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>) {
+pub fn update(workspace: &Workspace, tag: &Tag, windows: &mut Vec<&mut Window>) {
     let window_count = windows.len() as i32;
 
     // choose the number of columns so that we get close to an even NxN grid.
@@ -43,7 +44,14 @@ pub fn update(workspace: &Workspace, windows: &mut Vec<&mut Window>) {
             };
             win.set_height(win_height);
             win.set_width(win_width);
-            win.set_x(workspace.x_limited(num_cols as usize) + win_width * col);
+
+            let pos_x = if tag.flipped_horizontal {
+                num_cols - col - 1
+            } else {
+                col
+            };
+
+            win.set_x(workspace.x_limited(num_cols as usize) + win_width * pos_x);
             win.set_y(workspace.y() + win_height * row);
         }
     }

--- a/leftwm-core/src/layouts/grid_horizontal.rs
+++ b/leftwm-core/src/layouts/grid_horizontal.rs
@@ -37,6 +37,12 @@ pub fn update(workspace: &Workspace, tag: &Tag, windows: &mut Vec<&mut Window>) 
         let win_height = workspace.height() / num_rows_in_this_col;
         let win_width = workspace.width_limited(num_cols as usize) / num_cols;
 
+        let pos_x = if tag.flipped_horizontal {
+            num_cols - col - 1
+        } else {
+            col
+        };
+
         for row in 0..num_rows_in_this_col {
             let (_idx, win) = match iter.next() {
                 Some(x) => x,
@@ -44,12 +50,6 @@ pub fn update(workspace: &Workspace, tag: &Tag, windows: &mut Vec<&mut Window>) 
             };
             win.set_height(win_height);
             win.set_width(win_width);
-
-            let pos_x = if tag.flipped_horizontal {
-                num_cols - col - 1
-            } else {
-                col
-            };
 
             win.set_x(workspace.x_limited(num_cols as usize) + win_width * pos_x);
             win.set_y(workspace.y() + win_height * row);

--- a/leftwm-core/src/layouts/grid_horizontal.rs
+++ b/leftwm-core/src/layouts/grid_horizontal.rs
@@ -51,8 +51,14 @@ pub fn update(workspace: &Workspace, tag: &Tag, windows: &mut Vec<&mut Window>) 
             win.set_height(win_height);
             win.set_width(win_width);
 
+            let pos_y = if tag.flipped_vertical {
+                num_rows_in_this_col - row - 1
+            } else {
+                row
+            };
+
             win.set_x(workspace.x_limited(num_cols as usize) + win_width * pos_x);
-            win.set_y(workspace.y() + win_height * row);
+            win.set_y(workspace.y() + win_height * pos_y);
         }
     }
 }

--- a/leftwm-core/src/layouts/mod.rs
+++ b/leftwm-core/src/layouts/mod.rs
@@ -65,7 +65,7 @@ impl Layout {
                 main_and_horizontal_stack::update(workspace, tag, windows);
             }
             Self::MainAndDeck => main_and_deck::update(workspace, tag, windows),
-            Self::GridHorizontal => grid_horizontal::update(workspace, windows),
+            Self::GridHorizontal => grid_horizontal::update(workspace, tag, windows),
             Self::EvenHorizontal => even_horizontal::update(workspace, windows),
             Self::EvenVertical => even_vertical::update(workspace, windows),
             Self::Fibonacci => fibonacci::update(workspace, tag, windows),

--- a/leftwm-core/src/layouts/mod.rs
+++ b/leftwm-core/src/layouts/mod.rs
@@ -89,7 +89,7 @@ impl Layout {
     pub fn rotations(&self) -> Vec<(bool, bool)> {
         match self {
             //Layouts that can be flipped both ways
-            Self::Fibonacci => {
+            Self::Fibonacci | Self::GridHorizontal => {
                 [(false, false), (true, false), (true, true), (false, true)].to_vec()
             }
             //Layouts that can be flipped vertically


### PR DESCRIPTION
This pull request implements #612. 

I implemented only a horizontal flip, as that seemed to be the desired use case. Adding the vertical flip would be trivial, but would require adding 2 more rotation states (which may not be desired). If the vertical flip is desired, I can implement that before completing this pull request.