### PR TITLE
fix #801

### DIFF
--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -147,16 +147,16 @@ fn start_leftwm() {
                 nix::unistd::pause();
             }
         }
-    }
 
-    // TODO: either add more details or find a better workaround.
-    //
-    // Left is too fast for some logging managers. We need to
-    // wait to give the logging manager a second to boot.
-    #[cfg(feature = "slow-dm-fix")]
-    {
-        let delay = std::time::Duration::from_millis(2000);
-        std::thread::sleep(delay);
+        // TODO: either add more details or find a better workaround.
+        //
+        // Left is too fast for some logging managers. We need to
+        // wait to give the logging manager a second to boot.
+        #[cfg(feature = "slow-dm-fix")]
+        {
+            let delay = std::time::Duration::from_millis(2000);
+            std::thread::sleep(delay);
+        }
     }
 }
 

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -133,17 +133,19 @@ fn start_leftwm() {
 
     set_env_vars();
 
-    // Boot everything WM agnostic or LeftWM related in ~/.config/autostart
-    let mut children = Nanny::autostart();
+    loop {
+        // Boot everything WM agnostic or LeftWM related in ~/.config/autostart
+        let mut children = Nanny::autostart();
 
-    let flag = get_sigchld_flag();
-    let mut leftwm_session = start_leftwm_session(&current_exe);
-    while leftwm_is_still_running(&mut leftwm_session) {
-        // remove all child processes which finished
-        children.remove_finished_children();
+        let flag = get_sigchld_flag();
+        let mut leftwm_session = start_leftwm_session(&current_exe);
+        while leftwm_is_still_running(&mut leftwm_session) {
+            // remove all child processes which finished
+            children.remove_finished_children();
 
-        while is_suspending(&flag) {
-            nix::unistd::pause();
+            while is_suspending(&flag) {
+                nix::unistd::pause();
+            }
         }
     }
 

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -133,11 +133,12 @@ fn start_leftwm() {
 
     set_env_vars();
 
-    loop {
-        // Boot everything WM agnostic or LeftWM related in ~/.config/autostart
-        let mut children = Nanny::autostart();
+    // Boot everything WM agnostic or LeftWM related in ~/.config/autostart
+    let mut children = Nanny::autostart();
 
-        let flag = get_sigchld_flag();
+    let flag = get_sigchld_flag();
+
+    loop {
         let mut leftwm_session = start_leftwm_session(&current_exe);
         while leftwm_is_still_running(&mut leftwm_session) {
             // remove all child processes which finished


### PR DESCRIPTION
# Description

The earlier refactors missed to preserve an important `loop` that is needed for leftwm to restart the `worker` after being killed during a `SoftReload`
Fixes #801

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

(not applicable)

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
