### PR TITLE
Add configuration option to move new windows to top

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -31,6 +31,8 @@ pub trait Config {
 
     fn focus_new_windows(&self) -> bool;
 
+    fn insert_new_windows_on_top(&self) -> bool;
+
     fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
     where
         SERVER: DisplayServer,
@@ -112,6 +114,9 @@ impl Config for TestConfig {
         LayoutMode::Workspace
     }
     fn focus_new_windows(&self) -> bool {
+        false
+    }
+    fn insert_new_windows_on_top(&self) -> bool {
         false
     }
     fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -338,11 +338,14 @@ fn insert_window(state: &mut State, window: &mut Window, layout: Layout) {
         }
     }
 
-    // If a window is a dialog, splash, or scractchpad we want it to be at the top.
+    // If a window is a dialog, splash, or scractchpad,
+    // or move_new_windows_to_top is set in the config,
+    // we want it to be at the top.
     if window.r#type == WindowType::Dialog
         || window.r#type == WindowType::Splash
         || window.r#type == WindowType::Utility
         || is_scratchpad(state, window)
+        || state.insert_new_windows_on_top
     {
         state.windows.insert(0, window.clone());
         return;

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -31,6 +31,7 @@ pub struct State {
     pub default_width: i32,
     pub default_height: i32,
     pub disable_tile_drag: bool,
+    pub insert_new_windows_on_top: bool,
 }
 
 impl State {
@@ -59,6 +60,7 @@ impl State {
             default_width: config.default_width(),
             default_height: config.default_height(),
             disable_tile_drag: config.disable_tile_drag(),
+            insert_new_windows_on_top: config.insert_new_windows_on_top(),
         }
     }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -209,6 +209,7 @@ impl Default for Config {
             disable_tile_drag: false,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
             focus_new_windows: true, // default behaviour: focuses windows on creation
+            insert_new_windows_on_top: false, // default behaviour: new windows will not be moved to the top of the stack
             modkey: "Mod4".to_owned(), //win key
             mousekey: Some("Mod4".into()), //win key
             keybind: commands,

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -97,6 +97,7 @@ pub struct Config {
     pub disable_tile_drag: bool,
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
+    pub insert_new_windows_on_top: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
 
@@ -310,6 +311,10 @@ impl leftwm_core::Config for Config {
 
     fn focus_new_windows(&self) -> bool {
         self.focus_new_windows
+    }
+
+    fn insert_new_windows_on_top(&self) -> bool {
+        self.insert_new_windows_on_top
     }
 
     fn command_handler<SERVER: DisplayServer>(


### PR DESCRIPTION
This PR allows the user to explicitly say in the `config.toml` that
new windows should be moved to the top.