### PR TITLE
Make `test-full` fail on warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ test-nix:
 	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix flake check --extra-experimental-features "nix-command flakes"
 	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix build --extra-experimental-features "nix-command flakes"
 
-test-full:
-	make test
+test-full: test
 	cargo clippy --\
+		-D warnings\
 		-W clippy::pedantic\
 		-A clippy::must_use_candidate\
 		-A clippy::cast_precision_loss\
@@ -33,9 +33,7 @@ test-full:
 		-A clippy::cast_sign_loss\
 		-A clippy::mut_mut
 
-test-full-nix:
-	make test-full
-	make test-nix
+test-full-nix: test-full test-nix
 
 # builds the project
 build:


### PR DESCRIPTION
# Description

Make clippy pedantic fail on warnings, like the ci does. This is for me so I can run `make test-full && git push` and leave my Laptop. To be exact, the ci only runs `cargo clippy -- -Dwarnings`, but I only added i to the clippy pedantic check. You should run `make test-full`, not `make test` anyways before committing.

Edit: Also moved the make calls to be like in the install scripts.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
