### PR TITLE
update theme examples to ron

### DIFF
--- a/themes/basic_eww/theme.ron
+++ b/themes/basic_eww/theme.ron
@@ -1,0 +1,6 @@
+(border_width: 1,
+margin: 5,
+default_border_color: "#37474F",
+floating_border_color: "#225588",
+focused_border_color: "#885522",
+)

--- a/themes/basic_eww/theme.toml
+++ b/themes/basic_eww/theme.toml
@@ -1,5 +1,0 @@
-border_width = 1
-margin = 5
-default_border_color = "#37474F"
-floating_border_color = "#225588"
-focused_border_color = "#885522"

--- a/themes/basic_eww/up
+++ b/themes/basic_eww/up
@@ -24,8 +24,8 @@ elif [ -x "$(command -v compton)" ]; then
   compton &> /dev/null &
 fi
 
-# Set the theme.toml config
-leftwm-command "LoadTheme $SCRIPTPATH/theme.toml"
+# Set the theme.ron config
+leftwm-command "LoadTheme $SCRIPTPATH/theme.ron"
 
 # Set background
 if [ -x "$(command -v feh)" ]; then

--- a/themes/basic_lemonbar/theme.ron
+++ b/themes/basic_lemonbar/theme.ron
@@ -1,0 +1,6 @@
+(border_width: 1,
+margin: 10,
+default_border_color: "#222222",
+floating_border_color: "#555555",
+focused_border_color: "#AAAAAA",
+)

--- a/themes/basic_lemonbar/theme.toml
+++ b/themes/basic_lemonbar/theme.toml
@@ -1,5 +1,0 @@
-border_width = 1
-margin = 10 
-default_border_color = "#222222"
-floating_border_color = "#555555"
-focused_border_color = "#AAAAAA"

--- a/themes/basic_lemonbar/up
+++ b/themes/basic_lemonbar/up
@@ -17,8 +17,8 @@ elif [ -x "$(command -v picom)" ]; then
   picom &> /dev/null &
 fi
 
-#set the theme.toml config
-leftwm-command "LoadTheme $SCRIPTPATH/theme.toml"
+#set the theme.ron config
+leftwm-command "LoadTheme $SCRIPTPATH/theme.ron"
 
 
 #set background

--- a/themes/basic_polybar/theme.ron
+++ b/themes/basic_polybar/theme.ron
@@ -1,0 +1,6 @@
+(border_width: 1,
+margin: 20,
+default_border_color: "#222222",
+floating_border_color: "#005500",
+focused_border_color: "#FFB53A",
+)

--- a/themes/basic_polybar/theme.toml
+++ b/themes/basic_polybar/theme.toml
@@ -1,5 +1,0 @@
-border_width = 1
-margin = 20 
-default_border_color = "#222222"
-floating_border_color = "#005500"
-focused_border_color = "#FFB53A"

--- a/themes/basic_polybar/up
+++ b/themes/basic_polybar/up
@@ -17,8 +17,8 @@ elif [ -x "$(command -v compton)" ]; then
   compton &> /dev/null &
 fi
 
-#set the theme.toml config
-leftwm-command "LoadTheme $SCRIPTPATH/theme.toml"
+#set the theme.ron config
+leftwm-command "LoadTheme $SCRIPTPATH/theme.ron"
 
 #set background
 if [ -x "$(command -v feh)" ]; then

--- a/themes/basic_xmobar/theme.ron
+++ b/themes/basic_xmobar/theme.ron
@@ -1,0 +1,6 @@
+(border_width: 2,
+margin: 12,
+default_border_color: "#222222",
+floating_border_color: "#555555",
+focused_border_color: "#FF3333",
+)

--- a/themes/basic_xmobar/theme.toml
+++ b/themes/basic_xmobar/theme.toml
@@ -1,5 +1,0 @@
-border_width = 2
-margin = 12 
-default_border_color = "#222222"
-floating_border_color = "#555555"
-focused_border_color = "#FF3333"

--- a/themes/basic_xmobar/up
+++ b/themes/basic_xmobar/up
@@ -17,8 +17,8 @@ elif [ -x "$(command -v picom)" ]; then
   picom &> /dev/null &
 fi
 
-#set the theme.toml config
-leftwm-command "LoadTheme $SCRIPTPATH/theme.toml"
+#set the theme.ron config
+leftwm-command "LoadTheme $SCRIPTPATH/theme.ron"
 
 
 #set background


### PR DESCRIPTION
# Description

Just realised we did not update the theme examples to ron.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] Tested by applying themes with `leftwm-theme apply` and verified `theme.ron` was loaded by border colors :smiley:
