### PR TITLE
Update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,6 @@ See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documen
 
 # Checklist:
 
-- [ ] Ran `make test` locally with no errors or warnings reported
-- [ ] Enhanced review is performed with `cargo clippy -- -W clippy::pedantic -A clippy::must_use_candidate -A clippy::cast_precision_loss -A clippy::cast_possible_truncation -A clippy::cast_possible_wrap -A clippy::cast_sign_loss -A clippy::mut_mut`
+- [ ] Ran `make test-full` locally with no errors or warnings reported
 - [ ] Manual page has been updated accordingly
 - [ ] Wiki pages have been updated accordingly (to perform **after** merge)


### PR DESCRIPTION
Since we merged https://github.com/leftwm/leftwm/pull/790, we can update the PR-Template I guess.