### PR TITLE
Allow disabling window snapping

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -54,6 +54,7 @@ pub trait Config {
     fn get_list_of_gutters(&self) -> Vec<Gutter>;
     fn max_window_width(&self) -> Option<Size>;
     fn disable_tile_drag(&self) -> bool;
+    fn disable_window_snap(&self) -> bool;
 
     /// Attempt to write current state to a file.
     ///
@@ -176,6 +177,9 @@ impl Config for TestConfig {
         None
     }
     fn disable_tile_drag(&self) -> bool {
+        false
+    }
+    fn disable_window_snap(&self) -> bool {
         false
     }
     fn save_state(&self, _state: &State) {

--- a/leftwm-core/src/handlers/window_move_handler.rs
+++ b/leftwm-core/src/handlers/window_move_handler.rs
@@ -18,11 +18,12 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             Some(w) => w.margin_multiplier(),
             None => 1.0,
         };
+        let disable_swap = &self.config.disable_window_snap();
         match self.state.windows.iter_mut().find(|w| w.handle == *handle) {
             Some(w) => {
                 process_window(w, offset_x, offset_y);
                 w.apply_margin_multiplier(margin_multiplier);
-                if snap_to_workspaces(w, &self.state.workspaces) {
+                if !disable_swap && snap_to_workspaces(w, &self.state.workspaces) {
                     self.state.sort_windows();
                 }
                 true

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -207,6 +207,7 @@ impl Default for Config {
             window_rules: Some(vec![]),
             disable_current_tag_swap: false,
             disable_tile_drag: false,
+            disable_window_snap: false,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
             focus_new_windows: true, // default behaviour: focuses windows on creation
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -207,7 +207,7 @@ impl Default for Config {
             window_rules: Some(vec![]),
             disable_current_tag_swap: false,
             disable_tile_drag: false,
-            disable_window_snap: false,
+            disable_window_snap: true,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
             focus_new_windows: true, // default behaviour: focuses windows on creation
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -96,6 +96,7 @@ pub struct Config {
     //of you are on tag "1" and you goto tag "1" this takes you to the previous tag
     pub disable_current_tag_swap: bool,
     pub disable_tile_drag: bool,
+    pub disable_window_snap: bool,
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
@@ -381,6 +382,10 @@ impl leftwm_core::Config for Config {
 
     fn floating_border_color(&self) -> String {
         self.theme_setting.floating_border_color.clone()
+    }
+
+    fn disable_window_snap(&self) -> bool {
+        self.disable_window_snap
     }
 
     fn always_float(&self) -> bool {


### PR DESCRIPTION
Add disable_window_snap config option as mentioned in #561 

I would update the config wiki page as below.

# Snapping Behaviour
If snapping is enabled, floating windows are snapped (repositioned to a tile) when the window  is dragged close to a Workspace edge. This might lead to undesired behaviour when dragging windows near the edge of the screen, so it is disabled by default.

Snapping can be disabled with `disable_window_snap`:

Default: `disable_window_snap = true`

Example: `disable_window_snap = false` (enables snapping)