### PR TITLE
Add link to `leftfwm.desktop` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ sudo xbps-install -S leftwm
 cargo install leftwm
 ```
 
-If you install LeftWM with crates.io, you will need to link to the xsession desktop file if you want
+If you install LeftWM with crates.io, you will need to link to the [xsession desktop file](https://github.com/leftwm/leftwm/blob/758bbf837a8556cdc7e09ff2d394f528e7657333/leftwm.desktop) if you want
 to be able to login to LeftWM from a display manager (GDM, SSDM, LightDM, etc.):
 
 ```sh


### PR DESCRIPTION
as pointed out by @NicTanghe it was not clear where to get the desktop file from, when installing from crates.io directly. Should be clearer now.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
