### PR TITLE
change confusing name for `state_file` path config option

### DIFF
--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -216,7 +216,7 @@ impl Default for Config {
             keybind: commands,
             theme_setting: ThemeSetting::default(),
             max_window_width: None,
-            state: None,
+            state_path: None,
             sloppy_mouse_follows_focus: true,
         }
     }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -101,7 +101,7 @@ pub struct Config {
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
     pub keybind: Vec<Keybind>,
-    pub state: Option<PathBuf>,
+    pub state_path: Option<PathBuf>,
     pub sloppy_mouse_follows_focus: bool,
 
     #[serde(skip)]
@@ -488,7 +488,7 @@ impl leftwm_core::Config for Config {
 
 impl Config {
     fn state_file(&self) -> &Path {
-        self.state
+        self.state_path
             .as_deref()
             .unwrap_or_else(|| Path::new(STATE_FILE))
     }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -26,7 +26,7 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use xdg::BaseDirectories;
 
-/// Path to file where state will be dumper upon soft reload.
+/// Path to file where state will be dumped upon soft reload.
 const STATE_FILE: &str = "/tmp/leftwm.state";
 
 /// Selecting by `WM_CLASS` and/or window title, allow the user to define if a
@@ -94,7 +94,7 @@ pub struct Config {
     pub insert_behavior: InsertBehavior,
     pub scratchpad: Option<Vec<ScratchPad>>,
     pub window_rules: Option<Vec<WindowHook>>,
-    //of you are on tag "1" and you goto tag "1" this takes you to the previous tag
+    // If you are on tag "1" and you goto tag "1" this takes you to the previous tag
     pub disable_current_tag_swap: bool,
     pub disable_tile_drag: bool,
     pub disable_window_snap: bool,

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -103,11 +103,9 @@ pub struct Config {
     pub sloppy_mouse_follows_focus: bool,
     pub keybind: Vec<Keybind>,
     pub state_path: Option<PathBuf>,
-    pub sloppy_mouse_follows_focus: bool,
 
     // NOTE: any newly added parameters must be inserted before `pub keybind: Vec<Keybind>,`
     //       at least when `TOML` is used as config language
-    
     #[serde(skip)]
     pub theme_setting: ThemeSetting,
 }


### PR DESCRIPTION
# Description

A mention in #791 of the `state` config field and the following invstigation led to the decision a rename of `leftwm::config::Config::state` to `leftwm::config::Config::state_path` might help to prevent confusion with the actual `leftwm_core::state::State`.

Snuck in some typo fixes in comments along.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

No user doc update needed.

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
