### PR TITLE
Fix new windows always getting stacked topmost

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -50,6 +50,9 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             self.state.actions.push_back(act);
         }
 
+        // Tell the WM to reevaluate the stacking order, so the new window is put in the correct layer
+        self.state.sort_windows();
+
         if (self.state.focus_manager.focus_new_windows || is_first) && on_same_tag {
             self.state.focus_window(&window.handle);
         }


### PR DESCRIPTION
# Description

In #863 this line was refactore out, as it seemed to have no purpose.
Turns out it actually had:
It makes sure the new window is put in the correct stacking layer.

Without this line it can happen, that new windows overlap floating windows like `rofi` or some `scratchpad` window, which should not happen.

This PR updates the comment line, hopefully provideng better information, what this line is here for.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
