### PR TITLE
feat: Add a `spawn_as_type` to the `window_rules` configuration

### DIFF
--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use leftwm_core::{
     config::{InsertBehavior, ScratchPad, Workspace},
     layouts::{Layout, LAYOUTS},
-    models::{FocusBehaviour, Gutter, LayoutMode, Margins, Size, Window},
+    models::{FocusBehaviour, Gutter, LayoutMode, Margins, Size, Window, WindowType},
     state::State,
     DisplayServer, Manager,
 };
@@ -64,6 +64,8 @@ pub struct WindowHook {
     pub window_title: Option<String>,
     pub spawn_on_tag: Option<usize>,
     pub spawn_floating: Option<bool>,
+    /// Handle the window as if it was of this `_NET_WM_WINDOW_TYPE`
+    pub spawn_as_type: Option<WindowType>,
 }
 
 impl WindowHook {
@@ -93,6 +95,9 @@ impl WindowHook {
         }
         if let Some(should_float) = self.spawn_floating {
             window.set_floating(should_float);
+        }
+        if let Some(w_type) = self.spawn_as_type.clone() {
+            window.r#type = w_type;
         }
     }
 }
@@ -536,13 +541,14 @@ impl leftwm_core::Config for Config {
             if let Some((hook, _)) = best_match {
                 hook.apply(window);
                 tracing::debug!(
-                    "Window [[ TITLE={:?}, {:?}; WM_CLASS={:?}, {:?} ]] spawned in tag={:?} with floating={:?}",
+                    "Window [[ TITLE={:?}, {:?}; WM_CLASS={:?}, {:?} ]] spawned in tag={:?} with floating={:?} as type={:?}",
                     window.name,
                     window.legacy_name,
                     window.res_name,
                     window.res_class,
                     hook.spawn_on_tag,
                     hook.spawn_floating,
+                    hook.spawn_as_type,
                 );
                 return true;
             }


### PR DESCRIPTION
# Description

This PR adds a field to the window configuration in `window_rules`.
This field is called `spawn_as_type` and is a way for the user to set the [window type](https://specifications.freedesktop.org/wm-spec/latest/ar01s05.html#idm45374033166992) of a specific window with the usual rules via a config change.

Fixes #766 
Follow up to #879
Other references #631 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:

### Firefox Picture-in-Picture weird behavior fix:
Add this to your `config.ron` file in the `window_rules` section:
```ron
#![enable(implicit_some)]
(
    ...
    window_rules: [
        ...
        ( window_title: "Picture-in-Picture", spawn_as_type: Normal ),
        ...
    ]
    ...
)
```

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
