### PR TITLE
Allow disabling swap for MoveWindowTop

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -23,13 +23,17 @@ pub enum Command {
     ToggleFloating,
     MoveWindowUp,
     MoveWindowDown,
-    MoveWindowTop,
+    MoveWindowTop {
+        swap: bool,
+    },
     FocusNextTag,
     FocusPreviousTag,
     FocusWindow(String),
     FocusWindowUp,
     FocusWindowDown,
-    FocusWindowTop(bool),
+    FocusWindowTop {
+        swap: bool,
+    },
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     SendWindowToTag {

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -28,6 +28,21 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     }
 }
 
+macro_rules! move_focus_common_vars {
+    ($func:ident ($state:expr $(, $arg:expr )* $(,)? )) => {{
+        let handle = $state.focus_manager.window(&$state.windows)?.handle;
+        let tag_id = $state.focus_manager.tag(0)?;
+        let tag = $state.tags.get(tag_id)?;
+        let (tags, layout) = (vec![tag_id], Some(tag.layout));
+
+        let for_active_workspace =
+            |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && !x.is_unmanaged() };
+
+        let to_reorder = helpers::vec_extract(&mut $state.windows, for_active_workspace);
+        $func($state, handle, layout, to_reorder, $($arg),*)
+    }};
+}
+
 fn process_internal<C: Config, SERVER: DisplayServer>(
     manager: &mut Manager<C, SERVER>,
     command: &Command,
@@ -44,9 +59,9 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::SendWindowToTag { window, tag } => move_to_tag(*window, *tag, manager),
         Command::MoveWindowToNextWorkspace => move_window_to_workspace_change(manager, 1),
         Command::MoveWindowToPreviousWorkspace => move_window_to_workspace_change(manager, -1),
-        Command::MoveWindowUp => move_focus_common_vars(move_window_change, state, -1),
-        Command::MoveWindowDown => move_focus_common_vars(move_window_change, state, 1),
-        Command::MoveWindowTop => move_focus_common_vars(move_window_top, state, 0),
+        Command::MoveWindowUp => move_focus_common_vars!(move_window_change(state, -1)),
+        Command::MoveWindowDown => move_focus_common_vars!(move_window_change(state, 1)),
+        Command::MoveWindowTop { swap } => move_focus_common_vars!(move_window_top(state, *swap)),
 
         Command::GoToTag { tag, swap } => goto_tag(state, *tag, *swap),
 
@@ -65,9 +80,9 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::FocusNextTag => focus_tag_change(state, 1),
         Command::FocusPreviousTag => focus_tag_change(state, -1),
         Command::FocusWindow(param) => focus_window(state, param),
-        Command::FocusWindowUp => move_focus_common_vars(focus_window_change, state, -1),
-        Command::FocusWindowDown => move_focus_common_vars(focus_window_change, state, 1),
-        Command::FocusWindowTop(toggle) => focus_window_top(state, *toggle),
+        Command::FocusWindowUp => move_focus_common_vars!(focus_window_change(state, -1)),
+        Command::FocusWindowDown => move_focus_common_vars!(focus_window_change(state, 1)),
+        Command::FocusWindowTop { swap } => focus_window_top(state, *swap),
         Command::FocusWorkspaceNext => focus_workspace_change(state, 1),
         Command::FocusWorkspacePrevious => focus_workspace_change(state, -1),
 
@@ -557,28 +572,12 @@ fn toggle_floating(state: &mut State) -> Option<bool> {
     }
 }
 
