### PR TITLE
FIX: make leftwm-check -m migrate scratchpads correctly

### DIFF
--- a/leftwm-core/src/models/scratchpad.rs
+++ b/leftwm-core/src/models/scratchpad.rs
@@ -40,11 +40,18 @@ impl ScratchPad {
 /// Lisp/Scheme/...
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[serde(from = "String")]
+#[serde(into = "String")]
 pub struct ScratchPadName(String);
 
 impl From<String> for ScratchPadName {
     fn from(other: String) -> Self {
         Self(other)
+    }
+}
+
+impl From<ScratchPadName> for String {
+    fn from(other: ScratchPadName) -> Self {
+        other.0
     }
 }
 

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -93,31 +93,27 @@ async fn main() -> Result<()> {
 /// (inadequate permissions, disk full, etc.)
 /// If a path is specified and does not exist, returns `LeftError`.
 pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
-    let config_filename = match fspath {
-        Some(fspath) => {
-            println!("\x1b[1;35mNote: Using file {} \x1b[0m", fspath);
-            PathBuf::from(fspath)
-        }
-        None => {
-            let ron_file =
-                BaseDirectories::with_prefix("leftwm")?.place_config_file("config.ron")?;
-            let toml_file =
-                BaseDirectories::with_prefix("leftwm")?.place_config_file("config.toml")?;
-            if Path::new(&ron_file).exists() {
-                ron_file
-            } else if Path::new(&toml_file).exists() {
-                println!(
-                    "\x1b[1;93mWARN: TOML as config format is about to be deprecated.
+    let config_filename = if let Some(fspath) = fspath {
+        println!("\x1b[1;35mNote: Using file {} \x1b[0m", fspath);
+        PathBuf::from(fspath)
+    } else {
+        let ron_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.ron")?;
+        let toml_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.toml")?;
+        if Path::new(&ron_file).exists() {
+            ron_file
+        } else if Path::new(&toml_file).exists() {
+            println!(
+                "\x1b[1;93mWARN: TOML as config format is about to be deprecated.
       Please consider migrating to RON manually or by using `leftwm-check -m`.\x1b[0m"
-                );
-                toml_file
-            } else {
-                let config = Config::default();
-                write_to_file(&ron_file, &config)?;
-                return Ok(config);
-            }
+            );
+            toml_file
+        } else {
+            let config = Config::default();
+            write_to_file(&ron_file, &config)?;
+            return Ok(config);
         }
     };
+
     if verbose {
         dbg!(&config_filename);
     }

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -1,3 +1,5 @@
+use leftwm_core::models::{ScratchPad, Size};
+
 #[cfg(feature = "lefthk")]
 use super::{default_terminal, exit_strategy, BaseCommand, Keybind};
 use super::{Config, Default, FocusBehaviour, LayoutMode, ThemeSetting, LAYOUTS};
@@ -199,6 +201,15 @@ impl Default for Config {
             .map(|s| (*s).to_string())
             .collect();
 
+        let scratchpad = ScratchPad {
+            name: "Alacritty".into(),
+            value: "alacritty".to_string(),
+            x: Some(Size::Pixel(860)),
+            y: Some(Size::Pixel(390)),
+            height: Some(Size::Pixel(300)),
+            width: Some(Size::Pixel(200)),
+        };
+
         Self {
             workspaces: Some(vec![]),
             tags: Some(tags),
@@ -206,7 +217,7 @@ impl Default for Config {
             layout_mode: LayoutMode::Workspace,
             // TODO: add sane default for scratchpad config.
             // Currently default values are set in sane_dimension fn.
-            scratchpad: Some(vec![]),
+            scratchpad: Some(vec![scratchpad]),
             window_rules: Some(vec![]),
             disable_current_tag_swap: false,
             disable_tile_drag: false,

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -562,3 +562,23 @@ impl Config {
             .unwrap_or_else(|| Path::new(STATE_FILE))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_serializes_to_valid_ron_test() {
+        let config = Config::default();
+
+        // Check RON
+        let ron_pretty_conf = ron::ser::PrettyConfig::new()
+            .depth_limit(2)
+            .extensions(ron::extensions::Extensions::IMPLICIT_SOME);
+        let ron = ron::ser::to_string_pretty(&config, ron_pretty_conf);
+        assert!(ron.is_ok(), "Could not serialize default config");
+
+        let ron_config = ron::from_str::<'_, Config>(ron.unwrap().as_str());
+        assert!(ron_config.is_ok(), "Could not deserialize default config");
+    }
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

The newtype `ScratchPadName` did not define a way to convert to `String` (only from `String` to `ScratchPadName`). This gave the problem that the migration of `TOML` to `RON` introduced extra `(` and `)` around the scratchpad name and thus generating a bad config.

This PR also adds a test which tests that the (de)serialization can go in 2 ways. To make the test initially fail, a default scratchpad config was added to the `Default` impl of `Config`. The parameters were taken from the LeftWM wiki.

Fixes #860

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
