### PR TITLE
fix: workspace id validation

### DIFF
--- a/leftwm/src/config/checks.rs
+++ b/leftwm/src/config/checks.rs
@@ -29,8 +29,10 @@ impl Config {
             }
             let ids = crate::get_workspace_ids(wss);
             if ids.iter().any(std::option::Option::is_some) {
-                if crate::all_ids_some(&ids) && !crate::all_ids_unique(&ids) {
-                    println!("Your config.toml contains duplicate workspace IDs. Please assign unique IDs to workspaces. The default config will be used instead.");
+                if crate::all_ids_some(&ids) {
+                    if !crate::all_ids_unique(&ids) {
+                        println!("Your config.toml contains duplicate workspace IDs. Please assign unique IDs to workspaces. The default config will be used instead.");
+                    }
                 } else {
                     println!("Your config.toml specifies an ID for some but not all workspaces. This can lead to ID collisions and is not allowed. The default config will be used instead.");
                 }


### PR DESCRIPTION
This fix the config check showing a warning about id collision when all
workspaces have ID and none are duplicates.
