### PR TITLE
Add ToggleMargin

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -13,6 +13,7 @@ pub enum Command {
     HardReload,
     ToggleScratchPad(String),
     ToggleFullScreen,
+    ToggleMargin,
     ToggleSticky,
     GoToTag {
         tag: TagId,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -53,6 +53,7 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
 
         Command::ToggleScratchPad(name) => toggle_scratchpad(manager, name),
 
+        Command::ToggleMargin => toggle_margin(state),
         Command::ToggleFullScreen => toggle_state(state, WindowState::Fullscreen),
         Command::ToggleSticky => toggle_state(state, WindowState::Sticky),
 
@@ -212,6 +213,17 @@ fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
     }
     log::warn!("unable to find NSP tag");
     None
+}
+
+fn toggle_margin(state: &mut State) -> Option<bool> {
+    let ws = state.focus_manager.workspace_mut(&mut state.workspaces)?;
+    let margin = ws.margin_multiplier();
+    if margin > 0.0 {
+        set_margin_multiplier(state, 0.0);
+    } else {
+        set_margin_multiplier(state, 1.0);
+    }
+    Some(true)
 }
 
 fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -92,6 +92,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
     match head {
         "SoftReload" => Ok(Command::SoftReload),
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),
+        "ToggleMargin" => Ok(Command::ToggleMargin),
         "ToggleSticky" => Ok(Command::ToggleSticky),
         "SwapScreens" => Ok(Command::SwapScreens),
         "MoveWindowToLastWorkspace" => Ok(Command::MoveWindowToLastWorkspace),

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<()> {
         UnloadTheme
         SoftReload
         ToggleFullScreen
+        ToggleMargin
         ToggleSticky
         SwapScreens
         MoveWindowToLastWorkspace

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -19,6 +19,7 @@ pub enum BaseCommand {
     HardReload,
     ToggleScratchPad,
     ToggleFullScreen,
+    ToggleMargin,
     ToggleSticky,
     GotoTag,
     ReturnToLastTag,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -35,6 +35,7 @@ impl Keybind {
                 leftwm_core::Command::ToggleScratchPad(ensure_non_empty!(self.value.clone()))
             }
             BaseCommand::ToggleFullScreen => leftwm_core::Command::ToggleFullScreen,
+            BaseCommand::ToggleMargin => leftwm_core::Command::ToggleMargin,
             BaseCommand::ToggleSticky => leftwm_core::Command::ToggleSticky,
             BaseCommand::GotoTag => leftwm_core::Command::GoToTag {
                 tag: usize::from_str(&self.value).context("invalid index value for GotoTag")?,


### PR DESCRIPTION
# Description

I would like a option to toggle margins off and on. 
It does seem silly to have to two separate `SetMarginMultiplier` bindings when most people probably just want to toggle them on and off. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:
# Keybind

## ToggleMargin

Toggles the current tag between having no margin and default margin.

Example:

```toml
[[keybind]]
command = "ToggleMargin"
modifier = ["modkey"]
key = "g"
```

# External Commands
|Command | Arguments (if needed) | Notes |
|-|-|-|
| ToggleMargin | | Makes current tag have no margin/default margin |

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
- [x] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
