### PR TITLE
Add missing entry in leftwm-command command list for ReturnToLastTag

### DIFF
--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -76,6 +76,7 @@ async fn main() -> Result<()> {
         NextLayout
         PreviousLayout
         RotateTag
+        ReturnToLastTag
         CloseWindow
 
         Commands with arguments:


### PR DESCRIPTION
# Description

Adding missing entry in leftwm-command command list for ReturnToLastTag

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
