### PR TITLE
Fix build errors on architectures with u8

### DIFF
--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -3,7 +3,7 @@ use super::{Screen, WindowHandle, XlibError, MAX_PROPERTY_VALUE_LEN};
 use crate::models::{DockArea, WindowState, WindowType, XyhwChange};
 use crate::XWrap;
 use std::ffi::CString;
-use std::os::raw::{c_int, c_long, c_uchar, c_uint, c_ulong};
+use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong};
 use std::slice;
 use x11_dl::xlib;
 
@@ -575,7 +575,7 @@ impl XWrap {
             if status == 0 {
                 return Err(XlibError::FailedStatus);
             }
-            if let Ok(s) = CString::from_raw(text_prop.value.cast::<i8>()).into_string() {
+            if let Ok(s) = CString::from_raw(text_prop.value.cast::<c_char>()).into_string() {
                 return Ok(s);
             }
         };


### PR DESCRIPTION
On FreeBSD/powerpc64le:
```
   Compiling leftwm-core v0.2.10 (/wrkdirs/usr/ports/x11-wm/leftwm/work/leftwm-0.2.10/leftwm-core)
     Running `CARGO=/usr/local/bin/cargo CARGO_CRATE_NAME=leftwm_core CARGO_MANIFEST_DIR=/wrkdirs/usr/ports/x11-wm/leftwm/work/leftwm-0.2.10/leftwm-core CARGO_PKG_AUTHORS='Lex Childs <lexchilds@gmail.com>' CARGO_PKG_DESCRIPTION='A window manager for Adventurers' CARGO_PKG_HOMEPAGE='' CARGO_PKG_LICENSE=MIT CARGO_PKG_LICENSE_FILE='' CARGO_PKG_NAME=leftwm-core CARGO_PKG_REPOSITORY='https://github.com/leftwm/leftwm' CARGO_PKG_VERSION=0.2.10 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=2 CARGO_PKG_VERSION_PATCH=10 CARGO_PKG_VERSION_PRE='' CARGO_PRIMARY_PACKAGE=1 LD_LIBRARY_PATH='/wrkdirs/usr/ports/x11-wm/leftwm/work/target/release/deps:/usr/local/lib' /usr/local/bin/rustc --crate-name leftwm_core --edition=2018 leftwm-core/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts --crate-type lib --emit=dep-info,metadata,link -C opt-level=2 -C embed-bitcode=no -C metadata=4107fa8a5d99e531 -C extra-filename=-4107fa8a5d99e531 --out-dir /wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps --target powerpc64le-unknown-freebsd -C linker=cc -L dependency=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps -L dependency=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/release/deps --extern dirs_next=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libdirs_next-8ead4456b5994aaa.rmeta --extern futures=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libfutures-53fcea4d807e28f4.rmeta --extern log=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/liblog-6c00030bd99fe9ed.rmeta --extern mio=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libmio-522a404a2ff2b645.rmeta --extern nix=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libnix-56f7c1cc9d66de82.rmeta --extern serde=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libserde-32f4cb17b98d9fbd.rmeta --extern serde_json=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libserde_json-3f301d08908d418c.rmeta --extern signal_hook=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libsignal_hook-d8bf585a838964e2.rmeta --extern thiserror=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libthiserror-b95caac0782f4326.rmeta --extern tokio=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libtokio-0d5591c25545c438.rmeta --extern x11_dl=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libx11_dl-d48e2d88aed828fb.rmeta --extern xdg=/wrkdirs/usr/ports/x11-wm/leftwm/work/target/powerpc64le-unknown-freebsd/release/deps/libxdg-114e556087a4bc2a.rmeta -C link-arg=-fstack-protector-strong`
error[E0308]: mismatched types
   --> leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs:578:46
    |
578 |             if let Ok(s) = CString::from_raw(text_prop.value.cast::<i8>()).into_string() {
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `leftwm-core` due to previous error
```