### PR TITLE
Some fixes for the `Makefile` and `flake.nix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test:
 	cd $(ROOT_DIR) && cargo clippy
 
 test-nix:
-	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix flake check --extra-experimental-features "nix-command flakes"
-	cd $(ROOT_DIR) && sudo NIX_PATH=nixpkgs=channel:nixos-unstable nix build --extra-experimental-features "nix-command flakes"
+	cd $(ROOT_DIR) && NIX_PATH=nixpkgs=channel:nixos-unstable nix flake check --extra-experimental-features "nix-command flakes" --verbose
+	cd $(ROOT_DIR) && NIX_PATH=nixpkgs=channel:nixos-unstable nix build --extra-experimental-features "nix-command flakes" --verbose
 
 test-full: test
 	cargo clippy --\
@@ -42,6 +42,7 @@ build:
 # removes the generated binaries
 clean:
 	cd $(ROOT_DIR) && cargo clean
+	rm $(ROOT_DIR)/result
 	@echo "build files have been cleaned"
 
 # builds the project and installs the binaries (and .desktop)
@@ -55,7 +56,7 @@ install: build
 		$(ROOT_DIR)/target/release/leftwm-state\
 		$(ROOT_DIR)/target/release/leftwm-check\
 		$(ROOT_DIR)/target/release/leftwm-command\
-		-t /usr/bin
+		-t $(TARGET_DIR)
 	cd $(ROOT_DIR) && cargo clean
 	@echo "binaries, '.desktop' file and manual page have been installed"
 
@@ -71,8 +72,9 @@ install-linked: build
 	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-command $(TARGET_DIR)/leftwm-command
 	@echo "binaries have been linked, manpage and '.desktop' file have been installed"
 
+# same as above, but builds the project in debug mode (no optimisations, faster builds)
 install-linked-dev:
-	cd $(ROOT_DIR) && cargo build ${BUILDFLAGS}
+	cd $(ROOT_DIR) && cargo build
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
 	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm $(TARGET_DIR)/leftwm
@@ -84,7 +86,7 @@ install-linked-dev:
 	@echo "binaries have been linked, manpage and '.desktop' file have been linked."
 
 
-# uninstalls leftwm from the system, no matter if installed via 'install' or 'install-dev'
+# uninstalls leftwm from the system, no matter if installed via 'install', 'install-linked' or 'install-linked-dev'
 uninstall:
 	sudo rm -f $(SHARE_DIR)/leftwm.desktop
 	sudo rm /usr/local/share/man/man1/leftwm.1

--- a/flake.nix
+++ b/flake.nix
@@ -40,17 +40,21 @@
       in
       rec {
         # `nix build`
-        packages.leftwm = leftwm;
-        defaultPackage = packages.leftwm;
+        packages = {
+          inherit leftwm;
+          default = leftwm;
+        };
 
         # `nix run`
-        apps.leftwm = flake-utils.lib.mkApp {
-          drv = packages.leftwm;
+        apps = {
+          leftwm = flake-utils.lib.mkApp {
+            drv = packages.leftwm;
+          };
+          default = apps.leftwm;
         };
-        defaultApp = apps.leftwm;
 
         # `nix develop`
-        devShell = pkgs.mkShell
+        devShells.default = pkgs.mkShell
           {
             buildInputs = deps ++ [ pkgs.pkg-config pkgs.systemd ];
             nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
# Description

This change just fixes little things in the `Makefile`:
- Made the `install-linked-dev` rule build the project in debug mode, since it's linking files in `./target/debug`
- Changed the install dir for the `install` rule from `/usr/bin` to `TARGET_DIR`, which is `/usr/local/bin`, so it gets cleaned up with the `uninstall` rule
- `clean` now removes the `./result` symlink, which appears after building with `nix build`
- removed the invocation of `sudo` in the `test-nix`. If you can't use it without `sudo`, you should check if you are in the `nix-users` group
- added the `--verbose` flag for `test-nix`, so we get more info when building

This also fixes some deprecated declarations on `flake.nix`, which were triggering warnings with `test-nix`.
There is one that remains tho, its the [overlay](https://github.com/Syudagye/leftwm/blob/2d0433ae71414834c14d8d5910c2417230677ca5/flake.nix#L73), I don't know of to fix this for now, but this shouldn't be complicated.

I think this can be "breaking" because of the install directory change i've made.
Since it will install to another location, maybe the leftover binaries from the old location will remain and could be executed instead of the new ones.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: `test-full-nix` still has a warning for now
