### PR TITLE
Version bump.

### DIFF
--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-core"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["window manager"]
 edition = "2018"

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["window manager"]
 edition = "2018"
@@ -17,7 +17,7 @@ clap = "2.33.0"
 dirs-next = "2.0.0"
 futures = "0.3.12"
 git-version = "0.3.4"
-leftwm-core = { path = "../leftwm-core", version = '0.2.11' }
+leftwm-core = { path = "../leftwm-core", version = '0.2.12' }
 liquid = "0.23"
 log = "0.4.8"
 mio = "0.8.0"


### PR DESCRIPTION
Tagging @lex148, sorry these are close together this seemed an important patch. To also summarise for you, we are aligning the versioning closer to semantic e.g. MAJOR.MINOR.PATCH. This will allow us to add backwards compatible patches without needing to push new features that were added (possibly adding more bugs, and doesn't delay helpful patches by a feature not being done), then features can be added along minor iteration and be more spread out, then #292 will cause a major iteration (e.g. a 1.0.0 release).

Tagging @0323pin and @rigoletto-freebsd again so you know what is happening.