### PR TITLE
Fix border-color issue when focusing a floating window

### DIFF
--- a/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
+++ b/leftwm-core/src/display_servers/xlib_display_server/xwrap/window.rs
@@ -241,7 +241,7 @@ impl XWrap {
             // Update previous window.
             if let Some(previous) = previous {
                 if let WindowHandle::XlibHandle(previous_handle) = previous.handle {
-                    let color = if window.floating() {
+                    let color = if previous.floating() {
                         self.colors.floating
                     } else {
                         self.colors.normal


### PR DESCRIPTION
This partially fixes #735, namley:

> **Border colors for floating/non-floating windows seem to get mixed up**
When I switch focus from a tiled window to a floating window, the previously focused tiled window gets the `floating_border_color`. When switching focus from a tiled to another tiled window, this doesn't happen. The floating window seems to never receive the `floating_border_color` at all.

---

Issue simply was, that on window focus change, when changing the previous window's border color, the newly focused windows properties were considered to decide on the previous window's border colors :stuck_out_tongue: 