### PR TITLE
Move `TestConfig` to `tests` module

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -83,131 +83,129 @@ pub trait Config {
 }
 
 #[cfg(test)]
-#[allow(clippy::module_name_repetitions)]
-#[derive(Default)]
-pub struct TestConfig {
-    pub tags: Vec<String>,
-    pub layouts: Vec<Layout>,
-    pub workspaces: Option<Vec<Workspace>>,
-    pub insert_behavior: InsertBehavior,
-}
-
-#[cfg(test)]
-impl Config for TestConfig {
-    fn mapped_bindings(&self) -> Vec<Keybind> {
-        unimplemented!()
-    }
-    fn create_list_of_tag_labels(&self) -> Vec<String> {
-        self.tags.clone()
-    }
-    fn workspaces(&self) -> Option<Vec<Workspace>> {
-        self.workspaces.clone()
-    }
-    fn focus_behaviour(&self) -> FocusBehaviour {
-        FocusBehaviour::ClickTo
-    }
-    fn mousekey(&self) -> Vec<String> {
-        vec!["Mod4".to_owned()]
-    }
-    fn create_list_of_scratchpads(&self) -> Vec<ScratchPad> {
-        vec![]
-    }
-    fn layouts(&self) -> Vec<Layout> {
-        self.layouts.clone()
-    }
-    fn layout_mode(&self) -> LayoutMode {
-        LayoutMode::Workspace
-    }
-
-    fn insert_behavior(&self) -> InsertBehavior {
-        self.insert_behavior
-    }
-
-    fn focus_new_windows(&self) -> bool {
-        false
-    }
-    fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
-    where
-        SERVER: DisplayServer,
-    {
-        match command {
-            "GoToTag2" => manager.command_handler(&crate::Command::GoToTag {
-                tag: 2,
-                swap: false,
-            }),
-            _ => unimplemented!("custom command handler: {:?}", command),
-        }
-    }
-    fn always_float(&self) -> bool {
-        false
-    }
-    fn default_width(&self) -> i32 {
-        1000
-    }
-    fn default_height(&self) -> i32 {
-        800
-    }
-    fn border_width(&self) -> i32 {
-        0
-    }
-    fn margin(&self) -> Margins {
-        Margins::new(0)
-    }
-    fn workspace_margin(&self) -> Option<Margins> {
-        None
-    }
-    fn gutter(&self) -> Option<Vec<Gutter>> {
-        unimplemented!()
-    }
-    fn default_border_color(&self) -> String {
-        unimplemented!()
-    }
-    fn floating_border_color(&self) -> String {
-        unimplemented!()
-    }
-    fn focused_border_color(&self) -> String {
-        unimplemented!()
-    }
-    fn on_new_window_cmd(&self) -> Option<String> {
-        None
-    }
-    fn get_list_of_gutters(&self) -> Vec<Gutter> {
-        Default::default()
-    }
-    fn max_window_width(&self) -> Option<Size> {
-        None
-    }
-    fn disable_tile_drag(&self) -> bool {
-        false
-    }
-    fn disable_window_snap(&self) -> bool {
-        false
-    }
-    fn save_state(&self, _state: &State) {
-        unimplemented!()
-    }
-    fn load_state(&self, _state: &mut State) {
-        unimplemented!()
-    }
-    fn setup_predefined_window(&self, window: &mut Window) -> bool {
-        if window.res_class == Some("ShouldGoToTag2".to_string()) {
-            window.tags = vec![2];
-            true
-        } else {
-            false
-        }
-    }
-    fn sloppy_mouse_follows_focus(&self) -> bool {
-        true
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::models::Screen;
     use crate::models::Window;
     use crate::models::WindowHandle;
+
+    #[allow(clippy::module_name_repetitions)]
+    #[derive(Default)]
+    pub struct TestConfig {
+        pub tags: Vec<String>,
+        pub layouts: Vec<Layout>,
+        pub workspaces: Option<Vec<Workspace>>,
+        pub insert_behavior: InsertBehavior,
+    }
+
+    impl Config for TestConfig {
+        fn mapped_bindings(&self) -> Vec<Keybind> {
+            unimplemented!()
+        }
+        fn create_list_of_tag_labels(&self) -> Vec<String> {
+            self.tags.clone()
+        }
+        fn workspaces(&self) -> Option<Vec<Workspace>> {
+            self.workspaces.clone()
+        }
+        fn focus_behaviour(&self) -> FocusBehaviour {
+            FocusBehaviour::ClickTo
+        }
+        fn mousekey(&self) -> Vec<String> {
+            vec!["Mod4".to_owned()]
+        }
+        fn create_list_of_scratchpads(&self) -> Vec<ScratchPad> {
+            vec![]
+        }
+        fn layouts(&self) -> Vec<Layout> {
+            self.layouts.clone()
+        }
+        fn layout_mode(&self) -> LayoutMode {
+            LayoutMode::Workspace
+        }
+
+        fn insert_behavior(&self) -> InsertBehavior {
+            self.insert_behavior
+        }
+
+        fn focus_new_windows(&self) -> bool {
+            false
+        }
+        fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
+        where
+            SERVER: DisplayServer,
+        {
+            match command {
+                "GoToTag2" => manager.command_handler(&crate::Command::GoToTag {
+                    tag: 2,
+                    swap: false,
+                }),
+                _ => unimplemented!("custom command handler: {:?}", command),
+            }
+        }
+        fn always_float(&self) -> bool {
+            false
+        }
+        fn default_width(&self) -> i32 {
+            1000
+        }
+        fn default_height(&self) -> i32 {
+            800
+        }
+        fn border_width(&self) -> i32 {
+            0
+        }
+        fn margin(&self) -> Margins {
+            Margins::new(0)
+        }
+        fn workspace_margin(&self) -> Option<Margins> {
+            None
+        }
+        fn gutter(&self) -> Option<Vec<Gutter>> {
+            unimplemented!()
+        }
+        fn default_border_color(&self) -> String {
+            unimplemented!()
+        }
+        fn floating_border_color(&self) -> String {
+            unimplemented!()
+        }
+        fn focused_border_color(&self) -> String {
+            unimplemented!()
+        }
+        fn on_new_window_cmd(&self) -> Option<String> {
+            None
+        }
+        fn get_list_of_gutters(&self) -> Vec<Gutter> {
+            Default::default()
+        }
+        fn max_window_width(&self) -> Option<Size> {
+            None
+        }
+        fn disable_tile_drag(&self) -> bool {
+            false
+        }
+        fn disable_window_snap(&self) -> bool {
+            false
+        }
+        fn save_state(&self, _state: &State) {
+            unimplemented!()
+        }
+        fn load_state(&self, _state: &mut State) {
+            unimplemented!()
+        }
+        fn setup_predefined_window(&self, window: &mut Window) -> bool {
+            if window.res_class == Some("ShouldGoToTag2".to_string()) {
+                window.tags = vec![2];
+                true
+            } else {
+                false
+            }
+        }
+        fn sloppy_mouse_follows_focus(&self) -> bool {
+            true
+        }
+    }
 
     #[test]
     fn ensure_command_handler_trait_boundary() {

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -83,7 +83,7 @@ pub trait Config {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::models::Screen;
     use crate::models::Window;

--- a/leftwm-core/src/models/layout_manager.rs
+++ b/leftwm-core/src/models/layout_manager.rs
@@ -114,7 +114,7 @@ impl LayoutManager {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::TestConfig;
+    use crate::config::tests::TestConfig;
     use crate::models::BBox;
 
     use super::*;

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -56,9 +56,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 }
 
 #[cfg(test)]
-impl Manager<crate::config::TestConfig, crate::display_servers::MockDisplayServer> {
+impl Manager<crate::config::tests::TestConfig, crate::display_servers::MockDisplayServer> {
     pub fn new_test(tags: Vec<String>) -> Self {
-        use crate::config::TestConfig;
+        use crate::config::tests::TestConfig;
         Self::new(TestConfig {
             tags,
             ..TestConfig::default()


### PR DESCRIPTION
# Description

Since this struct seems be only used for `tests`, I thought that I could move it to the `tests` module then.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Not needed

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
