### PR TITLE
No single border

### DIFF
--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -27,7 +27,7 @@ pub trait Config {
 
     fn insert_behavior(&self) -> InsertBehavior;
 
-    fn no_single_border(&self) -> bool;
+    fn single_window_border(&self) -> bool;
 
     fn focus_new_windows(&self) -> bool;
 
@@ -93,7 +93,7 @@ pub(crate) mod tests {
         pub workspaces: Option<Vec<Workspace>>,
         pub insert_behavior: InsertBehavior,
         pub border_width: i32,
-        pub no_single_border: bool,
+        pub single_window_border: bool,
     }
 
     impl Config for TestConfig {
@@ -123,8 +123,8 @@ pub(crate) mod tests {
             self.insert_behavior
         }
 
-        fn no_single_border(&self) -> bool {
-            self.no_single_border
+        fn single_window_border(&self) -> bool {
+            self.single_window_border
         }
 
         fn focus_new_windows(&self) -> bool {

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -27,6 +27,8 @@ pub trait Config {
 
     fn insert_behavior(&self) -> InsertBehavior;
 
+    fn no_single_border(&self) -> bool;
+
     fn focus_new_windows(&self) -> bool;
 
     fn command_handler<SERVER>(command: &str, manager: &mut Manager<Self, SERVER>) -> bool
@@ -91,6 +93,7 @@ pub(crate) mod tests {
         pub workspaces: Option<Vec<Workspace>>,
         pub insert_behavior: InsertBehavior,
         pub border_width: i32,
+        pub no_single_border: bool,
     }
 
     impl Config for TestConfig {
@@ -118,6 +121,10 @@ pub(crate) mod tests {
 
         fn insert_behavior(&self) -> InsertBehavior {
             self.insert_behavior
+        }
+
+        fn no_single_border(&self) -> bool {
+            self.no_single_border
         }
 
         fn focus_new_windows(&self) -> bool {

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -90,6 +90,7 @@ pub(crate) mod tests {
         pub layouts: Vec<Layout>,
         pub workspaces: Option<Vec<Workspace>>,
         pub insert_behavior: InsertBehavior,
+        pub border_width: i32,
     }
 
     impl Config for TestConfig {
@@ -144,7 +145,7 @@ pub(crate) mod tests {
             800
         }
         fn border_width(&self) -> i32 {
-            0
+            self.border_width
         }
         fn margin(&self) -> Margins {
             Margins::new(0)

--- a/leftwm-core/src/handlers/command_handler/mod.rs
+++ b/leftwm-core/src/handlers/command_handler/mod.rs
@@ -1092,4 +1092,27 @@ mod tests {
 
         assert_eq!(manager.state.windows[0].border(), 0);
     }
+
+    #[test]
+    fn after_moving_single_window_to_another_single_window_both_have_borders() {
+        let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
+        manager.screen_create_handler(Screen::default());
+
+        let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
+        first_window.tag(&1);
+        manager.window_created_handler(first_window, -1, -1);
+
+        let mut second_window = Window::new(WindowHandle::MockHandle(2), None, None);
+        second_window.tag(&2);
+        manager.window_created_handler(second_window, -1, -1);
+
+        let second_tag = manager.state.tags.get(2).unwrap().id;
+        assert!(manager.command_handler(&Command::SendWindowToTag {
+            window: Some(manager.state.windows[0].handle),
+            tag: second_tag,
+        }));
+
+        assert_eq!(manager.state.windows[0].border(), 1);
+        assert_eq!(manager.state.windows[1].border(), 1);
+    }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -571,11 +571,7 @@ mod tests {
         manager.screen_create_handler(Screen::default());
 
         let window = Window::new(WindowHandle::MockHandle(1), None, None);
-        manager.window_created_handler(
-            window,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window, -1, -1);
 
         let actual = (&manager.state.windows[0]).border();
 
@@ -589,18 +585,10 @@ mod tests {
         manager.screen_create_handler(Screen::default());
 
         let window1 = Window::new(WindowHandle::MockHandle(1), None, None);
-        manager.window_created_handler(
-            window1,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window1, -1, -1);
 
         let window2 = Window::new(WindowHandle::MockHandle(2), None, None);
-        manager.window_created_handler(
-            window2,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window2, -1, -1);
 
         let actual_window1 = (&manager.state.windows[0]).border();
         let actual_window2 = (&manager.state.windows[1]).border();
@@ -616,19 +604,11 @@ mod tests {
         manager.screen_create_handler(Screen::default());
 
         let window1 = Window::new(WindowHandle::MockHandle(1), None, None);
-        manager.window_created_handler(
-            window1,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window1, -1, -1);
 
         let window_handle2 = WindowHandle::MockHandle(2);
         let window2 = Window::new(window_handle2, None, None);
-        manager.window_created_handler(
-            window2,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window2, -1, -1);
 
         manager.window_destroyed_handler(&window_handle2);
 
@@ -645,19 +625,11 @@ mod tests {
 
         let mut window1 = Window::new(WindowHandle::MockHandle(1), None, None);
         window1.tag(&1);
-        manager.window_created_handler(
-            window1,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window1, -1, -1);
 
         let mut window2 = Window::new(WindowHandle::MockHandle(2), None, None);
         window2.tag(&2);
-        manager.window_created_handler(
-            window2,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window2, -1, -1);
 
         let actual_window1 = (&manager.state.windows[0]).border();
         let actual_window2 = (&manager.state.windows[1]).border();
@@ -674,27 +646,15 @@ mod tests {
 
         let mut window1 = Window::new(WindowHandle::MockHandle(1), None, None);
         window1.tag(&1);
-        manager.window_created_handler(
-            window1,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window1, -1, -1);
 
         let mut window2 = Window::new(WindowHandle::MockHandle(2), None, None);
         window2.tag(&2);
-        manager.window_created_handler(
-            window2,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window2, -1, -1);
 
         let mut window3 = Window::new(WindowHandle::MockHandle(3), None, None);
         window3.tag(&2);
-        manager.window_created_handler(
-            window3,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window3, -1, -1);
 
         let actual_window1 = (&manager.state.windows[0]).border();
         let actual_window2 = (&manager.state.windows[1]).border();
@@ -713,28 +673,16 @@ mod tests {
 
         let mut window1 = Window::new(WindowHandle::MockHandle(1), None, None);
         window1.tag(&1);
-        manager.window_created_handler(
-            window1,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window1, -1, -1);
 
         let mut window2 = Window::new(WindowHandle::MockHandle(2), None, None);
         window2.tag(&2);
-        manager.window_created_handler(
-            window2,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window2, -1, -1);
 
         let window_handle3 = WindowHandle::MockHandle(3);
         let mut window3 = Window::new(window_handle3, None, None);
         window3.tag(&2);
-        manager.window_created_handler(
-            window3,
-            -1,
-            -1,
-        );
+        manager.window_created_handler(window3, -1, -1);
 
         manager.window_destroyed_handler(&window_handle3);
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -680,4 +680,31 @@ mod tests {
         assert_eq!((manager.state.windows[0]).border(), 0);
         assert_eq!((manager.state.windows[1]).border(), 0);
     }
+
+    #[test]
+    fn monocle_layout_only_has_single_windows() {
+        let mut manager = Manager::new_test_with_border(vec!["1".to_string()], 1);
+        manager.screen_create_handler(Screen::default());
+
+        manager
+            .state
+            .tags
+            .get_mut(1)
+            .unwrap()
+            .set_layout(Layout::Monocle, 0);
+
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(1), None, None),
+            -1,
+            -1,
+        );
+        manager.window_created_handler(
+            Window::new(WindowHandle::MockHandle(2), None, None),
+            -1,
+            -1,
+        );
+
+        assert_eq!((manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[1]).border(), 0);
+    }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -575,7 +575,7 @@ mod tests {
             -1,
         );
 
-        assert_eq!((&manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[0]).border(), 0);
     }
 
     #[test]
@@ -594,8 +594,8 @@ mod tests {
             -1,
         );
 
-        assert_eq!((&manager.state.windows[0]).border(), 1);
-        assert_eq!((&manager.state.windows[1]).border(), 1);
+        assert_eq!((manager.state.windows[0]).border(), 1);
+        assert_eq!((manager.state.windows[1]).border(), 1);
     }
 
     #[test]
@@ -616,7 +616,7 @@ mod tests {
 
         manager.window_destroyed_handler(&manager.state.windows[1].handle.clone());
 
-        assert_eq!((&manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[0]).border(), 0);
     }
 
     #[test]
@@ -632,8 +632,8 @@ mod tests {
         second_window.tag(&2);
         manager.window_created_handler(second_window, -1, -1);
 
-        assert_eq!((&manager.state.windows[0]).border(), 0);
-        assert_eq!((&manager.state.windows[1]).border(), 0);
+        assert_eq!((manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[1]).border(), 0);
     }
 
     #[test]
@@ -653,9 +653,9 @@ mod tests {
         third_window.tag(&2);
         manager.window_created_handler(third_window, -1, -1);
 
-        assert_eq!((&manager.state.windows[0]).border(), 0);
-        assert_eq!((&manager.state.windows[1]).border(), 1);
-        assert_eq!((&manager.state.windows[2]).border(), 1);
+        assert_eq!((manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[1]).border(), 1);
+        assert_eq!((manager.state.windows[2]).border(), 1);
     }
 
     #[test]
@@ -677,7 +677,7 @@ mod tests {
 
         manager.window_destroyed_handler(&manager.state.windows[2].handle.clone());
 
-        assert_eq!((&manager.state.windows[0]).border(), 0);
-        assert_eq!((&manager.state.windows[1]).border(), 0);
+        assert_eq!((manager.state.windows[0]).border(), 0);
+        assert_eq!((manager.state.windows[1]).border(), 0);
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -34,10 +34,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             &mut on_same_tag,
         );
         self.config.load_window(&mut window);
-
         insert_window(&mut self.state, &mut window, layout);
-
-        self.single_border_handler(&window);
 
         let follow_mouse = self.state.focus_manager.focus_new_windows
             && self.state.focus_manager.behaviour.is_sloppy()
@@ -55,6 +52,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
 
         // Tell the WM to reevaluate the stacking order, so the new window is put in the correct layer
         self.state.sort_windows();
+        self.state.handle_single_border(self.config.border_width());
 
         if (self.state.focus_manager.focus_new_windows || is_first) && on_same_tag {
             self.state.focus_window(&window.handle);
@@ -84,7 +82,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             .retain(|_, h| h != handle);
         self.state.windows.retain(|w| &w.handle != handle);
 
-        self.single_border_handler(&window);
+        self.state.handle_single_border(self.config.border_width());
 
         // Make sure the workspaces do not draw on the docks.
         update_workspace_avoid_list(&mut self.state);
@@ -181,25 +179,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             .map(|w| w.handle);
         self.state.windows.append(&mut windows_on_workspace);
         new_handle
-    }
-
-    fn single_border_handler(&mut self, window: &Window) {
-        let mut windows_on_tag: Vec<&mut Window> = self.state.windows
-            .iter_mut()
-            .filter(|w| w.tag == window.tag)
-            .collect();
-        if windows_on_tag.len() == 1 {
-            match windows_on_tag.first_mut() {
-                Some(w) => w.border = 0,
-                None => (),
-            };
-        }
-        if windows_on_tag.len() == 2 {
-            match windows_on_tag.first_mut() {
-                Some(w) => w.border = self.config.border_width(),
-                None => (),
-            };
-        }
     }
 }
 

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -70,6 +70,7 @@ impl Manager<crate::config::tests::TestConfig, crate::display_servers::MockDispl
         Self::new(TestConfig {
             tags,
             border_width,
+            no_single_border: true,
             ..TestConfig::default()
         })
     }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -70,7 +70,7 @@ impl Manager<crate::config::tests::TestConfig, crate::display_servers::MockDispl
         Self::new(TestConfig {
             tags,
             border_width,
-            no_single_border: true,
+            single_window_border: false,
             ..TestConfig::default()
         })
     }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -64,4 +64,13 @@ impl Manager<crate::config::tests::TestConfig, crate::display_servers::MockDispl
             ..TestConfig::default()
         })
     }
+
+    pub fn new_test_with_border(tags: Vec<String>, border_width: i32) -> Self {
+        use crate::config::tests::TestConfig;
+        Self::new(TestConfig {
+            tags,
+            border_width,
+            ..TestConfig::default()
+        })
+    }
 }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -3,13 +3,10 @@
 use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::Layout;
-use crate::models::Tags;
-use crate::models::Window;
-use crate::models::Workspace;
-use crate::models::{FocusManager, LayoutManager};
-use crate::models::{Mode, WindowHandle};
-use crate::models::{ScratchPadName, Screen};
-use crate::models::{Size, WindowType};
+use crate::models::{
+    FocusManager, LayoutManager, Mode, ScratchPadName, Screen, Size, Tags, Window, WindowHandle,
+    WindowType, Workspace,
+};
 use crate::DisplayAction;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -135,9 +135,9 @@ impl State {
                 }
             }
             if windows_on_tag.len() > 1 {
-                if let Some(w) = windows_on_tag.first_mut() {
-                    w.border = border_width;
-                }
+                windows_on_tag
+                    .iter_mut()
+                    .for_each(|w| w.border = border_width);
             }
         }
     }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -130,16 +130,14 @@ impl State {
                 .collect();
 
             if windows_on_tag.len() == 1 {
-                match windows_on_tag.first_mut() {
-                    Some(w) => w.border = 0,
-                    None => (),
-                };
+                if let Some(w) = windows_on_tag.first_mut() {
+                    w.border = 0;
+                }
             }
             if windows_on_tag.len() > 1 {
-                match windows_on_tag.first_mut() {
-                    Some(w) => w.border = border_width,
-                    None => (),
-                };
+                if let Some(w) = windows_on_tag.first_mut() {
+                    w.border = border_width;
+                }
             }
         }
     }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -3,13 +3,13 @@
 use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::Layout;
-use crate::models::{Size, WindowType};
 use crate::models::Tags;
 use crate::models::Window;
 use crate::models::Workspace;
 use crate::models::{FocusManager, LayoutManager};
 use crate::models::{Mode, WindowHandle};
 use crate::models::{ScratchPadName, Screen};
+use crate::models::{Size, WindowType};
 use crate::DisplayAction;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -129,16 +129,21 @@ impl State {
                 .filter(|w| w.tag.unwrap_or(0) == tag.id && w.r#type == WindowType::Normal)
                 .collect();
 
+            if tag.layout == Layout::Monocle {
+                windows_on_tag.iter_mut().for_each(|w| w.border = 0);
+                continue;
+            }
+
             if windows_on_tag.len() == 1 {
                 if let Some(w) = windows_on_tag.first_mut() {
                     w.border = 0;
                 }
+                continue;
             }
-            if windows_on_tag.len() > 1 {
-                windows_on_tag
-                    .iter_mut()
-                    .for_each(|w| w.border = border_width);
-            }
+
+            windows_on_tag
+                .iter_mut()
+                .for_each(|w| w.border = border_width);
         }
     }
 

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -30,7 +30,7 @@ pub struct State {
     pub default_height: i32,
     pub disable_tile_drag: bool,
     pub insert_behavior: InsertBehavior,
-    pub no_single_border: bool,
+    pub single_window_border: bool,
 }
 
 impl State {
@@ -60,7 +60,7 @@ impl State {
             default_height: config.default_height(),
             disable_tile_drag: config.disable_tile_drag(),
             insert_behavior: config.insert_behavior(),
-            no_single_border: config.no_single_border(),
+            single_window_border: config.single_window_border(),
         }
     }
 
@@ -118,7 +118,7 @@ impl State {
     }
 
     pub fn handle_single_border(&mut self, border_width: i32) {
-        if !self.no_single_border {
+        if self.single_window_border {
             return;
         }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -224,7 +224,7 @@ impl Default for Config {
             disable_window_snap: true,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
             focus_new_windows: true, // default behaviour: focuses windows on creation
-            no_single_border: false,
+            single_window_border: true,
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,
             modkey: "Mod4".to_owned(),     //win key
             mousekey: Some("Mod4".into()), //win key

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -224,6 +224,7 @@ impl Default for Config {
             disable_window_snap: true,
             focus_behaviour: FocusBehaviour::Sloppy, // default behaviour: mouse move auto-focuses window
             focus_new_windows: true, // default behaviour: focuses windows on creation
+            no_single_border: false,
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,
             modkey: "Mod4".to_owned(),     //win key
             mousekey: Some("Mod4".into()), //win key

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -118,7 +118,7 @@ pub struct Config {
     pub disable_window_snap: bool,
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
-    pub no_single_border: bool,
+    pub single_window_border: bool,
     pub sloppy_mouse_follows_focus: bool,
     #[cfg(feature = "lefthk")]
     pub keybind: Vec<Keybind>,
@@ -387,8 +387,8 @@ impl leftwm_core::Config for Config {
         self.insert_behavior
     }
 
-    fn no_single_border(&self) -> bool {
-        self.no_single_border
+    fn single_window_border(&self) -> bool {
+        self.single_window_border
     }
 
     fn focus_new_windows(&self) -> bool {

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -118,6 +118,7 @@ pub struct Config {
     pub disable_window_snap: bool,
     pub focus_behaviour: FocusBehaviour,
     pub focus_new_windows: bool,
+    pub no_single_border: bool,
     pub sloppy_mouse_follows_focus: bool,
     #[cfg(feature = "lefthk")]
     pub keybind: Vec<Keybind>,
@@ -384,6 +385,10 @@ impl leftwm_core::Config for Config {
 
     fn insert_behavior(&self) -> InsertBehavior {
         self.insert_behavior
+    }
+
+    fn no_single_border(&self) -> bool {
+        self.no_single_border
     }
 
     fn focus_new_windows(&self) -> bool {


### PR DESCRIPTION
# Description

This PR adds a configuration option `single_window_border`.
Its default is `true` but if set to `false` it removes the border of a window if it is the only one on its tag.

Motivation: I mostly only have one window open on a given tag. A border there just uses unnecessary space because it's obvious where the window ends.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:

On https://github.com/leftwm/leftwm/wiki/Config:

**Single Window Border**

This shows a border on windows even if they are the only normal window on their tags.

Default: `single_window_border: true`

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
