### PR TITLE
Fix spacing and else statements on liquid templates

### DIFF
--- a/themes/basic_eww/template.liquid
+++ b/themes/basic_eww/template.liquid
@@ -12,7 +12,7 @@
 {{visible_open}}{{workspace.index | append: ' ' | append: tag.index | append: '\"" `'}}{{ tag.name }}{{close}}
 {% elsif tag.busy  %}
 {{busy_open}}{{workspace.index | append: ' ' | append: tag.index | append: '\"" `'}}{{ tag.name }}{{close}}
-{% else tag.visible  %}
+{% else %}
 {{unoccupied}}{{workspace.index | append: ' ' | append: tag.index | append: '\"" `'}}{{ "·" }}{{close}}
 {% endif %}
 {% endfor %}

--- a/themes/basic_lemonbar/template.liquid
+++ b/themes/basic_lemonbar/template.liquid
@@ -12,7 +12,7 @@
 {{visible_open}}  {{ tag.name }}  {{visible_close}}
 {% elsif tag.busy  %}
 {{busy_open}}  {{ tag.name }}  {{busy_close}}
-{% else tag.visible  %}
+{% else %}
   {{ tag.name }}  
 {% endif %}
 {% endfor %}

--- a/themes/basic_polybar/template.liquid
+++ b/themes/basic_polybar/template.liquid
@@ -9,9 +9,9 @@
 %{A}
 {% elsif tag.busy %}
 %{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
-%{F#FFB52A}   {{tag.name}}   %{F-}
+%{F#FFB52A}  {{tag.name}}  %{F-}
 %{A}
-{% else tag.visible  %}
+{% else %}
 %{A1:$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}:}
 %{F#FFFFFF}  {{tag.name}}  %{F-}
 %{A}

--- a/themes/basic_xmobar/template.liquid
+++ b/themes/basic_xmobar/template.liquid
@@ -5,7 +5,7 @@
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`><fc=#FF9999>  {{tag.name}}  </fc></action>
 {% elsif tag.busy  %}
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`>  {{tag.name}}* </action>
-{% else tag.visible  %}
+{% else %}
 <action=`$SCRIPTPATH/change_to_tag {{workspace.index}} {{tag.index}}`><fc=#FFFFFF>  {{tag.name}}  </fc></action>
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
- The polybar template included three spaces instead of two for 'busy' tags, which caused an inconsistent layout.
- The else statements on all bar templates had a `tag.visible` condition (probably a copy/paste error).  