### PR TITLE
Reduce xlib calls and other optimisations

### DIFF
--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -44,7 +44,7 @@ pub enum DisplayAction {
     },
 
     /// Remove focus on any visible window by focusing the root window.
-    Unfocus(Option<WindowHandle>),
+    Unfocus(Option<WindowHandle>, bool),
 
     /// To the window under the cursor to take the focus.
     FocusWindowUnderCursor,

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -15,7 +15,7 @@ pub enum DisplayAction {
 
     /// Get triggered after a new window is discovered and WE are
     /// managing it.
-    AddedWindow(WindowHandle, bool),
+    AddedWindow(WindowHandle, bool, bool),
 
     /// Makes sure the mouse is over a given window.
     MoveMouseOver(WindowHandle),
@@ -40,7 +40,7 @@ pub enum DisplayAction {
     /// Tell a window that it is to become focused.
     WindowTakeFocus {
         window: Window,
-        previous_handle: Option<WindowHandle>,
+        previous_window: Option<Window>,
     },
 
     /// Remove focus on any visible window by focusing the root window.

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::display_action::DisplayAction;
 use crate::models::Window;
+use crate::models::WindowHandle;
 use crate::models::Workspace;
 use crate::DisplayEvent;
 #[cfg(test)]
@@ -18,11 +19,17 @@ pub trait DisplayServer {
 
     fn get_next_events(&mut self) -> Vec<DisplayEvent>;
 
-    fn load_config(&mut self, _config: &impl Config) {}
+    fn load_config(
+        &mut self,
+        _config: &impl Config,
+        _focused: Option<&Option<WindowHandle>>,
+        _windows: &[Window],
+    ) {
+    }
 
-    fn update_windows(&self, _windows: Vec<&Window>, _focused: Option<&Window>) {}
+    fn update_windows(&self, _windows: Vec<&Window>) {}
 
-    fn update_workspaces(&self, _windows: Vec<&Workspace>, _focused: Option<&Workspace>) {}
+    fn update_workspaces(&self, _focused: Option<&Workspace>) {}
 
     fn execute_action(&mut self, _act: DisplayAction) -> Option<DisplayEvent> {
         None

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -34,7 +34,7 @@ impl<'a> From<XEvent<'a>> for Option<DisplayEvent> {
             // Mouse button pressed.
             xlib::ButtonPress => Some(from_button_press(raw_event)),
             // Mouse button released.
-            xlib::ButtonRelease if !normal_mode => Some(DisplayEvent::ChangeToNormalMode),
+            xlib::ButtonRelease if !normal_mode => Some(from_button_release(x_event)),
             // Keyboard key pressed.
             xlib::KeyPress => Some(from_key_press(x_event)),
             // Listen for keyboard changes.
@@ -190,6 +190,12 @@ fn from_button_press(raw_event: xlib::XEvent) -> DisplayEvent {
     let mut mod_mask = event.state;
     mod_mask &= !(xlib::Mod2Mask | xlib::LockMask);
     DisplayEvent::MouseCombo(mod_mask, event.button, h)
+}
+
+fn from_button_release(x_event: XEvent) -> DisplayEvent {
+    let xw = x_event.0;
+    xw.set_mode(Mode::Normal);
+    DisplayEvent::ChangeToNormalMode
 }
 
 fn from_key_press(x_event: XEvent) -> DisplayEvent {

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -87,7 +87,6 @@ fn from_property_notify(x_event: &XEvent) -> Option<DisplayEvent> {
 }
 
 fn from_configure_request(x_event: XEvent) -> Option<DisplayEvent> {
-    log::info!("ConfigureRequest");
     let xw = x_event.0;
     let event = xlib::XConfigureRequestEvent::from(x_event.1);
     // If the window is not mapped, configure it.
@@ -190,7 +189,6 @@ fn from_motion_notify(x_event: XEvent) -> Option<DisplayEvent> {
 }
 
 fn from_button_press(raw_event: xlib::XEvent) -> DisplayEvent {
-    log::info!("ButtonPress");
     let event = xlib::XButtonPressedEvent::from(raw_event);
     let h = WindowHandle::XlibHandle(event.window);
     let mut mod_mask = event.state;
@@ -199,7 +197,6 @@ fn from_button_press(raw_event: xlib::XEvent) -> DisplayEvent {
 }
 
 fn from_button_release(x_event: XEvent) -> DisplayEvent {
-    log::info!("ButtonRelease");
     let xw = x_event.0;
     xw.set_mode(Mode::Normal);
     DisplayEvent::ChangeToNormalMode

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate_client_message.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate_client_message.rs
@@ -8,6 +8,9 @@ use std::os::raw::c_long;
 use x11_dl::xlib;
 
 pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<DisplayEvent> {
+    if !xw.managed_windows.contains(&event.window) {
+        return None;
+    }
     let atom_name = xw.atoms.get_name(event.message_type);
     log::trace!("ClientMessage: {} : {:?}", event.window, atom_name);
 

--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate_property_notify.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate_property_notify.rs
@@ -7,7 +7,10 @@ use crate::models::Xyhw;
 use x11_dl::xlib;
 
 pub fn from_event(xw: &XWrap, event: xlib::XPropertyEvent) -> Option<DisplayEvent> {
-    if event.window == xw.get_default_root() || event.state == xlib::PropertyDelete {
+    if event.window == xw.get_default_root()
+        || event.state == xlib::PropertyDelete
+        || !xw.managed_windows.contains(&event.window)
+    {
         return None;
     }
 

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -83,30 +83,14 @@ impl DisplayServer for XlibDisplayServer {
             }
         }
 
-        match self.xw.mode {
-            // Only process minimal events when moving/resizing.
-            Mode::MovingWindow(_)
-            | Mode::ResizingWindow(_)
-            | Mode::ReadyToMove(_)
-            | Mode::ReadyToResize(_) => {
-                let xlib_event = self.xw.get_mask_event();
-                let event = XEvent(&mut self.xw, xlib_event).into();
-                if let Some(e) = event {
-                    log::trace!("DisplayEvent: {:?}", e);
-                    events.push(e);
-                }
-            }
-            Mode::Normal => {
-                let events_in_queue = self.xw.queue_len();
+        let events_in_queue = self.xw.queue_len();
 
-                for _ in 0..events_in_queue {
-                    let xlib_event = self.xw.get_next_event();
-                    let event = XEvent(&mut self.xw, xlib_event).into();
-                    if let Some(e) = event {
-                        log::trace!("DisplayEvent: {:?}", e);
-                        events.push(e);
-                    }
-                }
+        for _ in 0..events_in_queue {
+            let xlib_event = self.xw.get_next_event();
+            let event = XEvent(&mut self.xw, xlib_event).into();
+            if let Some(e) = event {
+                log::trace!("DisplayEvent: {:?}", e);
+                events.push(e);
             }
         }
 

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -51,22 +51,22 @@ impl DisplayServer for XlibDisplayServer {
         }
     }
 
-    fn load_config(&mut self, config: &impl Config) {
-        self.xw.load_config(config);
+    fn load_config(
+        &mut self,
+        config: &impl Config,
+        focused: Option<&Option<WindowHandle>>,
+        windows: &[Window],
+    ) {
+        self.xw.load_config(config, focused, windows);
     }
 
-    fn update_windows(&self, windows: Vec<&Window>, focused_window: Option<&Window>) {
+    fn update_windows(&self, windows: Vec<&Window>) {
         for window in &windows {
-            let is_focused = match focused_window {
-                Some(f) => f.handle == window.handle,
-                None => false,
-            };
-
-            self.xw.update_window(window, is_focused);
+            self.xw.update_window(window);
         }
     }
 
-    fn update_workspaces(&self, _workspaces: Vec<&Workspace>, focused: Option<&Workspace>) {
+    fn update_workspaces(&self, focused: Option<&Workspace>) {
         if let Some(focused) = focused {
             self.xw.set_current_desktop(&focused.tags);
         }
@@ -110,8 +110,8 @@ impl DisplayServer for XlibDisplayServer {
                 self.xw.kill_window(&w);
                 None
             }
-            DisplayAction::AddedWindow(w, follow_mouse) => {
-                self.xw.setup_managed_window(w, follow_mouse)
+            DisplayAction::AddedWindow(w, floating, follow_mouse) => {
+                self.xw.setup_managed_window(w, floating, follow_mouse)
             }
             DisplayAction::MoveMouseOver(handle) => {
                 if let WindowHandle::XlibHandle(win) = handle {
@@ -129,9 +129,9 @@ impl DisplayServer for XlibDisplayServer {
             }
             DisplayAction::WindowTakeFocus {
                 window,
-                previous_handle,
+                previous_window,
             } => {
-                self.xw.window_take_focus(&window, previous_handle);
+                self.xw.window_take_focus(&window, previous_window.as_ref());
                 None
             }
             DisplayAction::Unfocus(handle) => {

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -84,6 +84,7 @@ impl DisplayServer for XlibDisplayServer {
         }
 
         match self.xw.mode {
+            // Only process minimal events when moving/resizing.
             Mode::MovingWindow(_)
             | Mode::ResizingWindow(_)
             | Mode::ReadyToMove(_)

--- a/leftwm-core/src/display_servers/xlib_display_server/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/mod.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::display_action::DisplayAction;
 use crate::models::Mode;
 use crate::models::Screen;
+use crate::models::TagId;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use crate::models::WindowState;
@@ -9,6 +10,7 @@ use crate::models::Workspace;
 use crate::utils;
 use crate::DisplayEvent;
 use crate::DisplayServer;
+use crate::Keybind;
 use futures::prelude::*;
 use std::pin::Pin;
 use x11_dl::xlib;
@@ -81,9 +83,9 @@ impl DisplayServer for XlibDisplayServer {
             }
         }
 
-        let event_in_queue = self.xw.queue_len();
+        let events_in_queue = self.xw.queue_len();
 
-        for _ in 0..event_in_queue {
+        for _ in 0..events_in_queue {
             let xlib_event = self.xw.get_next_event();
             let event = XEvent(&mut self.xw, xlib_event).into();
             if let Some(e) = event {
@@ -101,137 +103,32 @@ impl DisplayServer for XlibDisplayServer {
         events
     }
 
-    // TODO: Split function up.
-    #[allow(clippy::too_many_lines)]
     fn execute_action(&mut self, act: DisplayAction) -> Option<DisplayEvent> {
         log::trace!("DisplayAction: {:?}", act);
         let event: Option<DisplayEvent> = match act {
-            DisplayAction::KillWindow(w) => {
-                self.xw.kill_window(&w);
-                None
-            }
-            DisplayAction::AddedWindow(w, floating, follow_mouse) => {
-                self.xw.setup_managed_window(w, floating, follow_mouse)
-            }
-            DisplayAction::MoveMouseOver(handle) => {
-                if let WindowHandle::XlibHandle(win) = handle {
-                    let _ = self.xw.move_cursor_to_window(win);
-                }
-                None
-            }
-            DisplayAction::MoveMouseOverPoint(point) => {
-                let _ = self.xw.move_cursor_to_point(point);
-                None
-            }
-            DisplayAction::DestroyedWindow(w) => {
-                self.xw.teardown_managed_window(&w);
-                None
-            }
+            DisplayAction::KillWindow(h) => self.from_kill_window(h),
+            DisplayAction::AddedWindow(h, fl, fm) => self.from_added_window(h, fl, fm),
+            DisplayAction::MoveMouseOver(h) => self.from_move_mouse_over(h),
+            DisplayAction::MoveMouseOverPoint(p) => self.from_move_mouse_over_point(p),
+            DisplayAction::DestroyedWindow(h) => self.from_destroyed_window(h),
+            DisplayAction::Unfocus(h) => self.from_unfocus(h),
+            DisplayAction::SetState(h, t, s) => self.from_set_state(h, t, s),
+            DisplayAction::SetWindowOrder(ws) => self.from_set_window_order(&ws),
+            DisplayAction::MoveToTop(h) => self.from_move_to_top(h),
+            DisplayAction::ReadyToMoveWindow(h) => self.from_ready_to_move_window(h),
+            DisplayAction::ReadyToResizeWindow(h) => self.from_ready_to_resize_window(h),
+            DisplayAction::SetCurrentTags(ts) => self.from_set_current_tags(&ts),
+            DisplayAction::SetWindowTags(h, ts) => self.from_set_window_tags(h, &ts),
+            DisplayAction::ReloadKeyGrabs(ks) => self.from_reload_key_grabs(&ks),
+            DisplayAction::ConfigureXlibWindow(w) => self.from_configure_xlib_window(w),
+
             DisplayAction::WindowTakeFocus {
                 window,
                 previous_window,
-            } => {
-                self.xw.window_take_focus(&window, previous_window.as_ref());
-                None
-            }
-            DisplayAction::Unfocus(handle) => {
-                self.xw.unfocus(handle);
-                None
-            }
-            DisplayAction::SetState(h, toggle_to, window_state) => {
-                // TODO: impl from for windowstate and xlib::Atom
-                let state = match window_state {
-                    WindowState::Modal => self.xw.atoms.NetWMStateModal,
-                    WindowState::Sticky => self.xw.atoms.NetWMStateSticky,
-                    WindowState::MaximizedVert => self.xw.atoms.NetWMStateMaximizedVert,
-                    WindowState::MaximizedHorz => self.xw.atoms.NetWMStateMaximizedHorz,
-                    WindowState::Shaded => self.xw.atoms.NetWMStateShaded,
-                    WindowState::SkipTaskbar => self.xw.atoms.NetWMStateSkipTaskbar,
-                    WindowState::SkipPager => self.xw.atoms.NetWMStateSkipPager,
-                    WindowState::Hidden => self.xw.atoms.NetWMStateHidden,
-                    WindowState::Fullscreen => self.xw.atoms.NetWMStateFullscreen,
-                    WindowState::Above => self.xw.atoms.NetWMStateAbove,
-                    WindowState::Below => self.xw.atoms.NetWMStateBelow,
-                };
-                self.xw.set_state(h, toggle_to, state);
-                None
-            }
-            DisplayAction::SetWindowOrder(windows) => {
-                // The windows we are managing should be behind unmanaged windows. Unless they are
-                // fullscreen, or their children.
-                let (fullscreen_windows, other): (Vec<&Window>, Vec<&Window>) =
-                    windows.iter().partition(|w| w.is_fullscreen());
-                // Fullscreen windows.
-                let level2: Vec<WindowHandle> =
-                    fullscreen_windows.iter().map(|w| w.handle).collect();
-                let (fullscreen_children, other): (Vec<&Window>, Vec<&Window>) =
-                    other.iter().partition(|w| {
-                        level2.contains(&w.transient.unwrap_or(WindowHandle::XlibHandle(0)))
-                    });
-                // Fullscreen windows children.
-                let level1: Vec<WindowHandle> =
-                    fullscreen_children.iter().map(|w| w.handle).collect();
-                // Left over managed windows.
-                let level4: Vec<WindowHandle> = other.iter().map(|w| w.handle).collect();
-                // Unmanaged windows.
-                let level3: Vec<WindowHandle> = self
-                    .xw
-                    .get_all_windows()
-                    .unwrap_or_default()
-                    .iter()
-                    .filter(|&w| *w != self.root)
-                    .map(|w| WindowHandle::XlibHandle(*w))
-                    .filter(|&h| !windows.iter().any(|w| w.handle == h))
-                    .collect();
-                let all: Vec<WindowHandle> = level1
-                    .iter()
-                    .chain(level2.iter())
-                    .chain(level3.iter())
-                    .chain(level4.iter())
-                    .copied()
-                    .collect();
-                self.xw.restack(all);
-                None
-            }
-            DisplayAction::MoveToTop(handle) => {
-                self.xw.move_to_top(&handle);
-                None
-            }
-            DisplayAction::FocusWindowUnderCursor => {
-                let point = self.xw.get_cursor_point().ok()?;
-                let evt = DisplayEvent::MoveFocusTo(point.0, point.1);
-                Some(evt)
-            }
-            DisplayAction::ReadyToMoveWindow(w) => {
-                self.xw.set_mode(Mode::ReadyToMove(w));
-                None
-            }
-            DisplayAction::ReadyToResizeWindow(w) => {
-                self.xw.set_mode(Mode::ReadyToResize(w));
-                None
-            }
-            DisplayAction::NormalMode => {
-                self.xw.set_mode(Mode::Normal);
-                None
-            }
-            DisplayAction::SetCurrentTags(tags) => {
-                self.xw.set_current_desktop(&tags);
-                None
-            }
-            DisplayAction::SetWindowTags(handle, tag) => {
-                if let WindowHandle::XlibHandle(window) = handle {
-                    self.xw.set_window_desktop(window, &tag);
-                }
-                None
-            }
-            DisplayAction::ReloadKeyGrabs(keybinds) => {
-                self.xw.reset_grabs(&keybinds);
-                None
-            }
-            DisplayAction::ConfigureXlibWindow(window) => {
-                self.xw.configure_window(&window);
-                None
-            }
+            } => self.from_window_take_focus(window, previous_window),
+
+            DisplayAction::FocusWindowUnderCursor => self.from_focus_window_under_cursor(),
+            DisplayAction::NormalMode => self.from_normal_mode(),
         };
         if event.is_some() {
             log::trace!("DisplayEvent: {:?}", event);
@@ -307,5 +204,162 @@ impl XlibDisplayServer {
             }
         }
         all
+    }
+
+    // Display actions.
+    fn from_kill_window(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        self.xw.kill_window(&handle);
+        None
+    }
+
+    fn from_added_window(
+        &mut self,
+        handle: WindowHandle,
+        floating: bool,
+        follow_mouse: bool,
+    ) -> Option<DisplayEvent> {
+        self.xw.setup_managed_window(handle, floating, follow_mouse)
+    }
+
+    fn from_move_mouse_over(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        if let WindowHandle::XlibHandle(win) = handle {
+            let _ = self.xw.move_cursor_to_window(win);
+        }
+        None
+    }
+
+    fn from_move_mouse_over_point(&mut self, point: (i32, i32)) -> Option<DisplayEvent> {
+        let _ = self.xw.move_cursor_to_point(point);
+        None
+    }
+
+    fn from_destroyed_window(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        self.xw.teardown_managed_window(&handle);
+        None
+    }
+
+    fn from_unfocus(&mut self, handle: Option<WindowHandle>) -> Option<DisplayEvent> {
+        self.xw.unfocus(handle);
+        None
+    }
+
+    fn from_set_state(
+        &mut self,
+        handle: WindowHandle,
+        toggle_to: bool,
+        window_state: WindowState,
+    ) -> Option<DisplayEvent> {
+        // TODO: impl from for windowstate and xlib::Atom
+        let state = match window_state {
+            WindowState::Modal => self.xw.atoms.NetWMStateModal,
+            WindowState::Sticky => self.xw.atoms.NetWMStateSticky,
+            WindowState::MaximizedVert => self.xw.atoms.NetWMStateMaximizedVert,
+            WindowState::MaximizedHorz => self.xw.atoms.NetWMStateMaximizedHorz,
+            WindowState::Shaded => self.xw.atoms.NetWMStateShaded,
+            WindowState::SkipTaskbar => self.xw.atoms.NetWMStateSkipTaskbar,
+            WindowState::SkipPager => self.xw.atoms.NetWMStateSkipPager,
+            WindowState::Hidden => self.xw.atoms.NetWMStateHidden,
+            WindowState::Fullscreen => self.xw.atoms.NetWMStateFullscreen,
+            WindowState::Above => self.xw.atoms.NetWMStateAbove,
+            WindowState::Below => self.xw.atoms.NetWMStateBelow,
+        };
+        self.xw.set_state(handle, toggle_to, state);
+        None
+    }
+
+    fn from_set_window_order(&mut self, windows: &[Window]) -> Option<DisplayEvent> {
+        // The windows we are managing should be behind unmanaged windows. Unless they are
+        // fullscreen, or their children.
+        let (fullscreen_windows, other): (Vec<&Window>, Vec<&Window>) =
+            windows.iter().partition(|w| w.is_fullscreen());
+        // Fullscreen windows.
+        let level2: Vec<WindowHandle> = fullscreen_windows.iter().map(|w| w.handle).collect();
+        let (fullscreen_children, other): (Vec<&Window>, Vec<&Window>) = other
+            .iter()
+            .partition(|w| level2.contains(&w.transient.unwrap_or(WindowHandle::XlibHandle(0))));
+        // Fullscreen windows children.
+        let level1: Vec<WindowHandle> = fullscreen_children.iter().map(|w| w.handle).collect();
+        // Left over managed windows.
+        let level4: Vec<WindowHandle> = other.iter().map(|w| w.handle).collect();
+        // Unmanaged windows.
+        let level3: Vec<WindowHandle> = self
+            .xw
+            .get_all_windows()
+            .unwrap_or_default()
+            .iter()
+            .filter(|&w| *w != self.root)
+            .map(|w| WindowHandle::XlibHandle(*w))
+            .filter(|&h| !windows.iter().any(|w| w.handle == h))
+            .collect();
+        let all: Vec<WindowHandle> = level1
+            .iter()
+            .chain(level2.iter())
+            .chain(level3.iter())
+            .chain(level4.iter())
+            .copied()
+            .collect();
+        self.xw.restack(all);
+        None
+    }
+
+    fn from_move_to_top(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        self.xw.move_to_top(&handle);
+        None
+    }
+
+    fn from_ready_to_move_window(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        self.xw.set_mode(Mode::ReadyToMove(handle));
+        None
+    }
+
+    fn from_ready_to_resize_window(&mut self, handle: WindowHandle) -> Option<DisplayEvent> {
+        self.xw.set_mode(Mode::ReadyToResize(handle));
+        None
+    }
+
+    fn from_set_current_tags(&mut self, tags: &[TagId]) -> Option<DisplayEvent> {
+        self.xw.set_current_desktop(&tags);
+        None
+    }
+
+    fn from_set_window_tags(
+        &mut self,
+        handle: WindowHandle,
+        tags: &[TagId],
+    ) -> Option<DisplayEvent> {
+        if let WindowHandle::XlibHandle(window) = handle {
+            self.xw.set_window_desktop(window, &tags);
+        }
+        None
+    }
+
+    fn from_reload_key_grabs(&mut self, keybinds: &[Keybind]) -> Option<DisplayEvent> {
+        self.xw.reset_grabs(&keybinds);
+        None
+    }
+
+    fn from_configure_xlib_window(&mut self, window: Window) -> Option<DisplayEvent> {
+        self.xw.configure_window(&window);
+        None
+    }
+
+    fn from_window_take_focus(
+        &mut self,
+        window: Window,
+        previous_window: Option<Window>,
+    ) -> Option<DisplayEvent> {
+        self.xw.window_take_focus(&window, previous_window.as_ref());
+        None
+    }
+
+    fn from_focus_window_under_cursor(&mut self) -> Option<DisplayEvent> {
+        let point = self.xw.get_cursor_point().ok()?;
+        let evt = DisplayEvent::MoveFocusTo(point.0, point.1);
+        Some(evt)
+    }
+
+    fn from_normal_mode(&mut self) -> Option<DisplayEvent> {
+        self.xw.set_mode(Mode::Normal);
+        None
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
@@ -4,7 +4,6 @@ use x11_dl::xlib;
 // Specifications can be found here:
 // https://specifications.freedesktop.org/wm-spec/1.3/ar01s03.html
 
-//#![allow(non_snake_case)]
 #[derive(Clone, Debug)]
 #[allow(non_snake_case)]
 pub struct XAtom {
@@ -120,143 +119,57 @@ impl XAtom {
     #[allow(clippy::too_many_lines)]
     // TODO: Use a match statement.
     pub const fn get_name(&self, atom: xlib::Atom) -> &str {
-        if atom == self.WMProtocols {
-            return "WM_PROTOCOLS";
-        }
-        if atom == self.WMDelete {
-            return "WM_DELETE_WINDOW";
-        }
-        if atom == self.WMState {
-            return "WM_STATE";
-        }
-        if atom == self.WMClass {
-            return "WM_CLASS";
-        }
-        if atom == self.WMTakeFocus {
-            return "WM_TAKE_FOCUS";
-        }
-        if atom == self.NetActiveWindow {
-            return "_NET_ACTIVE_WINDOW";
-        }
-        if atom == self.NetSupported {
-            return "_NET_SUPPORTED";
-        }
-        if atom == self.NetWMName {
-            return "_NET_WM_NAME";
-        }
-        if atom == self.NetWMState {
-            return "_NET_WM_STATE";
-        }
-        if atom == self.NetWMAction {
-            return "_NET_WM_ALLOWED_ACTIONS";
-        }
-        if atom == self.NetWMPid {
-            return "_NET_WM_PID";
-        }
+        match atom {
+            a if a == self.WMProtocols => "WM_PROTOCOLS",
+            a if a == self.WMDelete => "WM_DELETE_WINDOW",
+            a if a == self.WMState => "WM_STATE",
+            a if a == self.WMClass => "WM_CLASS",
+            a if a == self.WMTakeFocus => "WM_TAKE_FOCUS",
+            a if a == self.NetActiveWindow => "_NET_ACTIVE_WINDOW",
+            a if a == self.NetSupported => "_NET_SUPPORTED",
+            a if a == self.NetWMName => "_NET_WM_NAME",
+            a if a == self.NetWMState => "_NET_WM_STATE",
+            a if a == self.NetWMAction => "_NET_WM_ALLOWED_ACTIONS",
+            a if a == self.NetWMPid => "_NET_WM_PID",
 
-        if atom == self.NetWMStateModal {
-            return "NetWMStateModal";
-        }
-        if atom == self.NetWMStateSticky {
-            return "NetWMStateSticky";
-        }
-        if atom == self.NetWMStateMaximizedVert {
-            return "NetWMStateMaximizedVert";
-        }
-        if atom == self.NetWMStateMaximizedHorz {
-            return "NetWMStateMaximizedHorz";
-        }
-        if atom == self.NetWMStateShaded {
-            return "NetWMStateShaded";
-        }
-        if atom == self.NetWMStateSkipTaskbar {
-            return "NetWMStateSkipTaskbar";
-        }
-        if atom == self.NetWMStateSkipPager {
-            return "NetWMStateSkipPager";
-        }
-        if atom == self.NetWMStateHidden {
-            return "NetWMStateHidden";
-        }
-        if atom == self.NetWMStateFullscreen {
-            return "NetWMStateFullscreen";
-        }
-        if atom == self.NetWMStateAbove {
-            return "NetWMStateAbove";
-        }
-        if atom == self.NetWMStateBelow {
-            return "NetWMStateBelow";
-        }
+            a if a == self.NetWMStateModal => "NetWMStateModal",
+            a if a == self.NetWMStateSticky => "NetWMStateSticky",
+            a if a == self.NetWMStateMaximizedVert => "NetWMStateMaximizedVert",
+            a if a == self.NetWMStateMaximizedHorz => "NetWMStateMaximizedHorz",
+            a if a == self.NetWMStateShaded => "NetWMStateShaded",
+            a if a == self.NetWMStateSkipTaskbar => "NetWMStateSkipTaskbar",
+            a if a == self.NetWMStateSkipPager => "NetWMStateSkipPager",
+            a if a == self.NetWMStateHidden => "NetWMStateHidden",
+            a if a == self.NetWMStateFullscreen => "NetWMStateFullscreen",
+            a if a == self.NetWMStateAbove => "NetWMStateAbove",
+            a if a == self.NetWMStateBelow => "NetWMStateBelow",
 
-        if atom == self.NetWMActionMove {
-            return "_NET_WM_ACTION_MOVE";
-        }
-        if atom == self.NetWMActionResize {
-            return "_NET_WM_ACTION_RESIZE";
-        }
-        if atom == self.NetWMActionMinimize {
-            return "_NET_WM_ACTION_MINIMIZE";
-        }
-        if atom == self.NetWMActionShade {
-            return "_NET_WM_ACTION_SHADE";
-        }
-        if atom == self.NetWMActionStick {
-            return "_NET_WM_ACTION_STICK";
-        }
-        if atom == self.NetWMActionMaximizeHorz {
-            return "_NET_WM_ACTION_MAXIMIZE_HORZ";
-        }
-        if atom == self.NetWMActionMaximizeVert {
-            return "_NET_WM_ACTION_MAXIMIZE_VERT";
-        }
-        if atom == self.NetWMActionFullscreen {
-            return "_NET_WM_ACTION_FULLSCREEN";
-        }
-        if atom == self.NetWMActionChangeDesktop {
-            return "_NET_WM_ACTION_CHANGE_DESKTOP";
-        }
-        if atom == self.NetWMActionClose {
-            return "_NET_WM_ACTION_CLOSE";
-        }
+            a if a == self.NetWMActionMove => "_NET_WM_ACTION_MOVE",
+            a if a == self.NetWMActionResize => "_NET_WM_ACTION_RESIZE",
+            a if a == self.NetWMActionMinimize => "_NET_WM_ACTION_MINIMIZE",
+            a if a == self.NetWMActionShade => "_NET_WM_ACTION_SHADE",
+            a if a == self.NetWMActionStick => "_NET_WM_ACTION_STICK",
+            a if a == self.NetWMActionMaximizeHorz => "_NET_WM_ACTION_MAXIMIZE_HORZ",
+            a if a == self.NetWMActionMaximizeVert => "_NET_WM_ACTION_MAXIMIZE_VERT",
+            a if a == self.NetWMActionFullscreen => "_NET_WM_ACTION_FULLSCREEN",
+            a if a == self.NetWMActionChangeDesktop => "_NET_WM_ACTION_CHANGE_DESKTOP",
+            a if a == self.NetWMActionClose => "_NET_WM_ACTION_CLOSE",
 
-        if atom == self.NetWMWindowType {
-            return "_NET_WM_WINDOW_TYPE";
-        }
-        if atom == self.NetWMWindowTypeDialog {
-            return "_NET_WM_WINDOW_TYPE_DIALOG";
-        }
-        if atom == self.NetWMWindowTypeDock {
-            return "_NET_WM_WINDOW_TYPE_DOCK";
-        }
-        if atom == self.NetClientList {
-            return "_NET_CLIENT_LIST";
-        }
-        if atom == self.NetDesktopViewport {
-            return "_NET_DESKTOP_VIEWPORT";
-        }
-        if atom == self.NetNumberOfDesktops {
-            return "_NET_NUMBER_OF_DESKTOPS";
-        }
-        if atom == self.NetCurrentDesktop {
-            return "_NET_CURRENT_DESKTOP";
-        }
-        if atom == self.NetDesktopNames {
-            return "_NET_DESKTOP_NAMES";
-        }
-        if atom == self.NetWMDesktop {
-            return "_NET_WM_DESKTOP";
-        }
-        if atom == self.NetWMStrutPartial {
-            return "_NET_WM_STRUT_PARTIAL";
-        }
-        if atom == self.NetWMStrut {
-            return "_NET_WM_STRUT";
-        }
+            a if a == self.NetWMWindowType => "_NET_WM_WINDOW_TYPE",
+            a if a == self.NetWMWindowTypeDialog => "_NET_WM_WINDOW_TYPE_DIALOG",
+            a if a == self.NetWMWindowTypeDock => "_NET_WM_WINDOW_TYPE_DOCK",
+            a if a == self.NetClientList => "_NET_CLIENT_LIST",
+            a if a == self.NetDesktopViewport => "_NET_DESKTOP_VIEWPORT",
+            a if a == self.NetNumberOfDesktops => "_NET_NUMBER_OF_DESKTOPS",
+            a if a == self.NetCurrentDesktop => "_NET_CURRENT_DESKTOP",
+            a if a == self.NetDesktopNames => "_NET_DESKTOP_NAMES",
+            a if a == self.NetWMDesktop => "_NET_WM_DESKTOP",
+            a if a == self.NetWMStrutPartial => "_NET_WM_STRUT_PARTIAL",
+            a if a == self.NetWMStrut => "_NET_WM_STRUT",
 
-        if atom == self.UTF8String {
-            return "UTF8_STRING";
+            a if a == self.UTF8String => "UTF8_STRING",
+            _ => "(UNKNOWN)",
         }
-        "(UNKNOWN)"
     }
 
     pub fn new(xlib: &xlib::Xlib, dpy: *mut xlib::Display) -> Self {

--- a/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xatom.rs
@@ -116,8 +116,6 @@ impl XAtom {
         ]
     }
 
-    #[allow(clippy::too_many_lines)]
-    // TODO: Use a match statement.
     pub const fn get_name(&self, atom: xlib::Atom) -> &str {
         match atom {
             a if a == self.WMProtocols => "WM_PROTOCOLS",

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -180,6 +180,8 @@ impl XWrap {
         None
     }
 
+    /// Returns the next `Xevent` that matches the mask of the xserver.
+    // `XMaskEvent`: https://tronche.com/gui/x/xlib/event-handling/manipulating-event-queue/XMaskEvent.html
     pub fn get_mask_event(&self) -> xlib::XEvent {
         unsafe {
             let mut event: xlib::XEvent = std::mem::zeroed();

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/getters.rs
@@ -1,5 +1,5 @@
 //! `XWrap` getters.
-use super::{Screen, WindowHandle, XlibError, MAX_PROPERTY_VALUE_LEN};
+use super::{Screen, WindowHandle, XlibError, MAX_PROPERTY_VALUE_LEN, MOUSEMASK};
 use crate::models::{DockArea, WindowState, WindowType, XyhwChange};
 use crate::XWrap;
 use std::ffi::CString;
@@ -178,6 +178,18 @@ impl XWrap {
             return Some(xyhw);
         }
         None
+    }
+
+    pub fn get_mask_event(&self) -> xlib::XEvent {
+        unsafe {
+            let mut event: xlib::XEvent = std::mem::zeroed();
+            (self.xlib.XMaskEvent)(
+                self.display,
+                MOUSEMASK | xlib::SubstructureRedirectMask | xlib::ExposureMask,
+                &mut event,
+            );
+            event
+        }
     }
 
     /// Returns the next `Xevent` of the xserver.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -237,10 +237,15 @@ impl XWrap {
         xw
     }
 
-    pub fn load_config(&mut self, config: &impl Config) {
+    pub fn load_config(
+        &mut self,
+        config: &impl Config,
+        focused: Option<&Option<WindowHandle>>,
+        windows: &[Window],
+    ) {
         self.focus_behaviour = config.focus_behaviour();
         self.mouse_key_mask = utils::xkeysym_lookup::into_modmask(&config.mousekey());
-        self.load_colors(config);
+        self.load_colors(config, focused, Some(windows));
         self.tag_labels = config.create_list_of_tag_labels();
         self.reset_grabs(&config.mapped_bindings());
     }
@@ -255,7 +260,7 @@ impl XWrap {
         self.mouse_key_mask = utils::xkeysym_lookup::into_modmask(&config.mousekey());
 
         let root = self.root;
-        self.load_colors(config);
+        self.load_colors(config, None, None);
 
         let mut attrs: xlib::XSetWindowAttributes = unsafe { std::mem::zeroed() };
         attrs.cursor = self.cursors.normal;
@@ -399,12 +404,34 @@ impl XWrap {
     }
 
     /// Load the colors of our theme.
-    pub fn load_colors(&mut self, config: &impl Config) {
+    pub fn load_colors(
+        &mut self,
+        config: &impl Config,
+        focused: Option<&Option<WindowHandle>>,
+        windows: Option<&[Window]>,
+    ) {
         self.colors = Colors {
             normal: self.get_color(config.default_border_color()),
             floating: self.get_color(config.floating_border_color()),
             active: self.get_color(config.focused_border_color()),
         };
+        // Update all the windows with the new colors.
+        if let Some(windows) = windows {
+            for window in windows {
+                if let WindowHandle::XlibHandle(handle) = window.handle {
+                    let is_focused =
+                        matches!(focused, Some(&Some(focused)) if focused == window.handle);
+                    let color: c_ulong = if is_focused {
+                        self.colors.active
+                    } else if window.floating() {
+                        self.colors.floating
+                    } else {
+                        self.colors.normal
+                    };
+                    self.set_window_border_color(handle, color);
+                }
+            }
+        }
     }
 
     /// Sets the mode within our xwrapper.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -450,9 +450,6 @@ impl XWrap {
             Mode::MovingWindow(h) | Mode::ResizingWindow(h)
                 if self.mode == Mode::ReadyToMove(h) || self.mode == Mode::ReadyToResize(h) =>
             {
-                if let WindowHandle::XlibHandle(h) = h {
-                    self.ungrab_buttons(h);
-                }
                 self.ungrab_pointer();
                 self.mode = mode;
                 let cursor = match mode {
@@ -464,13 +461,6 @@ impl XWrap {
             }
             Mode::Normal => {
                 self.ungrab_pointer();
-                match self.mode {
-                    Mode::MovingWindow(WindowHandle::XlibHandle(h))
-                    | Mode::ResizingWindow(WindowHandle::XlibHandle(h)) => {
-                        self.grab_mouse_clicks(h, true);
-                    }
-                    _ => {}
-                }
                 self.mode = mode;
             }
             _ => {}

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mod.rs
@@ -35,11 +35,11 @@ const MAX_PROPERTY_VALUE_LEN: c_long = 4096;
 
 pub const ROOT_EVENT_MASK: c_long = xlib::SubstructureRedirectMask
     | xlib::SubstructureNotifyMask
-    | xlib::StructureNotifyMask
     | xlib::ButtonPressMask
-    | xlib::PointerMotionMask;
+    | xlib::PointerMotionMask
+    | xlib::StructureNotifyMask;
 
-const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask;
+const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask | xlib::ButtonMotionMask;
 const MOUSEMASK: c_long = BUTTONMASK | xlib::PointerMotionMask;
 
 pub struct Colors {
@@ -91,7 +91,6 @@ impl XWrap {
     // `XDefaultRootWindow`: https://tronche.com/gui/x/xlib/display/display-macros.html#DefaultRootWindow
     // `XSetErrorHandler`: https://tronche.com/gui/x/xlib/event-handling/protocol-errors/XSetErrorHandler.html
     // `XSelectInput`: https://tronche.com/gui/x/xlib/event-handling/XSelectInput.html
-    // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn new() -> Self {
@@ -206,8 +205,8 @@ impl XWrap {
         unsafe {
             (xw.xlib.XSetErrorHandler)(Some(startup_check_for_other_wm));
             (xw.xlib.XSelectInput)(xw.display, root, xlib::SubstructureRedirectMask);
-            (xw.xlib.XSync)(xw.display, xlib::False);
         };
+        xw.sync();
 
         // This is allowed for now as const extern fns
         // are not yet stable (1.56.0, 16 Sept 2021)
@@ -230,10 +229,8 @@ impl XWrap {
         // https://stackoverflow.com/questions/35569562/how-to-catch-keyboard-layout-change-event-and-get-current-new-keyboard-layout-on
         xw.keysym_to_keycode(x11_dl::keysym::XK_F1);
 
-        unsafe {
-            (xw.xlib.XSetErrorHandler)(Some(on_error_from_xlib));
-            (xw.xlib.XSync)(xw.display, xlib::False);
-        };
+        unsafe { (xw.xlib.XSetErrorHandler)(Some(on_error_from_xlib)) };
+        xw.sync();
         xw
     }
 
@@ -253,7 +250,6 @@ impl XWrap {
     /// Initialize the xwrapper.
     // `XChangeWindowAttributes`: https://tronche.com/gui/x/xlib/window/XChangeWindowAttributes.html
     // `XDeleteProperty`: https://tronche.com/gui/x/xlib/window-information/XDeleteProperty.html
-    // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     // TODO: split into smaller functions
     pub fn init(&mut self, config: &impl Config) {
         self.focus_behaviour = config.focus_behaviour();
@@ -297,9 +293,7 @@ impl XWrap {
 
         self.reset_grabs(&config.mapped_bindings());
 
-        unsafe {
-            (self.xlib.XSync)(self.display, 0);
-        }
+        self.sync();
     }
 
     /// EWMH support used for bars such as polybar.
@@ -384,10 +378,8 @@ impl XWrap {
         mask: c_long,
         event: &mut xlib::XEvent,
     ) {
-        unsafe {
-            (self.xlib.XSendEvent)(self.display, window, propogate, mask, event);
-            (self.xlib.XSync)(self.display, 0);
-        }
+        unsafe { (self.xlib.XSendEvent)(self.display, window, propogate, mask, event) };
+        self.sync();
     }
 
     /// Returns whether a window can recieve a xevent atom.
@@ -436,8 +428,8 @@ impl XWrap {
 
     /// Sets the mode within our xwrapper.
     pub fn set_mode(&mut self, mode: Mode) {
-        // Prevent resizing and moving of root.
         match mode {
+            // Prevent resizing and moving of root.
             Mode::MovingWindow(h)
             | Mode::ResizingWindow(h)
             | Mode::ReadyToMove(h)
@@ -446,42 +438,47 @@ impl XWrap {
             {
                 return
             }
-            Mode::MovingWindow(WindowHandle::XlibHandle(h))
-            | Mode::ResizingWindow(WindowHandle::XlibHandle(h)) => self.ungrab_buttons(h),
-            _ => {}
-        }
-        if self.mode == Mode::Normal && mode != Mode::Normal {
-            self.mode = mode;
-            if let Ok(loc) = self.get_cursor_point() {
-                self.mode_origin = loc;
-            }
-            let cursor = match mode {
-                Mode::ReadyToResize(_) | Mode::ResizingWindow(_) => self.cursors.resize,
-                Mode::ReadyToMove(_) | Mode::MovingWindow(_) => self.cursors.move_,
-                Mode::Normal => self.cursors.normal,
-            };
-            self.grab_pointer(cursor);
-        }
-        if mode == Mode::Normal {
-            self.ungrab_pointer();
-            match self.mode {
-                Mode::MovingWindow(WindowHandle::XlibHandle(h))
-                | Mode::ResizingWindow(WindowHandle::XlibHandle(h)) => {
-                    self.grab_mouse_clicks(h, true);
+            Mode::ReadyToMove(_) | Mode::ReadyToResize(_) if self.mode == Mode::Normal => {
+                self.mode = mode;
+                if let Ok(loc) = self.get_cursor_point() {
+                    self.mode_origin = loc;
                 }
-                Mode::MovingWindow(_)
-                | Mode::ResizingWindow(_)
-                | Mode::ReadyToMove(_)
-                | Mode::ReadyToResize(_)
-                | Mode::Normal => {}
+                let cursor = match mode {
+                    Mode::ReadyToResize(_) | Mode::ResizingWindow(_) => self.cursors.resize,
+                    Mode::ReadyToMove(_) | Mode::MovingWindow(_) => self.cursors.move_,
+                    Mode::Normal => self.cursors.normal,
+                };
+                self.grab_pointer(cursor);
             }
-            self.mode = mode;
+            Mode::MovingWindow(h) | Mode::ResizingWindow(h)
+                if self.mode == Mode::ReadyToMove(h) || self.mode == Mode::ReadyToResize(h) =>
+            {
+                self.ungrab_pointer();
+                self.mode = mode;
+                let cursor = match mode {
+                    Mode::ReadyToResize(_) | Mode::ResizingWindow(_) => self.cursors.resize,
+                    Mode::ReadyToMove(_) | Mode::MovingWindow(_) => self.cursors.move_,
+                    Mode::Normal => self.cursors.normal,
+                };
+                self.grab_pointer(cursor);
+            }
+            Mode::Normal => {
+                self.ungrab_pointer();
+                self.mode = mode;
+            }
+            _ => {}
         }
     }
 
     /// Wait until readable.
     pub async fn wait_readable(&mut self) {
         self.task_notify.notified().await;
+    }
+
+    /// Flush and sync the xserver.
+    // `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
+    pub fn sync(&self) {
+        unsafe { (self.xlib.XSync)(self.display, xlib::False) };
     }
 
     /// Flush the xserver.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/mouse.rs
@@ -65,7 +65,7 @@ impl XWrap {
                     BUTTONMASK as u32,
                     pointer_mode,
                     xlib::GrabModeAsync,
-                    self.root,
+                    0,
                     0,
                 );
             }
@@ -154,9 +154,12 @@ impl XWrap {
     // `XAllowEvents`: https://linux.die.net/man/3/xallowevents
     //  `XSync`: https://tronche.com/gui/x/xlib/event-handling/XSync.html
     pub fn replay_click(&self) {
-        unsafe {
-            (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime);
-            (self.xlib.XSync)(self.display, xlib::False);
-        }
+        unsafe { (self.xlib.XAllowEvents)(self.display, xlib::ReplayPointer, xlib::CurrentTime) };
+    }
+
+    /// Release the pointer if it is frozen.
+    // `XAllowEvents`: https://linux.die.net/man/3/xallowevents
+    pub fn allow_pointer_events(&self) {
+        unsafe { (self.xlib.XAllowEvents)(self.display, xlib::SyncPointer, xlib::CurrentTime) };
     }
 }

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -148,6 +148,7 @@ impl XWrap {
     }
 
     /// Sets a windows border color.
+    // `XSetWindowBorder`: https://tronche.com/gui/x/xlib/window/XSetWindowBorder.html
     pub fn set_window_border_color(&self, window: xlib::Window, mut color: c_ulong) {
         unsafe {
             // Force border opacity to 0xff.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -147,6 +147,18 @@ impl XWrap {
         }
     }
 
+    /// Sets a windows border color.
+    pub fn set_window_border_color(&self, window: xlib::Window, mut color: c_ulong) {
+        unsafe {
+            // Force border opacity to 0xff.
+            let mut bytes = color.to_le_bytes();
+            bytes[3] = 0xff;
+            color = c_ulong::from_le_bytes(bytes);
+            (self.xlib.XSetWindowBorder)(self.display, window, color);
+        }
+    }
+
+    /// Sets a windows configuration.
     pub fn set_window_config(
         &self,
         window: xlib::Window,

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/setters.rs
@@ -166,10 +166,8 @@ impl XWrap {
         mut window_changes: xlib::XWindowChanges,
         unlock: u32,
     ) {
-        unsafe {
-            (self.xlib.XConfigureWindow)(self.display, window, unlock, &mut window_changes);
-            (self.xlib.XSync)(self.display, 0);
-        }
+        unsafe { (self.xlib.XConfigureWindow)(self.display, window, unlock, &mut window_changes) };
+        self.sync();
     }
 
     /// Sets what desktop a window is on.

--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -185,7 +185,7 @@ impl XWrap {
                 let unlock =
                     xlib::CWX | xlib::CWY | xlib::CWWidth | xlib::CWHeight | xlib::CWBorderWidth;
                 self.set_window_config(handle, changes, u32::from(unlock));
-                self.sync();
+                self.configure_window(window);
             }
             let state = match self.get_wm_state(handle) {
                 Some(state) => state,

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -61,7 +61,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             // If we need to update the displayed state.
             if needs_update {
-                log::info!("Update");
                 self.update_windows();
 
                 match self.state.mode {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -59,6 +59,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             // If we need to update the displayed state.
             if needs_update {
+                log::info!("Update");
                 self.update_windows();
 
                 match self.state.mode {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -53,7 +53,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     needs_update = self.command_handler(&cmd) || needs_update;
                 }
                 else => {
-                    event_buffer.drain(..).for_each(|event| needs_update = self.display_event_handler(event) || needs_update);
+                    event_buffer
+                        .drain(..)
+                        .for_each(|event| needs_update = self.display_event_handler(event) || needs_update);
                 }
             }
 

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -1,5 +1,5 @@
 use crate::{child_process::Nanny, config::Config, models::FocusBehaviour};
-use crate::{CommandPipe, DisplayServer, Manager, Mode, StateSocket, Window, Workspace};
+use crate::{CommandPipe, DisplayServer, Manager, Mode, StateSocket, Window};
 use std::path::{Path, PathBuf};
 use std::sync::{atomic::Ordering, Once};
 
@@ -51,34 +51,28 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 }
                 Some(cmd) = command_pipe.read_command(), if event_buffer.is_empty() => {
                     needs_update = self.command_handler(&cmd) || needs_update;
-                    self.display_server.load_config(&self.config);
                 }
                 else => {
                     event_buffer.drain(..).for_each(|event| needs_update = self.display_event_handler(event) || needs_update);
                 }
             }
 
-            //if we need to update the displayed state
+            // If we need to update the displayed state.
             if needs_update {
                 self.update_windows();
 
                 match self.state.mode {
-                    //when (resizing / moving) only deal with the single window
+                    // When (resizing / moving) only deal with the single window.
                     Mode::ResizingWindow(h) | Mode::MovingWindow(h) => {
-                        let focused = self.state.focus_manager.window(&self.state.windows);
                         let windows: Vec<&Window> = (&self.state.windows)
                             .iter()
                             .filter(|w| w.handle == h)
                             .collect();
-                        self.display_server.update_windows(windows, focused);
+                        self.display_server.update_windows(windows);
                     }
                     _ => {
                         let windows: Vec<&Window> = self.state.windows.iter().collect();
-                        let focused = self.state.focus_manager.window(&self.state.windows);
-                        self.display_server.update_windows(windows, focused);
-                        let workspaces: Vec<&Workspace> = self.state.workspaces.iter().collect();
-                        let focused = self.state.focus_manager.workspace(&self.state.workspaces);
-                        self.display_server.update_workspaces(workspaces, focused);
+                        self.display_server.update_windows(windows);
                     }
                 }
             }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -843,9 +843,9 @@ mod tests {
         let expected = manager.state.windows[0].clone();
         let initial = manager.state.windows[1].clone();
 
-        assert!(manager.state.focus_window(&initial.handle));
+        manager.state.focus_window(&initial.handle);
 
-        assert!(manager.command_handler(&Command::FocusWindowTop(false)));
+        manager.command_handler(&Command::FocusWindowTop(false));
         let actual = manager
             .state
             .focus_manager
@@ -854,7 +854,7 @@ mod tests {
             .handle;
         assert_eq!(expected.handle, actual);
 
-        assert!(!manager.command_handler(&Command::FocusWindowTop(false)));
+        manager.command_handler(&Command::FocusWindowTop(false));
         let actual = manager
             .state
             .focus_manager
@@ -863,7 +863,7 @@ mod tests {
             .handle;
         assert_eq!(expected.handle, actual);
 
-        assert!(manager.command_handler(&Command::FocusWindowTop(true)));
+        manager.command_handler(&Command::FocusWindowTop(true));
         let actual = manager
             .state
             .focus_manager

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -243,7 +243,7 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
     if let Some(new_handle) = new_handle {
         manager.state.focus_window(&new_handle);
     } else {
-        let act = DisplayAction::Unfocus(Some(handle));
+        let act = DisplayAction::Unfocus(Some(handle), false);
         manager.state.actions.push_back(act);
         manager.state.focus_manager.window_history.push_front(None);
     }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -586,9 +586,7 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
         .map(|w| w.handle);
 
     match (next, cur, prev) {
-        (Some(next), Some(cur), Some(prev)) if next == cur && toggle => {
-            handle_focus(state, prev);
-        }
+        (Some(next), Some(cur), Some(prev)) if next == cur && toggle => handle_focus(state, prev),
         (Some(next), Some(cur), _) if next != cur => handle_focus(state, next),
         _ => {}
     }

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -12,7 +12,10 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::ScreenCreate(s) => self.screen_create_handler(s),
             DisplayEvent::WindowCreate(w, x, y) => self.window_created_handler(w, x, y),
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
-            DisplayEvent::WindowTakeFocus(handle) => self.state.focus_window(&handle),
+            DisplayEvent::WindowTakeFocus(handle) => {
+                self.state.focus_window(&handle);
+                false
+            }
 
             DisplayEvent::KeyGrabReload => {
                 self.state
@@ -21,14 +24,19 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 false
             }
 
-            DisplayEvent::MoveFocusTo(x, y) => self.state.move_focus_to_point(x, y),
+            DisplayEvent::MoveFocusTo(x, y) => {
+                self.state.move_focus_to_point(x, y);
+                false
+            }
 
             // This is a request to validate focus. Double check that we are focused on the correct
             // window.
-            DisplayEvent::VerifyFocusedAt(handle) => match self.state.focus_manager.behaviour {
-                FocusBehaviour::Sloppy => return self.state.validate_focus_at(&handle),
-                _ => return false,
-            },
+            DisplayEvent::VerifyFocusedAt(handle) => {
+                if self.state.focus_manager.behaviour == FocusBehaviour::Sloppy {
+                    self.state.validate_focus_at(&handle);
+                }
+                false
+            }
 
             DisplayEvent::WindowDestroy(handle) => self.window_destroyed_handler(&handle),
 
@@ -48,7 +56,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             DisplayEvent::ChangeToNormalMode => {
                 match self.state.mode {
                     Mode::MovingWindow(h) | Mode::ResizingWindow(h) => {
-                        let _ = self.state.focus_window(&h);
+                        self.state.focus_window(&h);
                     }
                     _ => {}
                 }
@@ -60,7 +68,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
             DisplayEvent::Movement(handle, x, y) => {
                 if self.state.screens.iter().any(|s| s.root == handle) {
-                    return self.state.focus_workspace_under_cursor(x, y);
+                    self.state.focus_workspace_under_cursor(x, y);
                 }
                 false
             }

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -8,7 +8,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Process a collection of events, and apply them changes to a manager.
     /// Returns true if changes need to be rendered.
     pub fn display_event_handler(&mut self, event: DisplayEvent) -> bool {
-        let update_needed = match event {
+        match event {
             DisplayEvent::ScreenCreate(s) => self.screen_create_handler(s),
             DisplayEvent::WindowCreate(w, x, y) => self.window_created_handler(w, x, y),
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
@@ -61,8 +61,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                     _ => {}
                 }
                 self.state.mode = Mode::Normal;
-                let act = DisplayAction::NormalMode;
-                self.state.actions.push_back(act);
                 true
             }
 
@@ -94,17 +92,10 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 if let Some(window) = self.state.windows.iter().find(|w| w.handle == handle) {
                     let act = DisplayAction::ConfigureXlibWindow(window.clone());
                     self.state.actions.push_back(act);
-                    return true;
                 }
                 false
             }
-        };
-
-        if update_needed {
-            self.update_windows();
         }
-
-        update_needed
     }
 }
 

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -99,7 +99,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     }
 }
 
-// Save off the info about position of the window when we started to move/resize.
+// Save off the info about position of the window when we start to move/resize.
 fn prepare_window(state: &mut State, handle: WindowHandle) {
     if let Some(w) = state.windows.iter_mut().find(|w| w.handle == handle) {
         if w.floating() {

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -97,14 +97,18 @@ impl State {
         if found.is_unmanaged() {
             return None;
         }
-        let mut previous = None;
+        let previous = self.focus_manager.window(&self.windows);
         // No new history if no change.
-        if let Some(fw) = self.focus_manager.window(&self.windows) {
-            if &fw.handle == handle {
+        if let Some(previous) = previous {
+            if &previous.handle == handle {
                 // Return some so we still update the visuals.
                 return Some(found.clone());
             }
-            previous = Some(fw.clone());
+            for tag_id in &previous.tags {
+                self.focus_manager
+                    .tags_last_window
+                    .insert(*tag_id, previous.handle);
+            }
         }
 
         // Clean old history.
@@ -114,7 +118,7 @@ impl State {
 
         let act = DisplayAction::WindowTakeFocus {
             window: found.clone(),
-            previous_window: previous,
+            previous_window: previous.cloned(),
         };
         self.actions.push_back(act);
 

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -79,8 +79,10 @@ impl State {
         // Unfocus last window if the target tag is empty
         if let Some(window) = self.focus_manager.window(&self.windows) {
             if !window.tags.contains(tag) {
-                self.actions
-                    .push_back(DisplayAction::Unfocus(Some(window.handle)));
+                self.actions.push_back(DisplayAction::Unfocus(
+                    Some(window.handle),
+                    window.floating(),
+                ));
                 self.focus_manager.window_history.push_front(None);
             }
         }

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -6,23 +6,11 @@ use crate::state::State;
 use crate::{display_action::DisplayAction, models::FocusBehaviour};
 
 impl State {
-    /// Marks a workspace as the focused workspace.
-    //NOTE: should only be called externally from this file
-    pub fn focus_workspace(&mut self, workspace: &Workspace) -> bool {
-        if focus_workspace_work(self, workspace.id).is_some() {
-            //make sure this workspaces tag is focused
-            workspace.tags.iter().for_each(|t| {
-                focus_tag_work(self, *t);
-            });
-        }
-        false
-    }
-
-    /// Create a `DisplayAction` to cause this window to become focused
-    pub fn focus_window(&mut self, handle: &WindowHandle) -> bool {
-        let window = match focus_window_by_handle_work(self, handle) {
+    /// Focuses the given window.
+    pub fn focus_window(&mut self, handle: &WindowHandle) {
+        let window = match self.focus_window_work(handle) {
             Some(w) => w,
-            None => return false,
+            None => return,
         };
 
         // Make sure the focused window's workspace is focused.
@@ -35,37 +23,31 @@ impl State {
                 None => (None, None),
             };
         if let Some(workspace_id) = workspace_id {
-            let _ = focus_workspace_work(self, workspace_id);
+            let _ = self.focus_workspace_work(workspace_id);
         }
 
         // Make sure the focused window's tag is focused.
         if let Some(tag) = focused_window_tag {
-            let _ = focus_tag_work(self, tag);
+            let _ = self.focus_tag_work(tag);
         }
-        false
     }
 
-    pub fn focus_workspace_under_cursor(&mut self, x: i32, y: i32) -> bool {
-        let focused_id = match self.focus_manager.workspace(&self.workspaces) {
-            Some(fws) => fws.id,
-            None => None,
-        };
-        if let Some(w) = self
-            .workspaces
-            .iter()
-            .find(|ws| ws.contains_point(x, y) && ws.id != focused_id)
-            .cloned()
-        {
-            return self.focus_workspace(&w);
+    /// Focuses the given workspace.
+    // NOTE: Should only be called externally from this file.
+    pub fn focus_workspace(&mut self, workspace: &Workspace) {
+        if self.focus_workspace_work(workspace.id) {
+            // Make sure this workspaces tag is focused.
+            workspace.tags.iter().for_each(|t| {
+                self.focus_tag_work(*t);
+            });
         }
-        false
     }
 
-    /// marks a tag as the focused tag
-    //NOTE: should only be called externally from this file
-    pub fn focus_tag(&mut self, tag: &TagId) -> bool {
-        if focus_tag_work(self, *tag).is_none() {
-            return false;
+    /// Focuses the given tag.
+    // NOTE: Should only be called externally from this file.
+    pub fn focus_tag(&mut self, tag: &TagId) {
+        if !self.focus_tag_work(*tag) {
+            return;
         }
         // Check each workspace, if its displaying this tag it should be focused too.
         let to_focus: Vec<Workspace> = self
@@ -75,14 +57,14 @@ impl State {
             .cloned()
             .collect();
         for ws in &to_focus {
-            focus_workspace_work(self, ws.id);
+            self.focus_workspace_work(ws.id);
         }
         // Make sure the focused window is on this workspace.
         if self.focus_manager.behaviour == FocusBehaviour::Sloppy {
             let act = DisplayAction::FocusWindowUnderCursor;
             self.actions.push_back(act);
         } else if let Some(handle) = self.focus_manager.tags_last_window.get(tag).copied() {
-            focus_window_by_handle_work(self, &handle);
+            self.focus_window_work(&handle);
         } else if let Some(ws) = to_focus.first() {
             let handle = self
                 .windows
@@ -90,7 +72,7 @@ impl State {
                 .find(|w| ws.is_managed(w))
                 .map(|w| w.handle);
             if let Some(h) = handle {
-                focus_window_by_handle_work(self, &h);
+                self.focus_window_work(&h);
             }
         }
 
@@ -102,14 +84,92 @@ impl State {
                 self.focus_manager.window_history.push_front(None);
             }
         }
+    }
+
+    fn focus_window_work(&mut self, handle: &WindowHandle) -> Option<Window> {
+        // Find the handle in our managed windows.
+        let found: &Window = self.windows.iter().find(|w| &w.handle == handle)?;
+        // Docks don't want to get focus. If they do weird things happen. They don't get events...
+        if found.is_unmanaged() {
+            return None;
+        }
+        let mut previous = None;
+        // No new history if no change.
+        if let Some(fw) = self.focus_manager.window(&self.windows) {
+            if &fw.handle == handle {
+                // Return some so we still update the visuals.
+                return Some(found.clone());
+            }
+            previous = Some(fw.clone());
+        }
+
+        // Clean old history.
+        self.focus_manager.window_history.truncate(10);
+        // Add this focus change to the history.
+        self.focus_manager.window_history.push_front(Some(*handle));
+
+        let act = DisplayAction::WindowTakeFocus {
+            window: found.clone(),
+            previous_window: previous,
+        };
+        self.actions.push_back(act);
+
+        Some(found.clone())
+    }
+
+    fn focus_workspace_work(&mut self, workspace_id: Option<i32>) -> bool {
+        //no new history if no change
+        if let Some(fws) = self.focus_manager.workspace(&self.workspaces) {
+            if fws.id == workspace_id {
+                return false;
+            }
+        }
+        // Clean old history.
+        self.focus_manager.workspace_history.truncate(10);
+        // Add this focus to the history.
+        if let Some(index) = self.workspaces.iter().position(|x| x.id == workspace_id) {
+            self.focus_manager.workspace_history.push_front(index);
+            return true;
+        }
+        false
+    }
+
+    fn focus_tag_work(&mut self, tag: TagId) -> bool {
+        if let Some(current_tag) = self.focus_manager.tag(0) {
+            if current_tag == tag {
+                return false;
+            }
+        };
+        // Clean old history.
+        self.focus_manager.tag_history.truncate(10);
+        // Add this focus to the history.
+        self.focus_manager.tag_history.push_front(tag);
+
+        let act = DisplayAction::SetCurrentTags(vec![tag]);
+        self.actions.push_back(act);
         true
     }
 
-    pub fn validate_focus_at(&mut self, handle: &WindowHandle) -> bool {
+    pub fn focus_workspace_under_cursor(&mut self, x: i32, y: i32) {
+        let focused_id = match self.focus_manager.workspace(&self.workspaces) {
+            Some(fws) => fws.id,
+            None => None,
+        };
+        if let Some(w) = self
+            .workspaces
+            .iter()
+            .find(|ws| ws.contains_point(x, y) && ws.id != focused_id)
+            .cloned()
+        {
+            self.focus_workspace(&w);
+        }
+    }
+
+    pub fn validate_focus_at(&mut self, handle: &WindowHandle) {
         // If the window is already focused do nothing.
         if let Some(current) = self.focus_manager.window(&self.windows) {
             if &current.handle == handle {
-                return false;
+                return;
             }
         }
         // Focus the window only if it is also focusable.
@@ -118,12 +178,11 @@ impl State {
             .iter()
             .any(|w| w.can_focus() && &w.handle == handle)
         {
-            return self.focus_window(handle);
+            self.focus_window(handle);
         }
-        false
     }
 
-    pub fn move_focus_to_point(&mut self, x: i32, y: i32) -> bool {
+    pub fn move_focus_to_point(&mut self, x: i32, y: i32) {
         let handle_found: Option<WindowHandle> = self
             .windows
             .iter()
@@ -133,97 +192,36 @@ impl State {
         match handle_found {
             Some(found) => self.focus_window(&found),
             //backup plan, move focus closest window in workspace
-            None => focus_closest_window(self, x, y),
+            None => self.focus_closest_window(x, y),
+        }
+    }
+
+    fn focus_closest_window(&mut self, x: i32, y: i32) {
+        let ws = match self.workspaces.iter().find(|ws| ws.contains_point(x, y)) {
+            Some(ws) => ws,
+            None => return,
+        };
+        let mut dists: Vec<(i32, &Window)> = self
+            .windows
+            .iter()
+            .filter(|x| ws.is_managed(x) && x.can_focus())
+            .map(|w| (distance(w, x, y), w))
+            .collect();
+        dists.sort_by(|a, b| (a.0).cmp(&b.0));
+        if let Some(first) = dists.get(0) {
+            let handle = first.1.handle;
+            self.focus_window(&handle);
         }
     }
 }
 
-fn focus_workspace_work(state: &mut State, workspace_id: Option<i32>) -> Option<()> {
-    //no new history if no change
-    if let Some(fws) = state.focus_manager.workspace(&state.workspaces) {
-        if fws.id == workspace_id {
-            return None;
-        }
-    }
-    // Clean old history.
-    state.focus_manager.workspace_history.truncate(10);
-    // Add this focus to the history.
-    let index = state.workspaces.iter().position(|x| x.id == workspace_id)?;
-    state.focus_manager.workspace_history.push_front(index);
-    Some(())
-}
-fn focus_window_by_handle_work(state: &mut State, handle: &WindowHandle) -> Option<Window> {
-    // Find the handle in our managed windows.
-    let found: &Window = state.windows.iter().find(|w| &w.handle == handle)?;
-    // Docks don't want to get focus. If they do weird things happen. They don't get events...
-    if found.is_unmanaged() {
-        return None;
-    }
-    let mut previous = None;
-    // No new history if no change.
-    if let Some(fw) = state.focus_manager.window(&state.windows) {
-        if &fw.handle == handle {
-            // Return some so we still update the visuals.
-            return Some(found.clone());
-        }
-        previous = Some(fw.clone());
-    }
-
-    // Clean old history.
-    state.focus_manager.window_history.truncate(10);
-    // Add this focus change to the history.
-    state.focus_manager.window_history.push_front(Some(*handle));
-
-    let act = DisplayAction::WindowTakeFocus {
-        window: found.clone(),
-        previous_window: previous,
-    };
-    state.actions.push_back(act);
-
-    Some(found.clone())
-}
-
-fn focus_closest_window(state: &mut State, x: i32, y: i32) -> bool {
-    let ws = match state.workspaces.iter().find(|ws| ws.contains_point(x, y)) {
-        Some(ws) => ws,
-        None => return false,
-    };
-    let mut dists: Vec<(i32, &Window)> = state
-        .windows
-        .iter()
-        .filter(|x| ws.is_managed(x) && x.can_focus())
-        .map(|w| (distance(w, x, y), w))
-        .collect();
-    dists.sort_by(|a, b| (a.0).cmp(&b.0));
-    if let Some(first) = dists.get(0) {
-        let handle = first.1.handle;
-        return state.focus_window(&handle);
-    }
-    false
-}
-
+// Square root not needed as we are only interested in the comparison.
 fn distance(window: &Window, x: i32, y: i32) -> i32 {
-    // √((x_2-x_1)²+(y_2-y_1)²)
+    // (x_2-x_1)²+(y_2-y_1)²
     let (wx, wy) = window.calculated_xyhw().center();
-    let xs = f64::from((wx - x) * (wx - x));
-    let ys = f64::from((wy - y) * (wy - y));
-    (xs + ys).sqrt().abs().floor() as i32
-}
-
-fn focus_tag_work(state: &mut State, tag: TagId) -> Option<()> {
-    if let Some(current_tag) = state.focus_manager.tag(0) {
-        if current_tag == tag {
-            return None;
-        }
-    };
-    state
-        .actions
-        .push_back(DisplayAction::SetCurrentTags(vec![tag]));
-    //clean old ones
-    state.focus_manager.tag_history.truncate(10);
-    //add this focus to the history
-    state.focus_manager.tag_history.push_front(tag);
-    Some(())
+    let xs = (wx - x) * (wx - x);
+    let ys = (wy - y) * (wy - y);
+    xs + ys
 }
 
 #[cfg(test)]

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -29,7 +29,8 @@ impl State {
         } else if self.focus_manager.behaviour == FocusBehaviour::ClickTo {
             if let xlib::Button1 | xlib::Button3 = button {
                 if self.screens.iter().any(|s| s.root == handle) {
-                    return self.focus_workspace_under_cursor(x, y);
+                    self.focus_workspace_under_cursor(x, y);
+                    return false;
                 }
             }
         }

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -25,7 +25,6 @@ impl State {
                 }
             }
         }
-
         true
     }
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -40,7 +40,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             && self.state.focus_manager.behaviour == FocusBehaviour::Sloppy
             && on_same_tag;
         //let the DS know we are managing this window
-        let act = DisplayAction::AddedWindow(window.handle, follow_mouse);
+        let act = DisplayAction::AddedWindow(window.handle, window.floating(), follow_mouse);
         self.state.actions.push_back(act);
 
         //let the DS know the correct desktop to find this window

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -69,15 +69,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         // Find the next or previous window on the workspace.
         let new_handle = self.get_next_or_previous(handle);
         // If there is a parent we would want to focus it.
-        let transient = match self
-            .state
-            .windows
-            .iter()
-            .find(|w| &w.handle == handle)
-            .map(|w| w.transient)
-        {
-            Some(transient) => transient,
-            None => None,
+        let (transient, floating) = match self.state.windows.iter().find(|w| &w.handle == handle) {
+            Some(window) => (window.transient, window.floating()),
+            None => (None, false),
         };
         self.state
             .focus_manager
@@ -101,7 +95,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             } else if let Some(handle) = new_handle {
                 self.state.focus_window(&handle);
             } else {
-                let act = DisplayAction::Unfocus(Some(*handle));
+                let act = DisplayAction::Unfocus(Some(*handle), floating);
                 self.state.actions.push_back(act);
                 self.state.focus_manager.window_history.push_front(None);
             }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -44,12 +44,12 @@ impl<C, SERVER> Manager<C, SERVER> {
     }
 }
 
-impl<C, SERVER> Manager<C, SERVER>
-where
-    C: Config,
-{
+impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Reload the configuration of the running [`Manager`].
     pub fn reload_config(&mut self) -> bool {
+        let focused = self.state.focus_manager.window_history.front();
+        self.display_server
+            .load_config(&self.config, focused, &self.state.windows);
         self.state.load_config(&self.config);
         true
     }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -14,7 +14,7 @@ use leftwm_core::{
     layouts::{Layout, LAYOUTS},
     models::{FocusBehaviour, Gutter, LayoutMode, Margins, Size, Window},
     state::State,
-    Manager,
+    DisplayServer, Manager,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -312,7 +312,10 @@ impl leftwm_core::Config for Config {
         self.focus_new_windows
     }
 
-    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool {
+    fn command_handler<SERVER: DisplayServer>(
+        command: &str,
+        manager: &mut Manager<Self, SERVER>,
+    ) -> bool {
         if let Some((command, value)) = command.split_once(' ') {
             match command {
                 "LoadTheme" => {

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -98,8 +98,9 @@ pub struct Config {
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
-    pub window_rules: Vec<WindowHook>,
 
+    #[serde(skip)]
+    pub window_rules: Vec<WindowHook>,
     #[serde(skip)]
     pub theme_setting: ThemeSetting,
 }


### PR DESCRIPTION
This reduces the xlib calls by 1: removing calls that don't add anything, 2: focus events are self contained and no longer makes moving/resizing calls, 3: only make the windows move/resize when needed (this mainly involves returning false in command_handler/display_event_handler when the windows don't actually move/resize, not returning true/false depending on whether it succeeded). Maybe more to come.

Thanks.