### PR TITLE
fix building with no features

### DIFF
--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -14,10 +14,15 @@ fn main() {
         let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
         let _rt_guard = rt.enter();
 
+        #[cfg(feature = "lefthk")]
         let mut config = leftwm::load();
         // Clear the keybinds so leftwm is not storing them.
         // TODO: Make this more elegant.
-        config.keybind = vec![];
+        #[cfg(feature = "lefthk")]
+        config.clear_keybinds();
+
+        #[cfg(not(feature = "lefthk"))]
+        let config = leftwm::load();
 
         let manager = Manager::<leftwm::Config, XlibDisplayServer>::new(config);
         manager.register_child_hook();

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -42,7 +42,7 @@ const STATE_FILE: &str = "/tmp/leftwm.state";
 ///
 /// ```ron
 /// window_rules: [
-///     (window_class: "krita", spawn_on_tag: 3, spawn_floating: farse),
+///     (window_class: "krita", spawn_on_tag: 3, spawn_floating: false),
 /// ]
 /// ```
 ///

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -42,7 +42,7 @@ const STATE_FILE: &str = "/tmp/leftwm.state";
 ///
 /// ```ron
 /// window_rules: [
-///     (window_class: "krita", spawn_on_tag: 3, spawn_floating: farse),   
+///     (window_class: "krita", spawn_on_tag: 3, spawn_floating: farse),
 /// ]
 /// ```
 ///
@@ -551,6 +551,11 @@ impl leftwm_core::Config for Config {
 }
 
 impl Config {
+    #[cfg(feature = "lefthk")]
+    pub fn clear_keybinds(&mut self) {
+        self.keybind.clear();
+    }
+
     fn state_file(&self) -> &Path {
         self.state_path
             .as_deref()


### PR DESCRIPTION
When building without lefthk we would get an error as `config.keybind` does not exist. For some reason having a `cfg(feature...)` is not allowed above setting an attribute in this situation so I made a function.
