### PR TITLE
Added option to stop cursor from following focused windows

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -55,6 +55,7 @@ pub trait Config {
     fn max_window_width(&self) -> Option<Size>;
     fn disable_tile_drag(&self) -> bool;
     fn disable_window_snap(&self) -> bool;
+    fn mouse_follows_focus(&self) -> bool;
 
     /// Attempt to write current state to a file.
     ///
@@ -195,6 +196,9 @@ impl Config for TestConfig {
         } else {
             false
         }
+    }
+    fn mouse_follows_focus(&self) -> bool {
+        true
     }
 }
 

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -1,6 +1,7 @@
 use super::Config;
 use super::DisplayEvent;
 use super::DisplayServer;
+use crate::models::FocusManager;
 use crate::models::Screen;
 
 #[derive(Clone)]
@@ -26,7 +27,7 @@ impl DisplayServer for MockDisplayServer {
         unimplemented!()
     }
 
-    fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
+    fn generate_verify_focus_event(&self, _: &mut FocusManager) -> Option<DisplayEvent> {
         unimplemented!()
     }
 }

--- a/leftwm-core/src/display_servers/mod.rs
+++ b/leftwm-core/src/display_servers/mod.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::display_action::DisplayAction;
+use crate::models::FocusManager;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use crate::models::Workspace;
@@ -39,5 +40,5 @@ pub trait DisplayServer {
 
     fn flush(&self);
 
-    fn generate_verify_focus_event(&self) -> Option<DisplayEvent>;
+    fn generate_verify_focus_event(&self, focus_manager: &mut FocusManager) -> Option<DisplayEvent>;
 }

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -44,7 +44,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
                 // is currently focused.
                 _ = timeout(100), if event_buffer.is_empty()
                     && self.state.focus_manager.behaviour.is_sloppy() => {
-                    if let Some(verify_event) = self.display_server.generate_verify_focus_event() {
+                    if let Some(verify_event) = self.display_server.generate_verify_focus_event(&mut self.state.focus_manager) {
                         event_buffer.push(verify_event);
                     }
                     continue;

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -8,7 +8,7 @@ use crate::{display_action::DisplayAction, models::FocusBehaviour};
 impl State {
     pub fn handle_window_focus(&mut self, handle: &WindowHandle) {
         match self.focus_manager.behaviour {
-            FocusBehaviour::Sloppy => {
+            FocusBehaviour::Sloppy if self.focus_manager.mouse_follows_focus => {
                 let act = DisplayAction::MoveMouseOver(*handle, false);
                 self.actions.push_back(act);
             }

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -41,6 +41,8 @@ pub struct FocusManager {
     pub window_history: VecDeque<MaybeWindowHandle>,
     pub tag_history: VecDeque<TagId>,
     pub tags_last_window: HashMap<TagId, WindowHandle>,
+    pub mouse_follows_focus: bool,
+    pub last_mouse_position: Option<(i32, i32)>,
 }
 
 impl FocusManager {
@@ -52,6 +54,8 @@ impl FocusManager {
             window_history: Default::default(),
             tag_history: Default::default(),
             tags_last_window: Default::default(),
+            mouse_follows_focus: config.mouse_follows_focus(),
+            last_mouse_position: None,
         }
     }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -217,6 +217,7 @@ impl Default for Config {
             theme_setting: ThemeSetting::default(),
             max_window_width: None,
             state: None,
+            mouse_follows_focus: true,
         }
     }
 }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -101,6 +101,7 @@ pub struct Config {
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
+    pub mouse_follows_focus: bool,
 
     #[serde(skip)]
     pub theme_setting: ThemeSetting,
@@ -477,6 +478,10 @@ impl leftwm_core::Config for Config {
             return false;
         }
         false
+    }
+
+    fn mouse_follows_focus(&self) -> bool {
+        self.mouse_follows_focus
     }
 }
 


### PR DESCRIPTION
# Description

A little feature that adds the `mouse_follows_focus` option that will decide if the cursor will follow windows as they're focused or not.
Currently when you change the focused window, the cursor will be placed on the center of the newly created window, and that can sometimes be a bit annoying.
I can also lead to some problematic behaviors: for example when a window spawns a popup sub-window, and focusing the parent window forces you to focus the popup, the cursor would always teleport in the center of the popup when you try to escape it, and so your cursor would be stuck in the popup. This happened a lot to me with kde applications, such as kdenlive and krita.
I've discussed this feature idea briefly on discord a while ago, but didn't really went to try to implement it since then.

I couldn't find any related issue for this feature, let me know if one exists so i can reference it here.

This PR is just a draft, i couldn't finish it as fast as i would have liked it, so there is still stuff to do, and also I need others to see if the implementation is ok or needs more work.

The cursor will not teleport when:
- [x] Changing focus
- [ ] Spawning/Destroying a window
- [ ] Resizing the main window
- [x] Changing layout*
- [x] Changing tag/workspace*

<sub>
* Those looks like they are working, but still need to find if there is no issue
</sub>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:

*Will add later*

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
- [ ] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
