### PR TITLE
fix crash when serialising default config to toml

### DIFF
--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -100,10 +100,11 @@ pub struct Config {
     pub disable_window_snap: bool,
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
+    pub sloppy_mouse_follows_focus: bool,
     pub keybind: Vec<Keybind>,
     pub state: Option<PathBuf>,
-    pub sloppy_mouse_follows_focus: bool,
-
+    // NOTE: any newly added parameters must be inserted before `pub keybind: Vec<Keybind>,`
+    //       at least when `TOML` is used as config language
     #[serde(skip)]
     pub theme_setting: ThemeSetting,
 }


### PR DESCRIPTION
# Description

Fixes #692

This previously fixed issue was reintroduced by #765 by adding the default value for `sloppy_mouse_follows_focus` after the keybinds, which leads to a serialisation error with `toml` as it tries to add this value to the table of the last keybind entry.

There should be a test to avoid this in the future, but as this is somewhat critical for any new install I'd suggest to merge this asap and add the test later.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
- [x] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
