### PR TITLE
bump MSRV to 1.57.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: 1.56.1
+          toolchain: 1.57.0
           override: true
 
     - name: Run cargo check


### PR DESCRIPTION
# Description

Bump MSRV to 1.57.0 to suffice dependency needs for #821.
~~Our most consarvative target distro has been NetBSD and they use currently 1.62.1, yet I'd like to keep the bump as low as possible.~~

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
