### PR TITLE
fix(641): focus the last window in the workspace

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -596,17 +596,12 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
 fn focus_workspace_change(state: &mut State, val: i32) -> Option<bool> {
     let current = state.focus_manager.workspace(&state.workspaces)?;
     let workspace = helpers::relative_find(&state.workspaces, |w| w == current, val, true)?.clone();
-    state.focus_workspace(&workspace);
+    let result = state.focus_workspace(&workspace);
     if state.focus_manager.behaviour == FocusBehaviour::Sloppy {
         let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
         state.actions.push_back(act);
     }
-    let window = state
-        .windows
-        .iter()
-        .find(|w| workspace.is_displaying(w) && w.r#type == WindowType::Normal)?
-        .clone();
-    Some(handle_focus(state, window.handle))
+    Some(result)
 }
 
 fn rotate_tag(state: &mut State) -> Option<bool> {

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -585,10 +585,7 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
         (Some(next), Some(cur), Some(prev)) if next == cur && toggle => {
             Some(handle_focus(state, prev))
         }
-        (Some(next), Some(cur), _) if next != cur => {
-            state.focus_manager.tags_last_window.insert(tag, cur);
-            Some(handle_focus(state, next))
-        }
+        (Some(next), Some(cur), _) if next != cur => Some(handle_focus(state, next)),
         _ => None,
     }
 }
@@ -596,6 +593,7 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
 fn focus_workspace_change(state: &mut State, val: i32) -> Option<bool> {
     let current = state.focus_manager.workspace(&state.workspaces)?;
     let workspace = helpers::relative_find(&state.workspaces, |w| w == current, val, true)?.clone();
+
     if state.focus_manager.behaviour == FocusBehaviour::Sloppy {
         let action = workspace
             .tags
@@ -606,10 +604,9 @@ fn focus_workspace_change(state: &mut State, val: i32) -> Option<bool> {
                 |h| DisplayAction::MoveMouseOver(*h),
             );
         state.actions.push_back(action);
-        None
-    } else {
-        Some(state.focus_workspace(&workspace))
     }
+
+    Some(state.focus_workspace(&workspace))
 }
 
 fn rotate_tag(state: &mut State) -> Option<bool> {

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -601,8 +601,10 @@ fn focus_workspace_change(state: &mut State, val: i32) -> Option<bool> {
             .tags
             .first()
             .and_then(|tag| state.focus_manager.tags_last_window.get(tag))
-            .map(|handle| DisplayAction::MoveMouseOver(handle.clone()))
-            .unwrap_or_else(|| DisplayAction::MoveMouseOverPoint(workspace.xyhw.center()));
+            .map_or_else(
+                || DisplayAction::MoveMouseOverPoint(workspace.xyhw.center()),
+                |h| DisplayAction::MoveMouseOver(*h),
+            );
         state.actions.push_back(action);
         None
     } else {

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -596,12 +596,18 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
 fn focus_workspace_change(state: &mut State, val: i32) -> Option<bool> {
     let current = state.focus_manager.workspace(&state.workspaces)?;
     let workspace = helpers::relative_find(&state.workspaces, |w| w == current, val, true)?.clone();
-    let result = state.focus_workspace(&workspace);
     if state.focus_manager.behaviour == FocusBehaviour::Sloppy {
-        let act = DisplayAction::MoveMouseOverPoint(workspace.xyhw.center());
-        state.actions.push_back(act);
+        let action = workspace
+            .tags
+            .first()
+            .and_then(|tag| state.focus_manager.tags_last_window.get(tag))
+            .map(|handle| DisplayAction::MoveMouseOver(handle.clone()))
+            .unwrap_or_else(|| DisplayAction::MoveMouseOverPoint(workspace.xyhw.center()));
+        state.actions.push_back(action);
+        None
+    } else {
+        Some(state.focus_workspace(&workspace))
     }
-    Some(result)
 }
 
 fn rotate_tag(state: &mut State) -> Option<bool> {

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -165,15 +165,6 @@ fn focus_workspace_work(state: &mut State, workspace_id: Option<i32>) -> Option<
         }
     }
 
-    // Add the currently focused window to the history
-    if let Some((tag, handle)) = state
-        .focus_manager
-        .tag(0)
-        .zip(state.focus_manager.window(&state.windows).map(|w| w.handle))
-    {
-        state.focus_manager.tags_last_window.insert(tag, handle);
-    }
-
     // Clean old history.
     state.focus_manager.workspace_history.truncate(10);
     // Add this focus to the history.
@@ -245,6 +236,16 @@ fn focus_tag_work(state: &mut State, tag: TagId) -> Option<()> {
             return None;
         }
     };
+
+    // Add the currently focused window to the history
+    if let Some((tag, handle)) = state
+        .focus_manager
+        .tag(0)
+        .zip(state.focus_manager.window(&state.windows).map(|w| w.handle))
+    {
+        state.focus_manager.tags_last_window.insert(tag, handle);
+    }
+
     //clean old ones
     state.focus_manager.tag_history.truncate(10);
     //add this focus to the history

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -312,7 +312,6 @@ mod tests {
             -1,
             -1,
         );
-        // manager.screen_create_handler(Screen::default());
 
         manager
             .state

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -43,6 +43,7 @@ impl State {
                 ),
                 None => (None, None),
             };
+
         if let Some(workspace_id) = workspace_id {
             let _ = focus_workspace_work(self, workspace_id);
         }
@@ -51,6 +52,7 @@ impl State {
         if let Some(tag) = focused_window_tag {
             let _ = focus_tag_work(self, tag);
         }
+
         true
     }
 


### PR DESCRIPTION
Ensure `focus_workspace` saves the last window on the tag before
switching, and then restores it for the next workspace

Resolves #641 