### PR TITLE
Add GoToPreviousTag feature to unconditionally go to last visited tag

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -18,7 +18,7 @@ pub enum Command {
         tag: TagId,
         swap: bool,
     },
-    GoToPreviousTag,
+    ReturnToLastTag,
     FloatingToTile,
     TileToFloating,
     ToggleFloating,

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -18,6 +18,7 @@ pub enum Command {
         tag: TagId,
         swap: bool,
     },
+    GoToPreviousTag,
     FloatingToTile,
     TileToFloating,
     ToggleFloating,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -64,7 +64,7 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::MoveWindowTop { swap } => move_focus_common_vars!(move_window_top(state, *swap)),
 
         Command::GoToTag { tag, swap } => goto_tag(state, *tag, *swap),
-        Command::GoToPreviousTag => goto_previous_tag(state),
+        Command::ReturnToLastTag => return_to_last_tag(state),
 
         Command::CloseWindow => close_window(state),
         Command::SwapScreens => swap_tags(state),
@@ -301,7 +301,7 @@ fn goto_tag(state: &mut State, input_tag: TagId, current_tag_swap: bool) -> Opti
     state.goto_tag_handler(destination_tag)
 }
 
-fn goto_previous_tag(state: &mut State) -> Option<bool> {
+fn return_to_last_tag(state: &mut State) -> Option<bool> {
     let previous_tag = state.focus_manager.tag(1).unwrap_or_default();
     state.goto_tag_handler(previous_tag)
 }
@@ -769,7 +769,7 @@ mod tests {
     use crate::models::Tags;
 
     #[test]
-    fn go_to_previous_tag_should_go_to_previous_tag() {
+    fn return_to_last_tag_should_go_back_to_last_tag() {
         let mut manager = Manager::new_test(vec![
             "A15".to_string(),
             "B24".to_string(),
@@ -795,7 +795,7 @@ mod tests {
         let current_tag = manager.state.focus_manager.tag(0).unwrap_or_default();
         assert_eq!(current_tag, 2);
 
-        manager.command_handler(&Command::GoToPreviousTag);
+        manager.command_handler(&Command::ReturnToLastTag);
         let current_tag = manager.state.focus_manager.tag(0).unwrap_or_default();
         assert_eq!(current_tag, 1);
     }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -65,7 +65,7 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
 
         Command::GoToTag { tag, swap } => goto_tag(state, *tag, *swap),
         Command::GoToPreviousTag => goto_previous_tag(state),
-        
+
         Command::CloseWindow => close_window(state),
         Command::SwapScreens => swap_tags(state),
         Command::MoveWindowToLastWorkspace => move_to_last_workspace(state),

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -64,7 +64,8 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::MoveWindowTop { swap } => move_focus_common_vars!(move_window_top(state, *swap)),
 
         Command::GoToTag { tag, swap } => goto_tag(state, *tag, *swap),
-
+        Command::GoToPreviousTag => goto_previous_tag(state),
+        
         Command::CloseWindow => close_window(state),
         Command::SwapScreens => swap_tags(state),
         Command::MoveWindowToLastWorkspace => move_to_last_workspace(state),
@@ -298,6 +299,11 @@ fn goto_tag(state: &mut State, input_tag: TagId, current_tag_swap: bool) -> Opti
         input_tag
     };
     state.goto_tag_handler(destination_tag)
+}
+
+fn goto_previous_tag(state: &mut State) -> Option<bool> {
+    let previous_tag = state.focus_manager.tag(1).unwrap_or_default();
+    state.goto_tag_handler(previous_tag)
 }
 
 fn focus_window(state: &mut State, param: &str) -> Option<bool> {
@@ -761,6 +767,38 @@ fn send_workspace_to_tag(state: &mut State, ws_index: usize, tag_index: usize) -
 mod tests {
     use super::*;
     use crate::models::Tags;
+
+    #[test]
+    fn go_to_previous_tag_should_go_to_previous_tag() {
+        let mut manager = Manager::new_test(vec![
+            "A15".to_string(),
+            "B24".to_string(),
+            "C".to_string(),
+            "6D4".to_string(),
+            "E39".to_string(),
+            "F67".to_string(),
+        ]);
+        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default());
+
+        assert!(manager.command_handler(&Command::GoToTag {
+            tag: 1,
+            swap: false
+        }));
+        let current_tag = manager.state.focus_manager.tag(0).unwrap();
+        assert_eq!(current_tag, 1);
+
+        assert!(manager.command_handler(&Command::GoToTag {
+            tag: 2,
+            swap: false
+        }));
+        let current_tag = manager.state.focus_manager.tag(0).unwrap_or_default();
+        assert_eq!(current_tag, 2);
+
+        manager.command_handler(&Command::GoToPreviousTag);
+        let current_tag = manager.state.focus_manager.tag(0).unwrap_or_default();
+        assert_eq!(current_tag, 1);
+    }
 
     #[test]
     fn go_to_tag_should_return_false_if_no_screen_is_created() {

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -21,6 +21,7 @@ pub enum BaseCommand {
     ToggleFullScreen,
     ToggleSticky,
     GotoTag,
+    GoToPreviousTag,
     FloatingToTile,
     TileToFloating,
     ToggleFloating,

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -21,7 +21,7 @@ pub enum BaseCommand {
     ToggleFullScreen,
     ToggleSticky,
     GotoTag,
-    GoToPreviousTag,
+    ReturnToLastTag,
     FloatingToTile,
     TileToFloating,
     ToggleFloating,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -40,7 +40,7 @@ impl Keybind {
                 tag: usize::from_str(&self.value).context("invalid index value for GotoTag")?,
                 swap: !config.disable_current_tag_swap,
             },
-            BaseCommand::GoToPreviousTag => leftwm_core::Command::GoToPreviousTag,
+            BaseCommand::ReturnToLastTag => leftwm_core::Command::ReturnToLastTag,
             BaseCommand::FloatingToTile => leftwm_core::Command::FloatingToTile,
             BaseCommand::TileToFloating => leftwm_core::Command::TileToFloating,
             BaseCommand::ToggleFloating => leftwm_core::Command::ToggleFloating,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -40,6 +40,7 @@ impl Keybind {
                 tag: usize::from_str(&self.value).context("invalid index value for GotoTag")?,
                 swap: !config.disable_current_tag_swap,
             },
+            BaseCommand::GoToPreviousTag => leftwm_core::Command::GoToPreviousTag,
             BaseCommand::FloatingToTile => leftwm_core::Command::FloatingToTile,
             BaseCommand::TileToFloating => leftwm_core::Command::TileToFloating,
             BaseCommand::ToggleFloating => leftwm_core::Command::ToggleFloating,


### PR DESCRIPTION
Similarly to GoToTag feature, I wanted a way to unconditionally go to
previous tag, without having to press the key for the current tag.

No default keybindings have been assigned for this feature.

I did not find an up to date list of available commands so I did not
know where to document this new command.

Tested in Xephyr. `cargo test` passes.