### PR TITLE
README: Changed picom command for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ List of common dependencies for themes:
 | Dependency<br>(git) | Ubuntu 20.4.1<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 33<br> _sudo dnf install {}_ | PKGS |
 |--------------------------|-----------|-------------------|-----------|--------------------------|
 | [feh][feh-git]           | feh       | feh               | feh       | [feh][feh-pkg]           |
-| [compton][compton-git]   | compton   | paru -S picom*    | compton   | [compton][compton-pkg]   |
+| [compton][compton-git]   | compton   | picom             | compton   | [compton][compton-pkg]   |
 | [picom][picom-git]       | manual ** | picom             | picom     | [picom][picom-pkg]       |
 | [polybar][polybar-git]   | manual ** | paru -S polybar*  | polybar   | [polybar][polybar-pkg]   |
 | [xmobar][xmobar-git]     | xmobar    | xmobar            | xmobar    | [xmobar][xmobar-pkg]     |


### PR DESCRIPTION
# Description

Picom has been added to official Arch repos a couple of years ago, no need to provide a command to get it from AUR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:

README.md

# Checklist (is this filled by me or by maintainers?):

- [ ] Ran `make test` locally with no errors or warnings reported
- [ ] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
