### PR TITLE
Fix #692

### DIFF
--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -204,6 +204,7 @@ impl Default for Config {
             // TODO: add sane default for scratchpad config.
             // Currently default values are set in sane_dimension fn.
             scratchpad: Some(vec![]),
+            window_rules: Some(vec![]),
             disable_current_tag_swap: false,
             disable_tile_drag: false,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
@@ -214,7 +215,6 @@ impl Default for Config {
             theme_setting: ThemeSetting::default(),
             max_window_width: None,
             state: None,
-            window_rules: None,
         }
     }
 }

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -214,7 +214,7 @@ impl Default for Config {
             theme_setting: ThemeSetting::default(),
             max_window_width: None,
             state: None,
-            window_rules: Vec::new(),
+            window_rules: None,
         }
     }
 }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -91,6 +91,7 @@ pub struct Config {
     pub layouts: Vec<Layout>,
     pub layout_mode: LayoutMode,
     pub scratchpad: Option<Vec<ScratchPad>>,
+    pub window_rules: Option<Vec<WindowHook>>,
     //of you are on tag "1" and you goto tag "1" this takes you to the previous tag
     pub disable_current_tag_swap: bool,
     pub disable_tile_drag: bool,
@@ -98,7 +99,6 @@ pub struct Config {
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
-    pub window_rules: Option<Vec<WindowHook>>,
 
     #[serde(skip)]
     pub theme_setting: ThemeSetting,


### PR DESCRIPTION
toml doesn't like parsing window rules as an empty vec for some reason (even ```Some(vec![])```).
Also added leftwm-check loading the default config (mainly so I could test this).

Edit: toml didn't like where window_rules was positioned in the struct :face_exhaling: 