### PR TITLE
Fix `--no-default-features` build failing

### DIFF
--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -3,8 +3,14 @@ use lefthk_core::{config::Config, worker::Worker};
 #[cfg(feature = "lefthk")]
 use xdg::BaseDirectories;
 
-#[cfg(feature = "lefthk")]
 fn main() {
+    // we need this little shenanigan to allow actually building with `--no-default-features`
+    #[cfg(feature = "lefthk")]
+    lefthk_worker_main()
+}
+
+#[cfg(feature = "lefthk")]
+fn lefthk_worker_main() {
     leftwm::utils::log::setup_logging();
 
     tracing::info!("lefthk-worker booted!");

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -173,10 +173,10 @@ impl Modifier {
     }
 }
 
-fn is_valid_scratchpad_name(config: &Config, scratchpad_name: &str) -> bool {
-    config
-        .scratchpad
-        .as_ref()
-        .and_then(|scratchpads| scratchpads.iter().find(|s| s.name == scratchpad_name))
-        .is_some()
-}
+// fn is_valid_scratchpad_name(config: &Config, scratchpad_name: &str) -> bool {
+//     config
+//         .scratchpad
+//         .as_ref()
+//         .and_then(|scratchpads| scratchpads.iter().find(|s| s.name == scratchpad_name))
+//         .is_some()
+// }


### PR DESCRIPTION
# Description

As brought up be Adàhy on discord dm building with `cargo b --no-default-features` failed.
With this PR it is now possible to build actually without a hotkey daemon.
If somobody would have a suggestion for a nicer way to work around blocking the `main` function in `lefthk_worker.rs` this would be very welcome.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
