### PR TITLE
Floating window improvements

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -380,11 +380,15 @@ fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
     let xyhw = window.requested.map_or_else(
         || ws.center_halfed(),
         |mut requested| {
-            requested.center_relative(outer, window.border);
             if ws.xyhw.contains_xyhw(&requested) {
                 requested
             } else {
-                ws.center_halfed()
+                requested.center_relative(outer, window.border);
+                if ws.xyhw.contains_xyhw(&requested) {
+                    requested
+                } else {
+                    ws.center_halfed()
+                }
             }
         },
     );

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -266,6 +266,9 @@ fn setup_window(
         }
         if window.r#type == WindowType::Normal {
             window.apply_margin_multiplier(ws.margin_multiplier);
+            if window.floating() {
+                set_relative_floating(window, ws, ws.xyhw);
+            }
         }
         // Center dialogs and modal in workspace
         if window.r#type == WindowType::Dialog {


### PR DESCRIPTION
# Description

I wanted to fix #700 by using the window size / location hints when spawn_floating is configured. I don't think I fully fixed this, because we probably want to have a better default than falling back to "fullscreening" the window if it doesn't have a max height/width. Some windows define min width / height, this could be used as default width / height. I'd say this can be done in a separate PR.

As a side effect #632 will also be ~~fixed~~ partly fixed because windows will receive the last location / size as hint. ~~I don't know if this is application specific or something that is built into X, so I don't know if this completely fixes #632. This behavior is similar to the one from i3 for floating windows.~~ This only applies to apps that manually save the location / size and then set them as hint on startup.

<details>
  <summary>xprop output from last position hint</summary>
  
  ```
_NET_WM_DESKTOP(CARDINAL) = 0
_NET_WM_ICON(CARDINAL) =        Icon (128 x 128):
        (not shown)

WM_STATE(WM_STATE):
                window state: Normal
                icon window: <field not available>
_NET_WM_STATE(ATOM) =
XdndAware(ATOM) = BITMAP
WM_NAME(STRING) =
_NET_WM_NAME(UTF8_STRING) = "Yubico Authenticator"
_MOTIF_WM_HINTS(_MOTIF_WM_HINTS) = 0x3, 0x3e, 0x7e, 0x0, 0x0
_NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_NORMAL
_XEMBED_INFO(_XEMBED_INFO) = 0x0, 0x1
WM_CLIENT_LEADER(WINDOW): window id # 0x2800012
WM_HINTS(WM_HINTS):
                Client accepts input or input focus: True
                window id # of group leader: 0x2800012
WM_CLIENT_MACHINE(STRING) = "jannix"
_NET_WM_PID(CARDINAL) = 1146335
_NET_WM_SYNC_REQUEST_COUNTER(CARDINAL) = 41943057
WM_CLASS(STRING) = "yubioath-desktop", "Yubico Authenticator"
WM_PROTOCOLS(ATOM): protocols  WM_DELETE_WINDOW, WM_TAKE_FOCUS, _NET_WM_PING, _NET_WM_SYNC_REQUEST
WM_NORMAL_HINTS(WM_SIZE_HINTS):
                user specified location: 3893, 604
                user specified size: 427 by 657
                program specified minimum size: 270 by 381
                window gravity: Static
  ```
  
</details>

<details>
  <summary>Example with a window that is has spawn_floating configured</summary>

![floating-saves-position](https://user-images.githubusercontent.com/14895212/180790471-aa838c81-2b7f-469f-aa6d-eb3d34cc1ba9.gif)

</details>

The position will be remembered even after a leftwm reload, and this works similarly for dialogs like the auto type for keepassxc.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

I don't think the wiki has to be updated for this.

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
