### PR TITLE
Add leftwm config subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,13 +367,22 @@ For more information about themes check out our [theme guide][theme-guide] or th
 
 # Configuring
 
-The settings file to change key bindings and the default mod key can be found at
+You can configure key bindings, default mod key and many other options:
+
+## With [LeftWM-Config](https://github.com/leftwm/leftwm-config)
+```bash
+leftwm-config -n # Generate new config
+leftwm-config    # Open configuration file in $EDITOR
+leftwm-config -t # Edit configuration via TUI (Beta)
+```
+
+## Without via editing the file
 
 ```bash
 ~/.config/leftwm/config.ron
 ```
-
-the file is automatically generated when leftwm or leftwm-check is run for the first time.
+---
+**Note:** The configuration file is automatically generated when leftwm or leftwm-check is run for the first time.
 
 ---
 **Note:** leftwm uses RON now as its default config language. Please consider migrating your toml configs.

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -31,6 +31,8 @@ For a list of available commands use the '-l, --list' flag.
 Prints the current state of leftwm (in JSON format). You can also use flags and liqud-like syntax for a more refined output of this command.
 .IP "theme"
 Manage leftwm themes (This is part of an external package found in: https://GitHub.com/leftwm/leftwm-theme).
+.IP "config"
+Manage leftwm configuration (This is part of an external package found in: https://GitHub.com/leftwm/leftwm-config).
 .SH CONFIGURING LEFTWM
 
 .B NOTE:

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -21,11 +21,12 @@ const SUBCOMMAND_PREFIX: &str = "leftwm-";
 
 const SUBCOMMAND_NAME_INDEX: usize = 0;
 const SUBCOMMAND_DESCRIPTION_INDEX: usize = 1;
-const AVAILABLE_SUBCOMMANDS: [[&str; 2]; 4] = [
+const AVAILABLE_SUBCOMMANDS: [[&str; 2]; 5] = [
     ["check", "Check syntax of the configuration file"],
     ["command", "Send external commands to LeftWM"],
     ["state", "Print the current state of LeftWM"],
     ["theme", "Manage LeftWM themes"],
+    ["config", "Manage LeftWM configuration file"],
 ];
 
 fn main() {


### PR DESCRIPTION
# Description

As of #747 the new utility [leftwm-config](https://github.com/leftwm/leftwm-config) was created. This PR creates a subcommand to this utility and updates documentation to contain info about it. 

Fixes #658 

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

In the README.md I've added info about leftwm-config to Configuration block. Also updated manpage file. 

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [X] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [X] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
