### PR TITLE
Add `background_color` to theme config

### DIFF
--- a/display-servers/xlib-display-server/src/xwrap/mod.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mod.rs
@@ -447,8 +447,8 @@ impl XWrap {
                     self.set_window_border_color(handle, color);
                 }
             }
-            self.set_background_color(self.colors.background);
         }
+        self.set_background_color(self.colors.background);
     }
 
     /// Sets the mode within our xwrapper.

--- a/display-servers/xlib-display-server/src/xwrap/mod.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mod.rs
@@ -89,6 +89,7 @@ pub struct Colors {
     normal: c_ulong,
     floating: c_ulong,
     active: c_ulong,
+    background: c_ulong,
 }
 
 #[derive(Debug, Clone)]
@@ -183,6 +184,7 @@ impl XWrap {
             normal: 0,
             floating: 0,
             active: 0,
+            background: 0,
         };
 
         let refresh_rate = match Xrandr::open() {
@@ -427,6 +429,7 @@ impl XWrap {
             normal: self.get_color(config.default_border_color()),
             floating: self.get_color(config.floating_border_color()),
             active: self.get_color(config.focused_border_color()),
+            background: self.get_color(config.background_color()),
         };
         // Update all the windows with the new colors.
         if let Some(windows) = windows {
@@ -444,6 +447,7 @@ impl XWrap {
                     self.set_window_border_color(handle, color);
                 }
             }
+            self.set_background_color(self.colors.background);
         }
     }
 

--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -156,6 +156,20 @@ impl XWrap {
         }
     }
 
