### PR TITLE
fix: dialogue windows getting cut-off (#668)

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -368,8 +368,7 @@ fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
         || ws.center_halfed(),
         |mut requested| {
             requested.center_relative(outer, window.border);
-            let (corner_x, corner_y) = requested.lower_right_corner();
-            if ws.contains_point(corner_x, corner_y) {
+            if ws.xyhw.contains_xyhw(&requested) {
                 requested
             } else {
                 ws.center_halfed()

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -368,7 +368,12 @@ fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
         || ws.center_halfed(),
         |mut requested| {
             requested.center_relative(outer, window.border);
-            requested
+            let (corner_x, corner_y) = requested.lower_right_corner();
+            if ws.contains_point(corner_x, corner_y) {
+                requested
+            } else {
+                ws.center_halfed()
+            }
         },
     );
     window.set_floating_exact(xyhw);

--- a/leftwm-core/src/models/xyhw.rs
+++ b/leftwm-core/src/models/xyhw.rs
@@ -281,6 +281,13 @@ impl Xyhw {
         let y = self.y + (self.h / 2);
         (x, y)
     }
+
+    #[must_use]
+    pub const fn lower_right_corner(&self) -> (i32, i32) {
+        let x = self.x + self.w;
+        let y = self.y + self.h;
+        (x, y)
+    }
 }
 
 #[cfg(test)]

--- a/leftwm-core/src/models/xyhw.rs
+++ b/leftwm-core/src/models/xyhw.rs
@@ -275,14 +275,12 @@ impl Xyhw {
         self.y = outer.y() + outer.h() / 2 - self.h / 2 - border;
     }
 
-    #[must_use]
     pub const fn center(&self) -> (i32, i32) {
         let x = self.x + (self.w / 2);
         let y = self.y + (self.h / 2);
         (x, y)
     }
 
-    #[must_use]
     pub const fn lower_right_corner(&self) -> (i32, i32) {
         let x = self.x + self.w;
         let y = self.y + self.h;

--- a/leftwm-core/src/models/xyhw.rs
+++ b/leftwm-core/src/models/xyhw.rs
@@ -210,6 +210,12 @@ impl Xyhw {
         (self.x <= x && x <= max_x) && (self.y <= y && y <= max_y)
     }
 
+    pub const fn contains_xyhw(&self, other: &Self) -> bool {
+        let other_max_x = other.x + other.w;
+        let other_max_y = other.y + other.h;
+        self.contains_point(other.x, other.y) && self.contains_point(other_max_x, other_max_y)
+    }
+
     #[must_use]
     pub const fn volume(&self) -> u64 {
         self.h as u64 * self.w as u64
@@ -278,12 +284,6 @@ impl Xyhw {
     pub const fn center(&self) -> (i32, i32) {
         let x = self.x + (self.w / 2);
         let y = self.y + (self.h / 2);
-        (x, y)
-    }
-
-    pub const fn lower_right_corner(&self) -> (i32, i32) {
-        let x = self.x + self.w;
-        let y = self.y + self.h;
         (x, y)
     }
 }
@@ -421,5 +421,62 @@ mod tests {
                 ..Xyhw::default()
             }
         );
+    }
+
+    #[test]
+    fn contains_xyhw_should_detect_a_inner_window() {
+        let a = Xyhw {
+            x: 0,
+            y: 0,
+            h: 1000,
+            w: 1000,
+            ..Xyhw::default()
+        };
+        let b = Xyhw {
+            x: 100,
+            y: 100,
+            h: 800,
+            w: 800,
+            ..Xyhw::default()
+        };
+        assert!(a.contains_xyhw(&b));
+    }
+
+    #[test]
+    fn contains_xyhw_should_detect_a_upper_left_corner_outside() {
+        let a = Xyhw {
+            x: 100,
+            y: 100,
+            h: 800,
+            w: 800,
+            ..Xyhw::default()
+        };
+        let b = Xyhw {
+            x: 0,
+            y: 0,
+            h: 200,
+            w: 200,
+            ..Xyhw::default()
+        };
+        assert!(!a.contains_xyhw(&b));
+    }
+
+    #[test]
+    fn contains_xyhw_should_detect_a_lower_right_corner_outside() {
+        let a = Xyhw {
+            x: 100,
+            y: 100,
+            h: 800,
+            w: 800,
+            ..Xyhw::default()
+        };
+        let b = Xyhw {
+            x: 800,
+            y: 800,
+            h: 200,
+            w: 200,
+            ..Xyhw::default()
+        };
+        assert!(!a.contains_xyhw(&b));
     }
 }


### PR DESCRIPTION
This PR fixes the dialog windows getting cut off error by centering them in the workspace if their lower right corner is outside the workspace.

Since I'm starting with Rust, please let me know if there are more "idiomatic" ways of implementing it.
I'm eager to learn, thanks!

![image](https://user-images.githubusercontent.com/56983005/151640808-ae3148aa-0ad6-4b57-a5bf-89784847027e.png)
