### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,8 @@ simple black screen on login.  For a more customized look, install a theme.
 2. Build leftwm
 
    ```bash
-   # Without systemd logging
+   # With systemd logging (view with 'journalctl -f -t leftwm-worker')
    cargo build --release
- 
-   # OR with systemd logging (view with 'journalctl -f -t leftwm-worker')
-   cargo build --release --features=journald
    ```
 
 3. And press the following keybind to reload leftwm


### PR DESCRIPTION
# Description

Clarification on the use of systemd logging as the default for cargo builds under `Rebuilding the development installation`.