+    pub fn set_background_color(&self, mut color: c_ulong) {
+        tracing::warn!("Color {} printed.", color);
+        unsafe {
+            // Force border opacity to 0xff.
+            let mut bytes = color.to_le_bytes();
+            bytes[3] = 0xff;
+            color = c_ulong::from_le_bytes(bytes);
+            (self.xlib.XSetWindowBackground)(self.display, self.root, color);
+            (self.xlib.XClearWindow)(self.display, self.root);
+            (self.xlib.XFlush)(self.display);
+            (self.xlib.XSync)(self.display, 0);
+        }
+    }
+
     /// Sets a windows configuration.
     pub fn set_window_config(
         &self,

--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -157,7 +157,6 @@ impl XWrap {
     }
 
     pub fn set_background_color(&self, mut color: c_ulong) {
-        tracing::warn!("Color {} printed.", color);
         unsafe {
             // Force border opacity to 0xff.
             let mut bytes = color.to_le_bytes();

--- a/leftwm-core/src/config/mod.rs
+++ b/leftwm-core/src/config/mod.rs
@@ -46,6 +46,7 @@ pub trait Config {
     fn default_border_color(&self) -> String;
     fn floating_border_color(&self) -> String;
     fn focused_border_color(&self) -> String;
+    fn background_color(&self) -> String;
     fn on_new_window_cmd(&self) -> Option<String>;
     fn get_list_of_gutters(&self) -> Vec<Gutter>;
     fn max_window_width(&self) -> Option<Size>;
@@ -170,6 +171,9 @@ pub(crate) mod tests {
             unimplemented!()
         }
         fn focused_border_color(&self) -> String {
+            unimplemented!()
+        }
+        fn background_color(&self) -> String {
             unimplemented!()
         }
         fn on_new_window_cmd(&self) -> Option<String> {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -166,15 +166,15 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     fn call_up_scripts(&mut self) {
         match Nanny::run_global_up_script() {
             Ok(child) => {
-                child.map(|child| self.children.insert(child));
+                self.children.insert(child);
             }
-            Err(err) => tracing::error!("Global up script faild: {}", err),
+            Err(err) => tracing::warn!("Global up script faild: {}", err),
         }
         match Nanny::boot_current_theme() {
             Ok(child) => {
-                child.map(|child| self.children.insert(child));
+                self.children.insert(child);
             }
-            Err(err) => tracing::error!("Theme loading failed: {}", err),
+            Err(err) => tracing::warn!("Theme loading failed: {}", err),
         }
     }
 }

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -66,17 +66,12 @@ impl Nanny {
     }
 
     /// Runs a script if it exits
-    fn run_script(path: &Path) -> Result<Option<Child>> {
-        if path.is_file() {
-            Command::new(&path)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .spawn()
-                .map(Some)
-                .map_err(Into::into)
-        } else {
-            Ok(None)
-        }
+    fn run_script(path: &Path) -> Result<Child> {
+        Command::new(&path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .spawn()
+            .map_err(Into::into)
     }
 
     /// Runs the 'up' script in the config directory, if there is one.
@@ -85,7 +80,7 @@ impl Nanny {
     ///
     /// Will error if unable to open current config directory.
     /// Could be caused by inadequate permissions.
-    pub fn run_global_up_script() -> Result<Option<Child>> {
+    pub fn run_global_up_script() -> Result<Child> {
         let mut path = Self::get_config_dir()?;
         path.push("up");
         Self::run_script(&path)
@@ -97,7 +92,7 @@ impl Nanny {
     ///
     /// Will error if unable to open current theme directory.
     /// Could be caused by inadequate permissions.
-    pub fn boot_current_theme() -> Result<Option<Child>> {
+    pub fn boot_current_theme() -> Result<Child> {
         let mut path = Self::get_config_dir()?;
         path.push("themes");
         path.push("current");

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -540,7 +540,7 @@ impl leftwm_core::Config for Config {
         self.theme_setting
             .focused_border_color
             .clone()
-            .unwrap_or_else(|| "#FFD625".to_string())
+            .unwrap_or_else(|| "#FF0000".to_string())
     }
 
     fn on_new_window_cmd(&self) -> Option<String> {

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -507,6 +507,10 @@ impl leftwm_core::Config for Config {
         self.theme_setting.floating_border_color.clone()
     }
 
+    fn background_color(&self) -> String {
+        self.theme_setting.background_color.clone()
+    }
+
     fn disable_window_snap(&self) -> bool {
         self.disable_window_snap
     }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -469,11 +469,17 @@ impl leftwm_core::Config for Config {
     }
 
     fn border_width(&self) -> i32 {
-        self.theme_setting.border_width
+        self.theme_setting.border_width.unwrap_or(1)
     }
 
     fn margin(&self) -> Margins {
-        match self.theme_setting.margin.clone().try_into() {
+        match self
+            .theme_setting
+            .margin
+            .clone()
+            .unwrap_or(crate::CustomMargins::Int(10))
+            .try_into()
+        {
             Ok(margins) => margins,
             Err(err) => {
                 tracing::warn!("Could not read margin: {}", err);

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -500,15 +500,15 @@ impl leftwm_core::Config for Config {
     }
 
     fn default_border_color(&self) -> String {
-        self.theme_setting.default_border_color.clone()
+        self.theme_setting.default_border_color.clone().unwrap_or(String::from("#000000"))
     }
 
     fn floating_border_color(&self) -> String {
-        self.theme_setting.floating_border_color.clone()
+        self.theme_setting.floating_border_color.clone().unwrap_or(String::from("#000000"))
     }
 
     fn background_color(&self) -> String {
-        self.theme_setting.background_color.clone()
+        self.theme_setting.background_color.clone().unwrap_or(String::from("#333333"))
     }
 
     fn disable_window_snap(&self) -> bool {
@@ -528,7 +528,7 @@ impl leftwm_core::Config for Config {
     }
 
     fn focused_border_color(&self) -> String {
-        self.theme_setting.focused_border_color.clone()
+        self.theme_setting.focused_border_color.clone().unwrap_or(String::from("#FFD625"))
     }
 
     fn on_new_window_cmd(&self) -> Option<String> {

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -500,15 +500,24 @@ impl leftwm_core::Config for Config {
     }
 
     fn default_border_color(&self) -> String {
-        self.theme_setting.default_border_color.clone().unwrap_or(String::from("#000000"))
+        self.theme_setting
+            .default_border_color
+            .clone()
+            .unwrap_or(String::from("#000000"))
     }
 
     fn floating_border_color(&self) -> String {
-        self.theme_setting.floating_border_color.clone().unwrap_or(String::from("#000000"))
+        self.theme_setting
+            .floating_border_color
+            .clone()
+            .unwrap_or(String::from("#000000"))
     }
 
     fn background_color(&self) -> String {
-        self.theme_setting.background_color.clone().unwrap_or(String::from("#333333"))
+        self.theme_setting
+            .background_color
+            .clone()
+            .unwrap_or(String::from("#333333"))
     }
 
     fn disable_window_snap(&self) -> bool {
@@ -528,7 +537,10 @@ impl leftwm_core::Config for Config {
     }
 
     fn focused_border_color(&self) -> String {
-        self.theme_setting.focused_border_color.clone().unwrap_or(String::from("#FFD625"))
+        self.theme_setting
+            .focused_border_color
+            .clone()
+            .unwrap_or(String::from("#FFD625"))
     }
 
     fn on_new_window_cmd(&self) -> Option<String> {

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -503,21 +503,21 @@ impl leftwm_core::Config for Config {
         self.theme_setting
             .default_border_color
             .clone()
-            .unwrap_or(String::from("#000000"))
+            .unwrap_or_else(|| "#000000".to_string())
     }
 
     fn floating_border_color(&self) -> String {
         self.theme_setting
             .floating_border_color
             .clone()
-            .unwrap_or(String::from("#000000"))
+            .unwrap_or_else(|| "#000000".to_string())
     }
 
     fn background_color(&self) -> String {
         self.theme_setting
             .background_color
             .clone()
-            .unwrap_or(String::from("#333333"))
+            .unwrap_or_else(|| "#333333".to_string())
     }
 
     fn disable_window_snap(&self) -> bool {
@@ -540,7 +540,7 @@ impl leftwm_core::Config for Config {
         self.theme_setting
             .focused_border_color
             .clone()
-            .unwrap_or(String::from("#FFD625"))
+            .unwrap_or_else(|| "#FFD625".to_string())
     }
 
     fn on_new_window_cmd(&self) -> Option<String> {

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -16,6 +16,7 @@ pub struct ThemeSetting {
     pub default_border_color: String,
     pub floating_border_color: String,
     pub focused_border_color: String,
+    pub background_color: String,
     #[serde(rename = "on_new_window")]
     pub on_new_window_cmd: Option<String>,
 }
@@ -45,6 +46,7 @@ impl Default for ThemeSetting {
             default_border_color: "#000000".to_owned(),
             floating_border_color: "#000000".to_owned(),
             focused_border_color: "#FF0000".to_owned(),
+            background_color: "#333333".to_owned(),
             on_new_window_cmd: None,
         }
     }
@@ -109,6 +111,7 @@ workspace_margin = 5
 default_border_color = '#222222'
 floating_border_color = '#005500'
 focused_border_color = '#FFB53A'
+background_color = '#333333'
 on_new_window = 'echo Hello World'
 
 [[gutter]]
@@ -134,6 +137,7 @@ value = 0
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),
+                background_color: "#333333".to_owned(),
                 on_new_window_cmd: Some("echo Hello World".to_string()),
             }
         );
@@ -152,6 +156,7 @@ value = 0
     default_border_color: "#222222",
     floating_border_color: "#005500",
     focused_border_color: "#FFB53A",
+    background_color: "#333333",
     on_new_window: Some("echo Hello World"),
 
     gutter: Some([Gutter (
@@ -179,6 +184,7 @@ value = 0
                 default_border_color: "#222222".to_string(),
                 floating_border_color: "#005500".to_string(),
                 focused_border_color: "#FFB53A".to_string(),
+                background_color: "#333333".to_owned(),
                 on_new_window_cmd: Some("echo Hello World".to_string()),
             }
         );

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -13,10 +13,10 @@ pub struct ThemeSetting {
     pub default_height: Option<i32>,
     pub always_float: Option<bool>,
     pub gutter: Option<Vec<Gutter>>,
-    pub default_border_color: String,
-    pub floating_border_color: String,
-    pub focused_border_color: String,
-    pub background_color: String,
+    pub default_border_color: Option<String>,
+    pub floating_border_color: Option<String>,
+    pub focused_border_color: Option<String>,
+    pub background_color: Option<String>,
     #[serde(rename = "on_new_window")]
     pub on_new_window_cmd: Option<String>,
 }
@@ -43,10 +43,10 @@ impl Default for ThemeSetting {
             default_height: Some(700),
             always_float: Some(false),
             gutter: None,
-            default_border_color: "#000000".to_owned(),
-            floating_border_color: "#000000".to_owned(),
-            focused_border_color: "#FF0000".to_owned(),
-            background_color: "#333333".to_owned(),
+            default_border_color: Some("#000000".to_owned()),
+            floating_border_color: Some("#000000".to_owned()),
+            focused_border_color: Some("#FFD625".to_owned()),
+            background_color: Some("#333333".to_owned()),
             on_new_window_cmd: None,
         }
     }
@@ -134,10 +134,10 @@ value = 0
                     value: 0,
                     wsid: None,
                 }]),
-                default_border_color: "#222222".to_string(),
-                floating_border_color: "#005500".to_string(),
-                focused_border_color: "#FFB53A".to_string(),
-                background_color: "#333333".to_owned(),
+                default_border_color: Some("#222222".to_string()),
+                floating_border_color: Some("#005500".to_string()),
+                focused_border_color: Some("#FFB53A".to_string()),
+                background_color: Some("#333333".to_owned()),
                 on_new_window_cmd: Some("echo Hello World".to_string()),
             }
         );
@@ -153,10 +153,10 @@ value = 0
     always_float: Some(true),
     margin: 5,
     workspace_margin: Some(5),
-    default_border_color: "#222222",
-    floating_border_color: "#005500",
-    focused_border_color: "#FFB53A",
-    background_color: "#333333",
+    default_border_color: Some("#222222"),
+    floating_border_color: Some("#005500"),
+    focused_border_color: Some("#FFB53A"),
+    background_color: Some("#333333"),
     on_new_window: Some("echo Hello World"),
 
     gutter: Some([Gutter (
@@ -181,10 +181,10 @@ value = 0
                     value: 0,
                     wsid: None,
                 }]),
-                default_border_color: "#222222".to_string(),
-                floating_border_color: "#005500".to_string(),
-                focused_border_color: "#FFB53A".to_string(),
-                background_color: "#333333".to_owned(),
+                default_border_color: Some("#222222".to_string()),
+                floating_border_color: Some("#005500".to_string()),
+                focused_border_color: Some("#FFB53A".to_string()),
+                background_color: Some("#333333".to_owned()),
                 on_new_window_cmd: Some("echo Hello World".to_string()),
             }
         );

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -45,7 +45,7 @@ impl Default for ThemeSetting {
             gutter: None,
             default_border_color: Some("#000000".to_owned()),
             floating_border_color: Some("#000000".to_owned()),
-            focused_border_color: Some("#FFD625".to_owned()),
+            focused_border_color: Some("#FF0000".to_owned()),
             background_color: Some("#333333".to_owned()),
             on_new_window_cmd: None,
         }

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ThemeSetting {
-    pub border_width: i32,
-    pub margin: CustomMargins,
+    pub border_width: Option<i32>,
+    pub margin: Option<CustomMargins>,
     pub workspace_margin: Option<CustomMargins>,
     pub default_width: Option<i32>,
     pub default_height: Option<i32>,
@@ -36,8 +36,8 @@ impl ThemeSetting {
 impl Default for ThemeSetting {
     fn default() -> Self {
         Self {
-            border_width: 1,
-            margin: CustomMargins::Int(10),
+            border_width: Some(1),
+            margin: Some(CustomMargins::Int(10)),
             workspace_margin: Some(CustomMargins::Int(10)),
             default_width: Some(1000),
             default_height: Some(700),
@@ -123,8 +123,8 @@ value = 0
         assert_eq!(
             config,
             ThemeSetting {
-                border_width: 0,
-                margin: CustomMargins::Int(5),
+                border_width: Some(0),
+                margin: Some(CustomMargins::Int(5)),
                 workspace_margin: Some(CustomMargins::Int(5)),
                 default_width: Some(400),
                 default_height: Some(400),
@@ -147,11 +147,11 @@ value = 0
     fn deserialize_custom_theme_config_ron() {
         let config = r##"
 (
-    border_width: 0,
+    border_width: Some(0),
     default_width: Some(400),
     default_height: Some(400),
     always_float: Some(true),
-    margin: 5,
+    margin: Some(5),
     workspace_margin: Some(5),
     default_border_color: Some("#222222"),
     floating_border_color: Some("#005500"),
@@ -170,8 +170,8 @@ value = 0
         assert_eq!(
             config,
             ThemeSetting {
-                border_width: 0,
-                margin: CustomMargins::Int(5),
+                border_width: Some(0),
+                margin: Some(CustomMargins::Int(5)),
                 workspace_margin: Some(CustomMargins::Int(5)),
                 default_width: Some(400),
                 default_height: Some(400),


### PR DESCRIPTION
# Description

- Added `background_color` field to the theme config on request of @VuiMuich.
- Changed some theme handling, specifically printing the all error messages when failing to run a script.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Add `background_color: "#333333"` to the example in the to rename Border Colors section.

# Checklist

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)

# Todo
- Make (all) colors optional?
- Which default color?