### PR TITLE
fix 644

### DIFF
--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -45,6 +45,7 @@ fn main() {
     // If _not_ invoked with a subcommand, start leftwm.
     if let Ok(current_exe) = std::env::current_exe() {
         // Boot everything WM agnostic or LeftWM related in ~/.config/autostart
+        env::set_var("XDG_CURRENT_DESKTOP", "LeftWM");
         let mut children = Nanny::autostart();
 
         let flag = Arc::new(AtomicBool::new(false));
@@ -52,7 +53,6 @@ fn main() {
 
         // Fix for Java apps so they repaint correctly
         env::set_var("_JAVA_AWT_WM_NONREPARENTING", "1");
-        env::set_var("XDG_CURRENT_DESKTOP", "LeftWM");
 
         let worker_path = current_exe.with_file_name("leftwm-worker");
 


### PR DESCRIPTION
Just a small patch:
- fix order of setting XDG Autostart env, solves #644
- solve a few minor clippy pedantic lints

---
There is currently one `clippy pedantic` lint left, about missing `error doc` of `impl keybind` ind `leftwm/src/config/mod.rs` but I guess this takes a little more time to be done properly.