### PR TITLE
fix: git commit missing on nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,9 @@
             for p in $out/bin/leftwm*; do
               patchelf --set-rpath "${pkgs.lib.makeLibraryPath deps}" $p
             done
-            # '';
+          '';
+ 
+          GIT_HASH = self.shortRev or "dirty";
         });
       in
       rec {

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use clap::{App, Arg};
 use leftwm::{Config, ThemeSetting};
+use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
@@ -35,7 +36,7 @@ async fn main() -> Result<()> {
     );
     println!(
         "\x1b[0;94m::\x1b[0m LeftWM git hash: {}",
-        git_version::git_version!(fallback = "NONE")
+        git_version::git_version!(fallback = option_env!("GIT_HASH").unwrap_or("NONE"))
     );
     println!("\x1b[0;94m::\x1b[0m Loading configuration . . .");
     match load_from_file(config_file, verbose) {

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -158,11 +158,10 @@ fn execute_subcommand(args: &[String], subcommands: &[&str]) -> Option<bool> {
 fn handle_help_or_version_flags(args: &[String], subcommands: &BTreeMap<&str, &str>) {
     // If there are more than two arguments, do not invoke `clap`, since `clap` will get confused
     // about arguments to subcommands and throw spurrious errors.
-
     let version = format!(
         "{}, Git-Hash: {}",
         crate_version!(),
-        git_version::git_version!(fallback = "NONE")
+        git_version::git_version!(fallback = option_env!("GIT_HASH").unwrap_or("NONE"))
     );
     let mut app = App::new("LeftWM")
         .author("Lex Childs <lex.childs@gmail.com>")


### PR DESCRIPTION
Just a small improvement to #639 to include the git hash when building on NixOS, as `nixpkgs` will copy the source tree to an empty folder before building, thus `git_version` can't detect the hash.