-fn move_focus_common_vars<F>(func: F, state: &mut State, val: i32) -> Option<bool>
-where
-    F: Fn(&mut State, i32, WindowHandle, Option<Layout>, Vec<Window>) -> Option<bool>,
-{
-    let handle = state.focus_manager.window(&state.windows)?.handle;
-    let tag_id = state.focus_manager.tag(0)?;
-    let tag = state.tags.get(tag_id)?;
-    let (tags, layout) = (vec![tag_id], Some(tag.layout));
-
-    let for_active_workspace =
-        |x: &Window| -> bool { helpers::intersect(&tags, &x.tags) && !x.is_unmanaged() };
-
-    let to_reorder = helpers::vec_extract(&mut state.windows, for_active_workspace);
-    func(state, val, handle, layout, to_reorder)
-}
-
 fn move_window_change(
     state: &mut State,
-    val: i32,
     mut handle: WindowHandle,
     layout: Option<Layout>,
     mut to_reorder: Vec<Window>,
+    val: i32,
 ) -> Option<bool> {
     let is_handle = |x: &Window| -> bool { x.handle == handle };
     if layout == Some(Layout::Monocle) {
@@ -604,10 +603,10 @@ fn move_window_change(
 //val and layout aren't used which is a bit awkward
 fn move_window_top(
     state: &mut State,
-    _val: i32,
     handle: WindowHandle,
     _layout: Option<Layout>,
     mut to_reorder: Vec<Window>,
+    swap: bool,
 ) -> Option<bool> {
     // Moves the selected window at index 0 of the window list.
     // If the selected window is already at index 0, it is sent to index 1.
@@ -618,7 +617,7 @@ fn move_window_top(
     let item = list.get(index)?.clone();
     list.remove(index);
     let mut new_index: usize = match index {
-        0 => 1,
+        0 if swap => 1,
         _ => 0,
     };
     if new_index >= len {
@@ -636,10 +635,10 @@ fn move_window_top(
 
 fn focus_window_change(
     state: &mut State,
-    val: i32,
     mut handle: WindowHandle,
     layout: Option<Layout>,
     mut to_reorder: Vec<Window>,
+    val: i32,
 ) -> Option<bool> {
     let is_handle = |x: &Window| -> bool { x.handle == handle };
     if layout == Some(Layout::Monocle) {
@@ -672,7 +671,7 @@ fn focus_window_change(
     Some(layout == Some(Layout::Monocle))
 }
 
-fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
+fn focus_window_top(state: &mut State, swap: bool) -> Option<bool> {
     let tag = state.focus_manager.tag(0)?;
     let cur = state.focus_manager.window(&state.windows).map(|w| w.handle);
     let prev = state.focus_manager.tags_last_window.get(&tag).copied();
@@ -683,7 +682,7 @@ fn focus_window_top(state: &mut State, toggle: bool) -> Option<bool> {
         .map(|w| w.handle);
 
     match (next, cur, prev) {
-        (Some(next), Some(cur), Some(prev)) if next == cur && toggle => {
+        (Some(next), Some(cur), Some(prev)) if next == cur && swap => {
             state.handle_window_focus(&prev);
         }
         (Some(next), Some(cur), _) if next != cur => state.handle_window_focus(&next),
@@ -931,7 +930,7 @@ mod tests {
 
         manager.state.focus_window(&initial.handle);
 
-        manager.command_handler(&Command::FocusWindowTop(false));
+        manager.command_handler(&Command::FocusWindowTop { swap: false });
         let actual = manager
             .state
             .focus_manager
@@ -940,7 +939,7 @@ mod tests {
             .handle;
         assert_eq!(expected.handle, actual);
 
-        manager.command_handler(&Command::FocusWindowTop(false));
+        manager.command_handler(&Command::FocusWindowTop { swap: false });
         let actual = manager
             .state
             .focus_manager
@@ -949,7 +948,7 @@ mod tests {
             .handle;
         assert_eq!(expected.handle, actual);
 
-        manager.command_handler(&Command::FocusWindowTop(true));
+        manager.command_handler(&Command::FocusWindowTop { swap: true });
         let actual = manager
             .state
             .focus_manager
@@ -957,5 +956,41 @@ mod tests {
             .unwrap()
             .handle;
         assert_eq!(initial.handle, actual);
+    }
+
+    #[test]
+    fn move_window_top() {
+        let mut manager = Manager::new_test(vec![]);
+        manager.screen_create_handler(Screen::default());
+
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(1), None, None),
+            -1,
+            -1,
+        );
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(2), None, None),
+            -1,
+            -1,
+        );
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(3), None, None),
+            -1,
+            -1,
+        );
+
+        let expected = manager.state.windows[0].clone();
+        let initial = manager.state.windows[1].clone();
+
+        manager.state.focus_window(&initial.handle);
+
+        manager.command_handler(&Command::MoveWindowTop { swap: false });
+        assert_eq!(manager.state.windows[0].handle, initial.handle);
+
+        manager.command_handler(&Command::MoveWindowTop { swap: false });
+        assert_eq!(manager.state.windows[0].handle, initial.handle);
+
+        manager.command_handler(&Command::MoveWindowTop { swap: true });
+        assert_eq!(manager.state.windows[0].handle, expected.handle);
     }
 }

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -102,7 +102,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFloating" => Ok(Command::ToggleFloating),
         "MoveWindowUp" => Ok(Command::MoveWindowUp),
         "MoveWindowDown" => Ok(Command::MoveWindowDown),
-        "MoveWindowTop" => Ok(Command::MoveWindowTop),
+        "MoveWindowTop" => build_move_window_top(s),
         "FocusWindowUp" => Ok(Command::FocusWindowUp),
         "FocusWindowDown" => Ok(Command::FocusWindowDown),
         "FocusWindowTop" => build_focus_window_top(s),
@@ -168,8 +168,15 @@ fn build_set_margin_multiplier(raw: &str) -> Result<Command, Box<dyn std::error:
 fn build_focus_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
     let headless = without_head(raw, "FocusWindowTop ");
     let parts: Vec<&str> = headless.split(' ').collect();
-    let toggle = bool::from_str(parts.get(0).unwrap_or(&"false"))?;
-    Ok(Command::FocusWindowTop(toggle))
+    let swap = bool::from_str(parts.get(0).unwrap_or(&"false"))?;
+    Ok(Command::FocusWindowTop { swap })
+}
+
+fn build_move_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
+    let headless = without_head(raw, "MoveWindowTop ");
+    let parts: Vec<&str> = headless.split(' ').collect();
+    let swap = bool::from_str(parts.get(0).unwrap_or(&"true"))?;
+    Ok(Command::MoveWindowTop { swap })
 }
 
 fn without_head<'a, 'b>(s: &'a str, head: &'b str) -> &'a str {

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -45,20 +45,27 @@ impl Keybind {
             BaseCommand::ToggleFloating => leftwm_core::Command::ToggleFloating,
             BaseCommand::MoveWindowUp => leftwm_core::Command::MoveWindowUp,
             BaseCommand::MoveWindowDown => leftwm_core::Command::MoveWindowDown,
-            BaseCommand::MoveWindowTop => leftwm_core::Command::MoveWindowTop,
+            BaseCommand::MoveWindowTop => leftwm_core::Command::MoveWindowTop {
+                swap: if self.value.is_empty() {
+                    true
+                } else {
+                    bool::from_str(&self.value)
+                        .context("invalid boolean value for MoveWindowTop")?
+                },
+            },
             BaseCommand::FocusNextTag => leftwm_core::Command::FocusNextTag,
             BaseCommand::FocusPreviousTag => leftwm_core::Command::FocusPreviousTag,
             BaseCommand::FocusWindow => leftwm_core::Command::FocusWindow(self.value.clone()),
             BaseCommand::FocusWindowUp => leftwm_core::Command::FocusWindowUp,
             BaseCommand::FocusWindowDown => leftwm_core::Command::FocusWindowDown,
-            BaseCommand::FocusWindowTop => {
-                leftwm_core::Command::FocusWindowTop(if self.value.is_empty() {
+            BaseCommand::FocusWindowTop => leftwm_core::Command::FocusWindowTop {
+                swap: if self.value.is_empty() {
                     false
                 } else {
                     bool::from_str(&self.value)
                         .context("invalid boolean value for FocusWindowTop")?
-                })
-            }
+                },
+            },
             BaseCommand::FocusWorkspaceNext => leftwm_core::Command::FocusWorkspaceNext,
             BaseCommand::FocusWorkspacePrevious => leftwm_core::Command::FocusWorkspacePrevious,
             BaseCommand::MoveToTag => leftwm_core::Command::SendWindowToTag {


### PR DESCRIPTION
# Changes
- command `MoveWindowTop` in core allows disabling/enabling automatic swap
- changed `FocusWindowTop` to use struct variant instead of tuple variant (for clarity sake)
- turned `move_focus_common_vars` into a macro to allow flexibly pass any kind and number of parameters
- command in config toml `MoveWindowTop` now accepts a boolean value to disable/enable the swapping (enabled by default to avoid breaking compatibility)
- `MoveWindowTop` can be passed (optional) with a boolean argument in the command pipe. Defaults to swap: true (to avoid breaking change... though I think `false` would be better there imo)

No breaking change has been introduced (hopefully :grin:)