### PR TITLE
fix `dock` windows not recieving `click` after some window was `fullscreen`

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -147,8 +147,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             // Reorder windows.
             self.state.sort_windows();
 
-            // Update `dock` windows once, so the can recieve mouse click events again
-            // this is necessary since we exclude them from the general update loop above
+            // Update `dock` windows once, so they can recieve mouse click events again.
+            // This is necessary, since we exclude them from the general update loop above.
             if let Some(windows) = self
                 .state
                 .windows

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -146,6 +146,15 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         if fullscreen_changed {
             // Reorder windows.
             self.state.sort_windows();
+
+            if let Some(windows) = self
+                .state
+                .windows
+                .iter()
+                .find(|w| w.r#type == WindowType::Dock)
+            {
+                self.display_server.update_windows(vec![windows]);
+            }
         }
         if strut_changed {
             self.state.update_static();

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -147,6 +147,8 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             // Reorder windows.
             self.state.sort_windows();
 
+            // Update `dock` windows once, so the can recieve mouse click events again
+            // this is necessary since we exclude them from the general update loop above
             if let Some(windows) = self
                 .state
                 .windows


### PR DESCRIPTION
# Description

When some window was `fullscreen` and exits to `normal` mode windows of type `dock` don't recieve clicks anymore (tested with `eww` and `stalonetray`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

not applicable

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
