### PR TITLE
adding the `test-full` label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,21 @@ TARGET_DIR := /usr/local/bin
 all: build test
 
 # runs tests and linters
-test: 
+test:
 	cd $(ROOT_DIR) && cargo test --all-targets --all-features
 	cd $(ROOT_DIR) && cargo fmt -- --check
 	cd $(ROOT_DIR) && cargo clippy --release
+
+test-full:
+	make test
+	cargo clippy --\
+		-W clippy::pedantic\
+		-A clippy::must_use_candidate\
+		-A clippy::cast_precision_loss\
+		-A clippy::cast_possible_truncation\
+		-A clippy::cast_possible_wrap\
+		-A clippy::cast_sign_loss\
+		-A clippy::mut_mut
 
 # builds the project
 build:


### PR DESCRIPTION
# Description

In my opinion it's a little bit annoying to call `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut` manually on the command line, so I added `test-full` which does `make test` and this long clippy command.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Not needed

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
- [x] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
