### PR TITLE
fix: include display id in command pipe name

### DIFF
--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{atomic::Ordering, Once};
 
 impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
+    /// # Panics
+    /// This function panics if it can't create or write to the command file.
     pub async fn event_loop(mut self) {
         let socket_file = place_runtime_file("current_state.sock")
             .expect("ERROR: couldn't create current_state.sock");

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -13,11 +13,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             .await
             .expect("ERROR: couldn't connect to current_state.sock");
 
-        let pipe_file =
-            place_runtime_file("commands.pipe").expect("ERROR: couldn't create commands.pipe");
+        let file_name = CommandPipe::pipe_name();
+        let pipe_file = place_runtime_file(&file_name)
+            .unwrap_or_else(|_| panic!("ERROR: couldn't create {}", file_name.display()));
         let mut command_pipe = CommandPipe::new(pipe_file)
             .await
-            .expect("ERROR: couldn't connect to commands.pipe");
+            .unwrap_or_else(|_| panic!("ERROR: couldn't connect to {}", file_name.display()));
 
         //start the current theme
         let after_first_loop: Once = Once::new();

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -2,6 +2,7 @@
 use crate::layouts::Layout;
 use crate::models::TagId;
 use crate::Command;
+use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tokio::fs;
@@ -52,6 +53,15 @@ impl CommandPipe {
         });
 
         Ok(Self { pipe_file, rx })
+    }
+
+    pub fn pipe_name() -> PathBuf {
+        let display = env::var("DISPLAY")
+            .ok()
+            .and_then(|d| d.rsplit_once(":").map(|(_, r)| r.to_owned()))
+            .unwrap_or_else(|| "0".to_string());
+
+        PathBuf::from(format!("command-{}.pipe", display))
     }
 
     pub async fn read_command(&mut self) -> Option<Command> {


### PR DESCRIPTION
This change allow running multiple session of leftwm. Without this, the
second session would destroy the file of the first one, leaving it
unsuable.
