### PR TITLE
Add moving window to next/previous tag (#751)

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -41,6 +41,12 @@ pub enum Command {
         window: Option<WindowHandle>,
         tag: TagId,
     },
+    MoveWindowToNextTag {
+        follow: bool,
+    },
+    MoveWindowToPreviousTag {
+        follow: bool,
+    },
     MoveWindowToLastWorkspace,
     MoveWindowToNextWorkspace,
     MoveWindowToPreviousWorkspace,

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -94,6 +94,8 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),
         "ToggleSticky" => Ok(Command::ToggleSticky),
         "SwapScreens" => Ok(Command::SwapScreens),
+        "MoveWindowToNextTag" => build_move_window_to_next_tag(rest),
+        "MoveWindowToPreviousTag" => build_move_window_to_previous_tag(rest),
         "MoveWindowToLastWorkspace" => Ok(Command::MoveWindowToLastWorkspace),
         "MoveWindowToNextWorkspace" => Ok(Command::MoveWindowToNextWorkspace),
         "MoveWindowToPreviousWorkspace" => Ok(Command::MoveWindowToPreviousWorkspace),
@@ -194,6 +196,24 @@ fn build_move_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error
     Ok(Command::MoveWindowTop { swap })
 }
 
+fn build_move_window_to_next_tag(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
+    let follow = if raw.is_empty() {
+        true
+    } else {
+        bool::from_str(raw)?
+    };
+    Ok(Command::MoveWindowToNextTag { follow })
+}
+
+fn build_move_window_to_previous_tag(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
+    let follow = if raw.is_empty() {
+        true
+    } else {
+        bool::from_str(raw)?
+    };
+    Ok(Command::MoveWindowToPreviousTag { follow })
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -265,10 +285,7 @@ mod test {
         // Let the OS close the write end of the pipe before shutting down the listener.
         time::sleep(time::Duration::from_millis(100)).await;
 
-        // NOTE: clippy is drunk
-        {
-            assert!(!pipe_file.exists());
-        }
+        assert!(!pipe_file.exists());
     }
 
     #[test]
@@ -309,6 +326,22 @@ mod test {
         assert_eq!(
             build_focus_window_top("").unwrap(),
             Command::FocusWindowTop { swap: false }
+        );
+    }
+
+    #[test]
+    fn build_move_window_to_next_tag_without_parameter() {
+        assert_eq!(
+            build_move_window_to_next_tag("").unwrap(),
+            Command::MoveWindowToNextTag { follow: true }
+        );
+    }
+
+    #[test]
+    fn build_move_window_to_previous_tag_without_parameter() {
+        assert_eq!(
+            build_move_window_to_previous_tag("").unwrap(),
+            Command::MoveWindowToPreviousTag { follow: true }
         );
     }
 }

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -55,6 +55,8 @@ async fn main() -> Result<()> {
         ToggleFullScreen
         ToggleSticky
         SwapScreens
+        MoveWindowToNextTag
+        MoveWindowToPreviousTag
         MoveWindowToLastWorkspace
         MoveWindowToNextWorkspace
         MoveWindowToPreviousWorkspace

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -37,6 +37,8 @@ pub enum BaseCommand {
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
     MoveToTag,
+    MoveWindowToNextTag,
+    MoveWindowToPreviousTag,
     MoveToLastWorkspace,
     MoveWindowToNextWorkspace,
     MoveWindowToPreviousWorkspace,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -74,6 +74,14 @@ impl Keybind {
                 tag: usize::from_str(&self.value)
                     .context("invalid index value for SendWindowToTag")?,
             },
+            BaseCommand::MoveWindowToNextTag => leftwm_core::Command::MoveWindowToNextTag {
+                follow: bool::from_str(&self.value)
+                    .context("invalid boolean value for MoveWindowToNextTag")?,
+            },
+            BaseCommand::MoveWindowToPreviousTag => leftwm_core::Command::MoveWindowToPreviousTag {
+                follow: bool::from_str(&self.value)
+                    .context("invalid boolean value for MoveWindowToPreviousTag")?,
+            },
             BaseCommand::MoveToLastWorkspace => leftwm_core::Command::MoveWindowToLastWorkspace,
             BaseCommand::MoveWindowToNextWorkspace => {
                 leftwm_core::Command::MoveWindowToNextWorkspace


### PR DESCRIPTION
# Description

Add moving window to the next or previous tag.

When executing while working on first/last tag, the command will move window wrapping around tag list.

Fixes #751

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (wiki / Keybind Commands)

## Updated user documentation:

### Wiki

# Keybind Commands

...

## MoveWindowToNextTag

Takes the window that is currently focused and moves it to the next tag. If `value` is `true`, the focus will follow the window. Next tag is brought to the current workspace and focused.

Example:

```toml
[[keybind]]
command = "MoveWindowToNextTag"
value = "true"
modifier = ["modkey", "Shift"]
key = "l"
```

## MoveWindowToPreviousTag

Takes the window that is currently focused and moves it to the previous tag. If `value` is `true`, the focus will follow the window. Previous tag is brought to the current workspace and focused.

Example:

```toml
[[keybind]]
command = "MoveWindowToPreviousTag"
value = "true"
modifier = ["modkey", "Shift"]
key = "h"
```

## MoveToLastWorkspace
...

---

### command_handler

I've been struggling a bit with my command not taking an effect when running with `leftwm-command` so I've updated section about where to look when adding/renaming commands.

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details. (Seems broken link)

---

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
- [x] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [ ] Manual page has been updated accordingly (Not needed unless we want this as default)
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
