### PR TITLE
Ignorting .toggletasks.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ result
 .envrc
 
 sweep.timestamp
+
+.toggletasks.json


### PR DESCRIPTION
# Description

This PR is only relevant for (neo-)vim users who use the
[`toggletasks.nvim`](https://github.com/jedrzejboczar/toggletasks.nvim) plugin
since it needs a json file where they can write their execution tasks. This
should be probably ignored for the most users, at least that's what I think.
It *could* be probably useful for other neovim users as well though.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Not needed

# Checklist:

- [X] Ran `make test-full` locally with no errors or warnings reported
- [X] Manual page has been updated accordingly
- [X] Wiki pages have been updated accordingly (to perform **after** merge)
