### PR TITLE
feat: provide a Nix Flake for NixOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,14 @@ jobs:
 
     - name: Display MSRV
       run: cargo -V
+
+  nix-flake:
+    name: nix-flake
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix build
+    - run: nix develop -c make -- test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,5 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           substituters = https://cache.nixos.org/ https://nix-community.cachix.org
-    - run: nix build
     - run: nix develop -c make -- test
+    - run: nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: 
+        extra_nix_config: |
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           substituters = https://cache.nixos.org/ https://nix-community.cachix.org
     - run: nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,4 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           substituters = https://cache.nixos.org/ https://nix-community.cachix.org
-    - run: nix develop -c make -- test
     - run: nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,5 +70,8 @@ jobs:
     - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: 
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+          substituters = https://cache.nixos.org/ https://nix-community.cachix.org
     - run: nix build
     - run: nix develop -c make -- test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,5 @@ jobs:
         extra_nix_config: |
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           substituters = https://cache.nixos.org/ https://nix-community.cachix.org
+    - run: nix flake check
     - run: nix build

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,8 @@
 leftwm.logs
 .idea/
 
+result
+.direnv
+.envrc
+
 sweep.timestamp

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1640413491,
-        "narHash": "sha256-3VdQNPd9k4Fcjv/JBlwtJZWXg4fhrqTrEoSqhEOEWaU=",
+        "lastModified": 1640644357,
+        "narHash": "sha256-P3DOh+9f0kqfZVqRCrVAHyyx/vYgLN8GaoHdbRv/BcM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "730771574878f1fd5c31b4d7b1595df389f01ea3",
+        "rev": "ac55b49c49b53a60e8eb5761687fa741c7c80265",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1640408860,
-        "narHash": "sha256-h2uF3+a8bVfM8SjcS4hLbsOzOuG3qsxuImC0BucWs1Q=",
+        "lastModified": 1640540585,
+        "narHash": "sha256-cCmknKFjWgam9jq+58wSd0Z4REia8mjBP65kXcL3ki8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb372c3b8880e504b06946e8fb2ca9777c685505",
+        "rev": "ac169ec6371f0d835542db654a65e0f2feb07838",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1640270361,
-        "narHash": "sha256-g0canOfW6Iu/wSy0XUctgmlHJahfh5NqwDYddcRHXJQ=",
+        "lastModified": 1640459636,
+        "narHash": "sha256-lvHBAWuCd+7cYq6AwThqD6uMRqsKoGJFPKUqeyn3UEU=",
         "owner": "rust-analyzer",
         "repo": "rust-analyzer",
-        "rev": "7b7a1ed062edd438caa824b6a71aaaa56b48e7d4",
+        "rev": "c456b217d808058d2515dd909bc4f68206de340e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1640413491,
+        "narHash": "sha256-3VdQNPd9k4Fcjv/JBlwtJZWXg4fhrqTrEoSqhEOEWaU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "730771574878f1fd5c31b4d7b1595df389f01ea3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1639947939,
+        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1640408860,
+        "narHash": "sha256-h2uF3+a8bVfM8SjcS4hLbsOzOuG3qsxuImC0BucWs1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cb372c3b8880e504b06946e8fb2ca9777c685505",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640270361,
+        "narHash": "sha256-g0canOfW6Iu/wSy0XUctgmlHJahfh5NqwDYddcRHXJQ=",
+        "owner": "rust-analyzer",
+        "repo": "rust-analyzer",
+        "rev": "7b7a1ed062edd438caa824b6a71aaaa56b48e7d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-analyzer",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, fenix, flake-utils, naersk, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        deps = with pkgs; [
+          xorg.libX11
+          xorg.libXinerama
+        ];
+
+        devToolchain = fenix.packages.${system}.stable;
+
+        leftwm = ((naersk.lib.${system}.override {
+          inherit (fenix.packages.${system}.minimal) cargo rustc;
+        }).buildPackage {
+          name = "leftwm";
+          src = ./.;
+          buildInputs = deps;
+          postFixup = ''
+            for p in $out/bin/leftwm*; do
+              patchelf --set-rpath "${pkgs.lib.makeLibraryPath deps}" $p
+            done
+            # '';
+        });
+      in
+      rec {
+        # `nix build`
+        packages.leftwm = leftwm;
+        defaultPackage = packages.leftwm;
+
+        # `nix run`
+        apps.leftwm = flake-utils.lib.mkApp {
+          drv = packages.leftwm;
+        };
+        defaultApp = apps.leftwm;
+
+        # `nix develop`
+        devShell = pkgs.mkShell
+          {
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (deps ++ [ (pkgs.lib.getLib pkgs.systemd) ]);
+            buildInputs = deps ++ [ pkgs.pkg-config ];
+            nativeBuildInputs = with pkgs; [
+              gnumake
+              (devToolchain.withComponents [
+                "cargo"
+                "clippy"
+                "rust-src"
+                "rustc"
+                "rustfmt"
+              ])
+              fenix.packages.${system}.rust-analyzer
+            ];
+          };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
         devShell = pkgs.mkShell
           {
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (deps ++ [ (pkgs.lib.getLib pkgs.systemd) ]);
-            buildInputs = deps ++ [ pkgs.pkg-config ];
+            buildInputs = deps ++ [ pkgs.pkg-config pkgs.systemd ];
             nativeBuildInputs = with pkgs; [
               gnumake
               (devToolchain.withComponents [

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   };
 
   outputs = { self, fenix, flake-utils, naersk, nixpkgs }:
-    flake-utils.lib.eachDefaultSystem (system:
+    (flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         deps = with pkgs; [
@@ -63,5 +63,9 @@
               fenix.packages.${system}.rust-analyzer
             ];
           };
-      });
+      })) // {
+      overlay = _: _: {
+        leftwm = self.defaultPackage;
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
         # `nix develop`
         devShell = pkgs.mkShell
           {
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (deps ++ [ (pkgs.lib.getLib pkgs.systemd) ]);
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (deps ++ [ pkgs.glibc (pkgs.lib.getLib pkgs.systemd) ]);
             buildInputs = deps ++ [ pkgs.pkg-config pkgs.systemd ];
             nativeBuildInputs = with pkgs; [
               gnumake

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,8 @@
             ];
           };
       })) // {
-      overlay = _: _: {
-        leftwm = self.defaultPackage;
+      overlay = final: prev: {
+        leftwm = self.packages.${final.system}.leftwm;
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
         # `nix develop`
         devShell = pkgs.mkShell
           {
-            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (deps ++ [ pkgs.glibc (pkgs.lib.getLib pkgs.systemd) ]);
             buildInputs = deps ++ [ pkgs.pkg-config pkgs.systemd ];
             nativeBuildInputs = with pkgs; [
               gnumake


### PR DESCRIPTION
This PR adds a flake.nix for people using NixOS. It makes it easy to install the latest version of leftwm, as well as running custom branches.

It also provides a shell with the minimal tooling required to work on leftwm. This can be called through `nix-direnv` or directly with `nix develop`
