### PR TITLE
Fix binary arguments (clap)

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -41,11 +41,10 @@ async fn main() -> Result<()> {
 
     let config_file: Option<&str> = matches
         .get_one::<String>(INPUT_ARG)
-        .map(|input| input.as_ref());
+        .map(std::convert::AsRef::as_ref);
     let verbose = matches
         .get_one::<bool>(VERBOSE_ARG)
-        .map(|verbose| verbose.to_owned())
-        .unwrap_or(false);
+        .map_or(false, std::borrow::ToOwned::to_owned);
 
     println!(
         "\x1b[0;94m::\x1b[0m LeftWM version: {}",

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use clap::{Arg, command};
+use clap::{command, Arg};
 use leftwm::{Config, ThemeSetting};
 use std::env;
 use std::fs;
@@ -39,9 +39,11 @@ async fn main() -> Result<()> {
         )
         .get_matches();
 
-    let config_file: Option<&str> = matches.get_one::<String>(INPUT_ARG)
+    let config_file: Option<&str> = matches
+        .get_one::<String>(INPUT_ARG)
         .map(|input| input.as_ref());
-    let verbose = matches.get_one::<bool>(VERBOSE_ARG)
+    let verbose = matches
+        .get_one::<bool>(VERBOSE_ARG)
         .map(|verbose| verbose.to_owned())
         .unwrap_or(false);
 

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -12,14 +12,11 @@ async fn main() -> Result<()> {
         .version(env!("CARGO_PKG_VERSION"))
         .about("Sends external commands to LeftWM")
         .arg(
-            arg!("command").help("The command to be sent. See 'list' flag."), // .required(true)
+            arg!(--"command" "The command to be sent. See 'list' flag."), // .required(true)
                                                                               // .multiple(true)
         )
         .arg(
-            arg!("list")
-                .help("Print a list of available commands with their arguments.")
-                .short('l')
-                .long("list"),
+            arg!(-l --list "Print a list of available commands with their arguments.")
         )
         .get_matches();
 

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -13,11 +13,9 @@ async fn main() -> Result<()> {
         .about("Sends external commands to LeftWM")
         .arg(
             arg!(--"command" "The command to be sent. See 'list' flag."), // .required(true)
-                                                                              // .multiple(true)
+                                                                          // .multiple(true)
         )
-        .arg(
-            arg!(-l --list "Print a list of available commands with their arguments.")
-        )
+        .arg(arg!(-l --list "Print a list of available commands with their arguments."))
         .get_matches();
 
     let file_name = CommandPipe::pipe_name();

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
         .about("Sends external commands to LeftWM")
         .arg(
             arg!(--"command" [COMMAND] "The command to be sent. See 'list' flag."), // .required(true)
-                                                                          // .multiple(true)
+                                                                                    // .multiple(true)
         )
         .arg(arg!(-l --list "Print a list of available commands with their arguments."))
         .get_matches();

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
         .version(env!("CARGO_PKG_VERSION"))
         .about("Sends external commands to LeftWM")
         .arg(
-            arg!(--"command" "The command to be sent. See 'list' flag."), // .required(true)
+            arg!(--"command" [COMMAND] "The command to be sent. See 'list' flag."), // .required(true)
                                                                           // .multiple(true)
         )
         .arg(arg!(-l --list "Print a list of available commands with their arguments."))
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
         .append(true)
         .open(file_path)
         .with_context(|| format!("ERROR: Couldn't open {}", file_name.display()))?;
+
     if let Some(commands) = matches.get_many::<String>("command") {
         for command in commands {
             if let Err(e) = writeln!(file, "{}", command) {
@@ -34,7 +35,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let command_list = matches.get_count("list") == 1;
+    let command_list = matches.get_one::<bool>("list").is_some();
 
     if command_list {
         println!(

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -17,21 +17,13 @@ async fn main() -> Result<()> {
         .author("Lex Childs <lex.childs@gmail.com>")
         .version(env!("CARGO_PKG_VERSION"))
         .about("prints out the current state of LeftWM")
+        .arg(arg!(-t --template [FILE] "A liquid template to use for the output"))
         .arg(
-            arg!(-t --template [FILE] "A liquid template to use for the output")
+            arg!(-s --string [STRING] "Use a liquid template string literal to use for the output"),
         )
-        .arg(
-            arg!(-s --string [STRING] "Use a liquid template string literal to use for the output")
-        )
-        .arg(
-            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]")
-        )
-        .arg(
-            arg!(-n --newline "Print new lines in the output")
-        )
-        .arg(
-            arg!(-q --quit "Prints the state once and quits")
-        )
+        .arg(arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]"))
+        .arg(arg!(-n --newline "Print new lines in the output"))
+        .arg(arg!(-q --quit "Prints the state once and quits"))
         .get_matches();
 
     let template_file = matches.get_one::<String>("template");

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -18,37 +18,19 @@ async fn main() -> Result<()> {
         .version(env!("CARGO_PKG_VERSION"))
         .about("prints out the current state of LeftWM")
         .arg(
-            arg!("template")
-                .short('t')
-                .long("template")
-                .value_name("FILE")
-                .help("A liquid template to use for the output"), // .takes_value(true),
+            arg!(-t --template [FILE] "A liquid template to use for the output")
         )
         .arg(
-            arg!("string")
-                .short('s')
-                .long("string")
-                .value_name("STRING")
-                .help("Use a liquid template string literal to use for the output"), // .takes_value(true),
+            arg!(-s --string [STRING] "Use a liquid template string literal to use for the output")
         )
         .arg(
-            arg!("workspace")
-                .short('w')
-                .long("workspace")
-                .value_name("WS_NUM")
-                .help("render only info about a given workspace [0..]"), // .takes_value(true),
+            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]")
         )
         .arg(
-            arg!("newline")
-                .short('n')
-                .long("newline")
-                .help("Print new lines in the output"),
+            arg!(-n --newline "Print new lines in the output")
         )
         .arg(
-            arg!("quit")
-                .short('q')
-                .long("quit")
-                .help("Prints the state once and quits"),
+            arg!(-q --quit "Prints the state once and quits")
         )
         .get_matches();
 

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -36,8 +36,8 @@ async fn main() -> Result<()> {
     };
 
     let mut stream_reader = stream_reader().await?;
-    let once = matches.get_count("quit") == 1;
-    let newline = matches.get_count("newline") == 1;
+    let once = matches.get_one::<bool>("quit").is_some();
+    let newline = matches.get_one::<bool>("newline").is_some();
 
     if let Some(template_file) = template_file {
         let path = Path::new(template_file);

--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -21,6 +21,8 @@ fn main() {
         #[cfg(not(feature = "lefthk"))]
         let config = leftwm::load();
 
+        tracing::info!("{:?}", config);
+
         let manager = Manager::<leftwm::Config, XlibDisplayServer>::new(config);
         manager.register_child_hook();
         rt.block_on(manager.start_event_loop())

--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -21,8 +21,6 @@ fn main() {
         #[cfg(not(feature = "lefthk"))]
         let config = leftwm::load();
 
-        tracing::info!("{:?}", config);
-
         let manager = Manager::<leftwm::Config, XlibDisplayServer>::new(config);
         manager.register_child_hook();
         rt.block_on(manager.start_event_loop())


### PR DESCRIPTION
# Description

This should make `leftwm-check` working again.

Fixes #(993) (only half)

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Not needed

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
