### PR TITLE
Add install-linked-dev to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ install: build
 	@echo "binaries, '.desktop' file and manual page have been installed"
 
 # build the project and links the binaries, will also install the .desktop file
-install-dev: build
+install-linked: build
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
 	sudo ln -sf $(ROOT_DIR)/target/release/leftwm $(TARGET_DIR)/leftwm
@@ -72,6 +72,19 @@ install-dev: build
 	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-check $(TARGET_DIR)/leftwm-check
 	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-command $(TARGET_DIR)/leftwm-command
 	@echo "binaries have been linked, manpage and '.desktop' file have been installed"
+
+install-linked-dev:
+	cd $(ROOT_DIR) && cargo build ${BUILDFLAGS}
+	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
+	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
+	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm $(TARGET_DIR)/leftwm
+	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-worker $(TARGET_DIR)/leftwm-worker
+	sudo ln -sf $(ROOT_DIR)/target/debug/lefthk-worker $(TARGET_DIR)/lefthk-worker
+	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-state $(TARGET_DIR)/leftwm-state
+	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-check $(TARGET_DIR)/leftwm-check
+	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-command $(TARGET_DIR)/leftwm-command
+	@echo "binaries have been linked, manpage and '.desktop' file have been linked."
+
 
 # uninstalls leftwm from the system, no matter if installed via 'install' or 'install-dev'
 uninstall:


### PR DESCRIPTION
# Description

The current `make install-dev` does not really describe what it does. It build leftwm in release mode and then links these files. I renamed it to `install-linked` and added `install-linked-dev` to build and link in development mode.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  This change is breaking, as some scripts may invoke `make install-dev`, but I consider this a minority and a simple fix.
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
