### PR TITLE
[FEATURE] Set windows to spawn on predefined tags given the WM_CLASS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leftwm"
-version = "0.2.11"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -434,13 +434,14 @@ dependencies = [
 
 [[package]]
 name = "leftwm-core"
-version = "0.2.11"
+version = "0.3.0"
 dependencies = [
  "dirs-next",
  "futures",
  "log",
  "mio 0.8.0",
  "nix",
+ "phf",
  "serde",
  "serde_json",
  "signal-hook",
@@ -703,6 +704,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +986,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
  "log",
  "mio 0.8.0",
  "nix",
- "phf",
  "serde",
  "serde_json",
  "signal-hook",
@@ -704,50 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,12 +941,6 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -23,7 +23,6 @@ thiserror = "1.0.30"
 tokio = { version = "1.2.0", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 x11-dl = "2.18.4"
 xdg = "2.2.0"
-phf = { version = "0.10", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0.30"
 tokio = { version = "1.2.0", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 x11-dl = "2.18.4"
 xdg = "2.2.0"
+phf = { version = "0.10", features = ["macros"] }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -59,6 +59,9 @@ pub trait Config {
 
     /// Load saved state if it exists.
     fn load_state(&self, state: &mut State);
+
+    /// Handle window placement based on `WM_CLASS`
+    fn get_tag_from_wm_class(&self, wm_class: &Option<String>) -> Option<usize>;
 }
 
 #[cfg(test)]
@@ -152,6 +155,9 @@ impl Config for TestConfig {
     }
     fn load_state(&self, _state: &mut State) {
         unimplemented!()
+    }
+    fn get_tag_from_wm_class(&self, _wm_class: &Option<String>) -> Option<usize> {
+        None
     }
 }
 

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -89,6 +89,8 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
     };
     // Gather info about the window from xlib.
     let name = xw.get_window_name(event.window);
+    let class = xw.get_window_class(event.window);
+    log::info!("WM class: {:?}", class);
     let pid = xw.get_window_pid(event.window);
     let r#type = xw.get_window_type(event.window);
     let states = xw.get_window_states(event.window);
@@ -100,6 +102,7 @@ fn from_map_request(raw_event: xlib::XEvent, xw: &mut XWrap) -> Option<DisplayEv
 
     // Build the new window, and fill in info about it.
     let mut w = Window::new(handle, name, pid);
+    w.wm_class = class;
     w.r#type = r#type.clone();
     w.set_states(states);
     if let Some(trans) = trans {

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -359,6 +359,15 @@ impl XWrap {
         None
     }
 
+    /// Returns a windows class `WM_CLASS`
+    #[must_use]
+    pub fn get_window_class(&self, window: xlib::Window) -> Option<String> {
+        if let Ok(text) = self.get_text_prop(window, self.atoms.WMClass) {
+            return Some(text);
+        }
+        None
+    }
+
     /// Returns a windows `_NET_WM_PID`.
     #[must_use]
     pub fn get_window_pid(&self, window: xlib::Window) -> Option<u32> {

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -230,21 +230,10 @@ fn setup_window(
     on_same_tag: &mut bool,
     predefined_tag: Option<usize>,
 ) {
-    // lookup if window has a predefined tag to be set
-    if let Some(tag) = predefined_tag {
-        window.tags = vec![tag];
-        log::info!(
-            "Windows  {:?} spawned in predefined tag {}",
-            window.wm_class,
-            tag
-        );
-        return;
-    }
-
     //When adding a window we add to the workspace under the cursor, This isn't necessarily the
     //focused workspace. If the workspace is empty, it might not have received focus. This is so
     //the workspace that has windows on its is still active not the empty workspace.
-    let ws: Option<&Workspace> = state
+    let mut ws: Option<&Workspace> = state
         .workspaces
         .iter()
         .find(|ws| {
@@ -253,17 +242,44 @@ fn setup_window(
         })
         .or_else(|| state.focus_manager.workspace(&state.workspaces)); //backup plan
 
+    // lookup if window has a predefined tag to be set
+    if let Some(tag) = predefined_tag {
+        window.tags = vec![tag];
+        log::info!(
+            "Windows {:?} spawned in predefined tag {}",
+            window.wm_class,
+            tag
+        );
+
+        // TODO: maybe this block should be removed so that Dialogs, Splash,
+        // etc. are placed in focused window regardless of user config
+        ws = state
+            .workspaces
+            .iter()
+            .find(|ws| ws.has_tag(&tag))
+            .or_else(|| state.focus_manager.workspace(&state.workspaces));
+
+        // A WM_CLASS may be shared between the dialogs, splashes and the main program
+        // window, but the Splash and Dialogs require further processing.
+        if ws.is_none() {
+            return;
+        }
+    }
+
     if let Some(ws) = ws {
         let for_active_workspace =
             |x: &Window| -> bool { helpers::intersect(&ws.tags, &x.tags) && !x.is_unmanaged() };
         *is_first = !state.windows.iter().any(|w| for_active_workspace(w));
-        window.tags = find_terminal(state, window.pid).map_or_else(
-            || ws.tags.clone(),
-            |terminal| {
-                *on_same_tag = ws.tags == terminal.tags;
-                terminal.tags.clone()
-            },
-        );
+        // may have been set by a predefined tag
+        if window.tags.is_empty() {
+            window.tags = find_terminal(state, window.pid).map_or_else(
+                || ws.tags.clone(),
+                |terminal| {
+                    *on_same_tag = ws.tags == terminal.tags;
+                    terminal.tags.clone()
+                },
+            );
+        }
         *layout = ws.layout;
 
         if is_scratchpad(state, window) {

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -46,6 +46,7 @@ pub struct Window {
     pub start_loc: Option<Xyhw>,
     pub container_size: Option<Xyhw>,
     pub strut: Option<Xyhw>,
+    pub wm_class: Option<String>,
 }
 
 impl Window {
@@ -74,6 +75,7 @@ impl Window {
             start_loc: None,
             container_size: None,
             strut: None,
+            wm_class: None,
         }
     }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -210,6 +210,7 @@ impl Default for Config {
             theme_setting: ThemeSetting::default(),
             max_window_width: None,
             state: None,
+            window_config_by_class: None,
         }
     }
 }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -13,7 +13,6 @@ use leftwm_core::{
     Manager,
 };
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use std::default::Default;
 use std::env;
 use std::fs;
@@ -21,6 +20,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::{collections::HashMap, convert::TryInto};
 use xdg::BaseDirectories;
 
 /// Path to file where state will be dumper upon soft reload.
@@ -141,6 +141,7 @@ pub struct Config {
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
+    pub window_config_by_class: Option<HashMap<String, usize>>,
 
     #[serde(skip)]
     pub theme_setting: ThemeSetting,
@@ -460,6 +461,14 @@ impl leftwm_core::Config for Config {
                 }
             }
             Err(err) => log::error!("Cannot open old state: {}", err),
+        }
+    }
+
+    fn get_tag_from_wm_class(&self, wm_class: &Option<String>) -> Option<usize> {
+        if let (Some(class), Some(wm_middleware)) = (wm_class, &self.window_config_by_class) {
+            wm_middleware.get(class).copied()
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
Would close #427 

> This PR is a (working) proof of concept.

### Description

Implement _a way_ to define the tag where a window, defined by its `WM_CLASS`, should spawn. This is a common feature in other tiling window managers (like xmonad). The concrete way for now is to have a section in the config in the following form:

```toml
[window_config_by_class]
Navigator=2
krita=3
blender=3
"org.inkscape.inkscape"=3
soffice=4
```

In this example, windows whose `WM_CLASS` is, for instance, "krita" will spawn in the workspace number 3 (1-indexed).

### Implementation

Added a function to the trait `leftwm_core::Config`, and a corresponding implementation for `leftmw::Config`, with its corresponding serializable struct as a [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html).

This allows users of compiled configs to set their own implementation, maybe using a [`phf::Map`](https://docs.rs/phf/latest/phf/).

### Considerations

This PR is incomplete because it does not implement the desires set of features, mainly, that the user should be able to also specify windows that should float. It also may be reasonable to wait for https://github.com/leftwm/leftwm/pull/292.

A possible complete implementation would have a config like the one proposed at https://github.com/leftwm/leftwm/issues/427#issuecomment-997421359:

```toml
[[window_config_by_class]]
wm-class = "qutebrowser"
spawn_on_tag = "www" #tag.id as in the tag-configuration array, this could optionally be an integer with the tag.index
spawn_floating = true
```

This would mainly require changing the introduced `leftwm_core::Config` trait method [`get_tag_from_wm_class`](https://github.com/carrascomj/leftwm/blob/feat-phf-wmclass/leftwm-core/src/config/mod.rs#L64) to

```rust
/// Take a window and set the tag and is_floating, possibly from `WM_CLASS`. 
/// Returns true if the window was handled
fn setup_predefined_window(&self, window: &mut Window) -> bool;
```

(and changing the corresponding `leftwm::Config`).

**Or** introducing a new trait (such as `WindowMiddleware` or `WindowHook`) that a field in `leftmw_core::Manager` implements, if separating it from `Config` is desired:
```rust
trait WindowMiddleware {
    fn setup_predefined_window(&self, window: &mut Window) -> bool;
}
```