### PR TITLE
Make workspace layouts an option

### DIFF
--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -11,5 +11,5 @@ pub struct Workspace {
     pub width: i32,
     pub id: Option<i32>,
     pub max_window_width: Option<Size>,
-    pub layouts: Vec<Layout>,
+    pub layouts: Option<Vec<Layout>>,
 }

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -28,7 +28,6 @@ impl LayoutManager {
             .workspaces()
             .unwrap_or_default()
             .iter()
-            // .filter(|ws| ws.id.is_some() && ws.layouts.is_some())
             .map(|ws| {
                 (
                     ws.id.unwrap_or_default(),

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -124,11 +124,11 @@ mod tests {
             workspaces: Some(vec![
                 crate::config::Workspace {
                     id: Some(0),
-                    layouts: vec![
+                    layouts: Some(vec![
                         Layout::CenterMain,
                         Layout::CenterMainBalanced,
                         Layout::MainAndDeck,
-                    ],
+                    ]),
                     ..Default::default()
                 },
                 crate::config::Workspace {
@@ -137,7 +137,7 @@ mod tests {
                 },
                 crate::config::Workspace {
                     id: Some(2),
-                    layouts: vec![],
+                    layouts: Some(vec![]),
                     ..Default::default()
                 },
             ]),

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -28,7 +28,7 @@ impl LayoutManager {
             .workspaces()
             .unwrap_or_default()
             .iter()
-            .filter_map(|ws| ws.id.map(|id| (id, ws.layouts.clone())))
+            .filter_map(|ws| ws.id.map(|id| (id, ws.layouts.clone().unwrap_or_default())))
             .collect();
 
         Self {

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -28,7 +28,13 @@ impl LayoutManager {
             .workspaces()
             .unwrap_or_default()
             .iter()
-            .filter_map(|ws| ws.id.map(|id| (id, ws.layouts.clone().unwrap_or_default())))
+            // .filter(|ws| ws.id.is_some() && ws.layouts.is_some())
+            .map(|ws| {
+                (
+                    ws.id.unwrap_or_default(),
+                    ws.layouts.clone().unwrap_or_default(),
+                )
+            })
             .collect();
 
         Self {


### PR DESCRIPTION
This makes the `layouts` field in workspace config optional.
This was mainly a little papercut, when workspaces are setup manually, but share the same set of layouts.