### PR TITLE
fix `leftwm-state` broken by `clap` bump

### DIFF
--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command};
+use clap::{arg, command, value_parser};
 use leftwm_core::errors::Result;
 use leftwm_core::models::dto::{DisplayState, ManagerState};
 use std::ffi::OsStr;
@@ -20,7 +20,8 @@ async fn main() -> Result<()> {
         .args(&[
             arg!(-t --template [FILE] "A liquid template to use for the output"),
             arg!(-s --string [STRING] "Use a liquid template string literal to use for the output"),
-            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]"),
+            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]")
+                .value_parser(value_parser!(usize)),
             arg!(-n --newline "Print new lines in the output"),
             arg!(-q --quit "Prints the state once and quits"),
         ])
@@ -69,7 +70,7 @@ async fn main() -> Result<()> {
         }
     } else {
         while let Some(line) = stream_reader.next_line().await? {
-            let _droppable2 = raw_handler(&line);
+            let _droppable = raw_handler(&line);
             if once {
                 break;
             }


### PR DESCRIPTION
# Description

As reported by @paaperia via discord, the `-w` or `--workspace` flag in `leftwm-state` was broken by #920.

Thanks @Eskaan for the relevant hint.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
