### PR TITLE
Fix #637

### DIFF
--- a/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/event_translate.rs
@@ -145,11 +145,13 @@ fn from_configure_request(x_event: XEvent) -> Option<DisplayEvent> {
 }
 
 fn from_enter_notify(x_event: &XEvent) -> Option<DisplayEvent> {
-    let event = xlib::XEnterWindowEvent::from(x_event.1);
-    let crossing = xlib::XCrossingEvent::from(x_event.1);
-    if crossing.detail == xlib::NotifyInferior && crossing.window != x_event.0.get_default_root() {
+    let event = xlib::XCrossingEvent::from(x_event.1);
+    if (event.mode != xlib::NotifyNormal || event.detail == xlib::NotifyInferior)
+        && event.window != x_event.0.get_default_root()
+    {
         return None;
     }
+
     let h = WindowHandle::XlibHandle(event.window);
     Some(DisplayEvent::WindowTakeFocus(h))
 }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -224,8 +224,14 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
     };
 
     let handle = window.or(*manager.state.focus_manager.window_history.get(0)?)?;
-    //Focus the next or previous window on the workspace
-    let new_handle = manager.get_next_or_previous(&handle);
+    // Only handle the focus when moving the focused window.
+    let handle_focus = window.is_none();
+    // Focus the next or previous window on the workspace.
+    let new_handle = if handle_focus {
+        manager.get_next_or_previous(&handle)
+    } else {
+        None
+    };
 
     let window = manager
         .state
@@ -240,12 +246,14 @@ fn move_to_tag<C: Config, SERVER: DisplayServer>(
     manager.state.actions.push_back(act);
 
     manager.state.sort_windows();
-    if let Some(new_handle) = new_handle {
-        manager.state.focus_window(&new_handle);
-    } else {
-        let act = DisplayAction::Unfocus(Some(handle), false);
-        manager.state.actions.push_back(act);
-        manager.state.focus_manager.window_history.push_front(None);
+    if handle_focus {
+        if let Some(new_handle) = new_handle {
+            manager.state.focus_window(&new_handle);
+        } else {
+            let act = DisplayAction::Unfocus(Some(handle), false);
+            manager.state.actions.push_back(act);
+            manager.state.focus_manager.window_history.push_front(None);
+        }
     }
     Some(true)
 }


### PR DESCRIPTION
Fixes #637. The new issue is now fixed and windows activated externally will now move the mouse in sloppy focus.