### PR TITLE
Add .xinitrc instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,22 @@ Make sure this is at the end of your .xinitrc file:
 exec dbus-launch leftwm
 ```
 
+Note: If you are running Arch and use `exec dbus-launch leftwm` some services like gnome-keyring won't work.
+
+### Arch Linux
+As per [the Arch docs](https://wiki.archlinux.org/title/Xinit#xinitrc), copy the default xinitrc into your home directory:
+
+```bash
+cp /etc/X11/xinit/xinitrc ~/.xinitrc
+```
+
+Then edit the ~/.xinitrc file and make sure this at the end of your .xinitrc file:
+
+```bash
+# .xinitrc
+exec leftwm
+```
+
 # Theming
 
 If you want to see more than a black screen when you login, select a theme:


### PR DESCRIPTION
# Description

Adds instructions for starting leftwm with .xinitrc on Arch. On Arch installs the `exec dbus-launch leftwm` command causes some services such as gnome-keyring to not work.

Fixes #705 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:

README.md

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
