### PR TITLE
No need to run clippy in release mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: build test
 test:
 	cd $(ROOT_DIR) && cargo test --all-targets --all-features
 	cd $(ROOT_DIR) && cargo fmt -- --check
-	cd $(ROOT_DIR) && cargo clippy --release
+	cd $(ROOT_DIR) && cargo clippy
 
 test-full:
 	make test


### PR DESCRIPTION
# Description

There is no need to run clippy in release mode. Clippy is only a linter and this just slows down make test as the previous compiles all compile in development mode (all code has to be compiled again just for clippy, can't use cache).

Also, there is no mention of the --release flag in the [clippy readme](https://github.com/rust-lang/rust-clippy#step-3-run-clippy).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Development change (no change visible for user)

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported