### PR TITLE
Implement a good-looking fix instead of a hotfix

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         .get_matches();
 
     let config_file = matches.get_one::<String>("INPUT").map(String::as_str);
-    let verbose = *matches.get_one::<bool>("verbose").unwrap_or(&false);
+    let verbose = matches.get_flag("verbose");
 
     println!(
         "\x1b[0;94m::\x1b[0m LeftWM version: {}",

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -33,9 +33,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let command_list = *matches.get_one::<bool>("list").unwrap();
-
-    if command_list {
+    if matches.get_flag("list") {
         println!(
             "
         Available Commands:

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -1,4 +1,4 @@
-use clap::{arg, command};
+use clap::{arg, command, value_parser};
 use leftwm_core::errors::Result;
 use leftwm_core::models::dto::{DisplayState, ManagerState};
 use std::ffi::OsStr;
@@ -20,7 +20,8 @@ async fn main() -> Result<()> {
         .args(&[
             arg!(-t --template [FILE] "A liquid template to use for the output"),
             arg!(-s --string [STRING] "Use a liquid template string literal to use for the output"),
-            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]"),
+            arg!(-w --workspace [WS_NUM] "render only info about a given workspace [0..]")
+                .value_parser(value_parser!(usize)),
             arg!(-n --newline "Print new lines in the output"),
             arg!(-q --quit "Prints the state once and quits"),
         ])
@@ -30,14 +31,11 @@ async fn main() -> Result<()> {
 
     let string_literal = matches.get_one::<String>("string");
 
-    let ws_num: Option<usize> = match matches.get_one("workspace") {
-        Some(&x) => Some(x),
-        _ => None,
-    };
+    let ws_num = matches.get_one("workspace").copied();
 
     let mut stream_reader = stream_reader().await?;
-    let once = *matches.get_one::<bool>("quit").unwrap();
-    let newline = *matches.get_one::<bool>("newline").unwrap();
+    let once = matches.get_flag("quit");
+    let newline = matches.get_flag("newline");
 
     if let Some(template_file) = template_file {
         let path = Path::new(template_file);


### PR DESCRIPTION
# Description

In #935, there was a hotfix implemented to fix the git builds as fast as possible. Now I reworked this a bit to look better.
Also fixes `leftwm-state --workspace`, which was forgotten in the hotfix.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
