### PR TITLE
Added nix tests to Makefile.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,6 @@ See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documen
 # Checklist:
 
 - [ ] Ran `make test-full` locally with no errors or warnings reported
+  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
 - [ ] Manual page has been updated accordingly
 - [ ] Wiki pages have been updated accordingly (to perform **after** merge)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ test:
 	cd $(ROOT_DIR) && cargo fmt -- --check
 	cd $(ROOT_DIR) && cargo clippy
 
+test-nix:
+	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix flake check --extra-experimental-features "nix-command flakes"
+	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix build --extra-experimental-features "nix-command flakes"
+
 test-full:
 	make test
 	cargo clippy --\
@@ -28,6 +32,10 @@ test-full:
 		-A clippy::cast_possible_wrap\
 		-A clippy::cast_sign_loss\
 		-A clippy::mut_mut
+
+test-full-nix:
+	make test-full
+	make test-nix
 
 # builds the project
 build:


### PR DESCRIPTION
# Description

Added `test-nix` and `test-full-nix` to Makefile, plus a note in the pr template.
`make-test-nix` should now reproduce all CI checks.
You will of course have to install nix to run this.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
- [x] Ran `make test-full-nix` locally with no errors reported. `nix flake check` throws some deprecated warnings that are not my fault.