### PR TITLE
Add missing match arm for external ReturnToLastTag command

### DIFF
--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -122,6 +122,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFloating" => Ok(Command::ToggleFloating),
         // Workspace/Tag
         "GoToTag" => build_go_to_tag(rest),
+        "ReturnToLastTag" => Ok(Command::ReturnToLastTag),
         "SendWorkspaceToTag" => build_send_workspace_to_tag(rest),
         "SwapScreens" => Ok(Command::SwapScreens),
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),


### PR DESCRIPTION
# Description

In leftwm-core/src/utils/command_pipe.rs there was a missing match arm for ReturnToLastTag, preventing this command to work externally.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
