### PR TITLE
[bugfix] `leftwm-check` didn't reset color

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -97,7 +97,7 @@ fn check_elogind(verbose: bool) -> Result<()> {
                 println!(":: XDG_RUNTIME_DIR: {}, LOGINCTL OKAY", val);
             }
 
-            println!("\x1b[0;92m    -> Environment OK \x1b[0;92m");
+            println!("\x1b[0;92m    -> Environment OK \x1b[0m");
 
             Ok(())
         }
@@ -106,7 +106,7 @@ fn check_elogind(verbose: bool) -> Result<()> {
                 println!(":: XDG_RUNTIME_DIR: {}, LOGINCTL not installed", val);
             }
 
-            println!("\x1b[0;92m    -> Environment OK (has XDG_RUNTIME_DIR) \x1b[0;92m");
+            println!("\x1b[0;92m    -> Environment OK (has XDG_RUNTIME_DIR) \x1b[0m");
 
             Ok(())
         }
@@ -188,7 +188,7 @@ fn check_theme_contents(filepaths: Vec<PathBuf>, verbose: bool) -> bool {
     }
 
     if returns.is_empty() {
-        println!("\x1b[0;92m    -> Theme OK \x1b[0;92m");
+        println!("\x1b[0;92m    -> Theme OK \x1b[0m");
         true
     } else {
         for error in &returns {

--- a/leftwm/src/config/checks.rs
+++ b/leftwm/src/config/checks.rs
@@ -37,7 +37,7 @@ impl Config {
         let mut returns = Vec::new();
         println!("\x1b[0;94m::\x1b[0m Checking keybinds . . .");
         let mut bindings = HashSet::new();
-        for keybind in self.keybind.iter() {
+        for keybind in &self.keybind {
             if verbose {
                 println!("Keybind: {:?} {}", keybind, keybind.value.is_empty());
             }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -139,7 +139,7 @@ impl Keybind {
 /// spawn_floating = false
 /// ```
 ///
-/// windows whose WM_CLASS is "krita" will spawn on tag 3 (1-indexed) and not floating.
+/// windows whose `WM_CLASS` is "krita" will spawn on tag 3 (1-indexed) and not floating.
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct WindowHook {
     /// `WM_CLASS` in X11
@@ -169,7 +169,7 @@ impl WindowHook {
             window.tags = vec![tag];
         }
         if let Some(should_float) = self.spawn_floating {
-            window.set_floating(should_float)
+            window.set_floating(should_float);
         }
     }
 }


### PR DESCRIPTION
This fixes a report from Discord, by user Jalish#4407, that the line `Theme OK` did not reset the terminal color. So when no prompt styling is present any further characters in the terminal are printed in green.

While allready at this I fixed this for all `println` in `leftwm-check.rs`.