### PR TITLE
FocusWindow command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.52.0
+          toolchain: 1.56.1
           override: true
 
     - name: Run cargo check

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -26,6 +26,7 @@ pub enum Command {
     MoveWindowTop,
     FocusNextTag,
     FocusPreviousTag,
+    FocusWindow(String),
     FocusWindowUp,
     FocusWindowDown,
     FocusWindowTop(bool),

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -287,11 +287,13 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
         state.windows.iter().find(|w| is_target(*w)).cloned()
     }?;
 
-    let handle = target_window.handle;
-    let tag = target_window.tags.first()?;
+    if state.workspaces.iter().any(|ws| ws.is_displaying(&target_window)) {
+        let handle = target_window.handle;
+        return Some(handle_focus(state, handle));
+    }
 
-    state.goto_tag_handler(*tag)
-        .and(Some(handle_focus(state, handle)))
+    let tag_id = target_window.tags.first()?;
+    state.goto_tag_handler(*tag_id)
 }
 
 /// Focus the adjacent tags, depending on the delta.

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -299,11 +299,11 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
         state.windows.iter().find(|w| is_target(*w)).cloned()
     }?;
 
-    let focus = |s: &mut State, h: WindowHandle| -> Option<bool> { Some(handle_focus(s, h)) };
     let handle = target_window.handle;
 
     if target_window.visible() {
-        return focus(state, handle);
+        handle_focus(state, handle);
+        return None;
     }
 
     let tag_id = target_window.tags.first()?;
@@ -335,9 +335,13 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
                 state.windows.append(&mut windows);
             }
 
-            focus(state, handle)
+            handle_focus(state, handle);
+            Some(true)
         }
-        Some(_) => focus(state, handle),
+        Some(_) => {
+            handle_focus(state, handle);
+            Some(true)
+        }
         None => None,
     }
 }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -305,7 +305,7 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
         .workspace(&state.workspaces)
         .map(|ws| ws.layout)
     {
-        Some(Layout::Monocle | Layout::MainAndDeck) => {
+        Some(Layout::Monocle) | Some(Layout::MainAndDeck) => {
             let mut windows = helpers::vec_extract(&mut state.windows, |w| {
                 w.has_tag(tag_id) && !w.is_unmanaged()
             });

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -309,7 +309,7 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
             let mut windows = helpers::vec_extract(&mut state.windows, |w| {
                 w.has_tag(tag_id) && !w.is_unmanaged()
             });
-            let window_index = windows.iter().position(|w| is_target(w))?;
+            let window_index = windows.iter().position(|w| w.handle == handle)?;
             let _ = helpers::cycle_vec(&mut windows, -(window_index as i32));
             state.windows.append(&mut windows);
             Some(handle_focus(state, handle))

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -305,7 +305,7 @@ fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
         .workspace(&state.workspaces)
         .map(|ws| ws.layout)
     {
-        Some(Layout::Monocle) | Some(Layout::MainAndDeck) => {
+        Some(Layout::Monocle | Layout::MainAndDeck) => {
             let mut windows = helpers::vec_extract(&mut state.windows, |w| {
                 w.has_tag(tag_id) && !w.is_unmanaged()
             });

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -277,8 +277,14 @@ fn goto_tag(state: &mut State, input_tag: TagId, current_tag_swap: bool) -> Opti
 }
 
 fn focus_window(state: &mut State, window_name: &str) -> Option<bool> {
-    let is_target =
-        |w: &Window| -> bool { w.res_name.as_ref().map_or(false, |c| c == window_name) };
+    let is_target = |w: &Window| -> bool {
+        w.res_name
+            .as_ref()
+            .zip(w.res_class.as_ref())
+            .map_or(false, |(res_name, res_class)| {
+                window_name == res_name || window_name == res_class
+            })
+    };
 
     let current_window = state.focus_manager.window(&state.windows)?;
     let target_window = if is_target(current_window) {

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
         SendWindowToTag        Args: <tag_index> (int)
         SetLayout              Args: <LayoutName>
         SetMarginMultiplier    Args: <multiplier-value> (float)
-        FocusWindow            Args: <WindowClass>
+        FocusWindow            Args: <WindowClass> or <visible-window-index> (int)
 
         For more information please visit:
         https://github.com/leftwm/leftwm/wiki/External-Commands

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<()> {
         SendWindowToTag        Args: <tag_index> (int)
         SetLayout              Args: <LayoutName>
         SetMarginMultiplier    Args: <multiplier-value> (float)
+        FocusWindow            Args: <WindowClass>
 
         For more information please visit:
         https://github.com/leftwm/leftwm/wiki/External-Commands

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -29,6 +29,7 @@ pub enum BaseCommand {
     MoveWindowTop,
     FocusNextTag,
     FocusPreviousTag,
+    FocusWindow,
     FocusWindowUp,
     FocusWindowDown,
     FocusWindowTop,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -48,6 +48,7 @@ impl Keybind {
             BaseCommand::MoveWindowTop => leftwm_core::Command::MoveWindowTop,
             BaseCommand::FocusNextTag => leftwm_core::Command::FocusNextTag,
             BaseCommand::FocusPreviousTag => leftwm_core::Command::FocusPreviousTag,
+            BaseCommand::FocusWindow => leftwm_core::Command::FocusWindow(self.value.clone()),
             BaseCommand::FocusWindowUp => leftwm_core::Command::FocusWindowUp,
             BaseCommand::FocusWindowDown => leftwm_core::Command::FocusWindowDown,
             BaseCommand::FocusWindowTop => {


### PR DESCRIPTION
This command focuses a window with the given `WM_CLASS`. 

- If the window is not present, it does nothing
- If the window is visible in any workspace, it will gain focus
- If the window is not visible, the current workspace will switch to a tag with the window and give it focus
- If the window is hidden in the `Monocle` or `MainAndDeck` layout, it will scroll the layout so that the window becomes visible and focused
- If the window is already focused, it will focus the previousely focused one, following the same rules

Example configuration:

```toml
[[keybind]]
command = "FocusWindow"
value = "brave-browser" # The first or the second entry of WM_CLASS attribute
modifier = ["modkey"]
key = "b"
```
Another added possibility is to focus a visible window by its index on the screen. Example configuration:

```toml
[[keybind]]
command = "FocusWindow"
value = "1" # Will focus the first window on the screen
modifier = ["modkey", "Control"]
key = "1"
```
Indices are not displayed in any way yet. This feature is WIP for now and will not be documented