### PR TITLE
Add github action to notify discord about Q&A

### DIFF
--- a/.github/workflows/discussions-qa.yml
+++ b/.github/workflows/discussions-qa.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Discord notification
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_QA_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: |
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Discord notification
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_QA_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: |

--- a/.github/workflows/discussions-qa.yml
+++ b/.github/workflows/discussions-qa.yml
@@ -1,0 +1,38 @@
+name: discussion-questions
+on:
+  discussion:
+    types: [created, answered]
+jobs:
+  new_question:
+    if: github.event.action == 'created' && github.event.discussion.category.is_answerable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: |
+            :thinking: *{{ EVENT_PAYLOAD.discussion.user.login }} asked a question*
+
+            **{{ EVENT_PAYLOAD.discussion.title }}**
+            {{ EVENT_PAYLOAD.discussion.body }}
+
+            {{ EVENT_PAYLOAD.discussion.html_url }}
+
+  question_answered:
+    if: github.event.action == 'answered'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: |
+            :tada: *{{ EVENT_PAYLOAD.answer.user.login }} answered a question*
+
+            **Q**: {{ EVENT_PAYLOAD.discussion.title }}
+            **A**: *{{ EVENT_PAYLOAD.answer.body }}*
+
+            {{ EVENT_PAYLOAD.answer.html_url }}


### PR DESCRIPTION
Adding a Github Action to automatically notify our Discord `#support` channel about new questions in the Github discussions tab. I'm proposing this addition as part of [my comment](https://discord.com/channels/889371782388256818/889374673593331712/1006664686516830331) on Discord.

> I was thinking whether we should "move" the support channel towards the Github Discussions Q&A?
Just because of 1. Question discoverability (via search engines etc) and 2. because the same questions pop up from time to time.
We could still leave the channel open and create a Github Workflow to post here when a new Q&A pops up. And maybe leave it as is for more chat-like back and forth when going into detail on something.

To merge this, the `DISCORD_WEBHOOK` secret must be configured on the repository. I have only the triage permission on the leftwm repo, so maybe one of you guys (@VuiMuich, @AethanFoot) can add it?

I've already created a webhook on our Discord server, you just need to copy the URL.
In Discord go to `Server Settings` > `Integrations` > `Webhooks` > `Github Discussions` > `Copy Webhook URL`.

Btw. we could also do something similar to notify `#polling` about polls in the discussions tab :)

---

*There is one thing I am not sure about; the webhook might fail if a question/answer has more than 2000 characters, because I think that's the maximum for Discord messages. I'm not sure about that though, but we can either ignore that and potentially "lose" some notifications, or we can somehow truncate the text. Not sure how best to do this with the Github Action Expressions though...*

