### PR TITLE
Make help pages work

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -13,9 +13,8 @@ use xdg::BaseDirectories;
 #[tokio::main]
 async fn main() -> Result<()> {
     let matches = command!("LeftWM Check")
-        .author(clap::crate_authors!("\n"))
-        .version(clap::crate_version!())
         .about("Checks syntax of the configuration file")
+        .help_template(leftwm::utils::get_help_template())
         .args(&[
             arg!(-v --verbose "Outputs received configuration file."),
             arg!(migrate: -m --"migrate-toml-to-ron" "Migrates an exesting `toml` based config to a `ron` based one.\nKeeps the old file for reference, please delete it manually."),

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -33,9 +33,8 @@ async fn main() -> Result<()> {
 
 fn get_command() -> clap::Command {
     command!("LeftWM Command")
-        .author(clap::crate_authors!("\n"))
-        .version(clap::crate_version!())
         .about("Sends external commands to LeftWM")
+        .help_template(leftwm::utils::get_help_template())
         .args(&[
             arg!(-l --list "Print a list of available commands with their arguments."),
             arg!([COMMAND] ... "The command to be sent. See 'list' flag."),

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -154,9 +154,8 @@ async fn stream_reader() -> Result<Lines<BufReader<UnixStream>>> {
 
 fn get_command() -> clap::Command {
     command!("LeftWM State")
-        .author(clap::crate_authors!("\n"))
-        .version(clap::crate_version!())
-        .about("prints out the current state of LeftWM")
+        .about("Prints out the current state of LeftWM")
+        .help_template(leftwm::utils::get_help_template())
         .args(&[
             arg!(-t --template [FILE] "A liquid template to use for the output"),
             arg!(-s --string [STRING] "Use a liquid template string literal to use for the output"),

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -78,24 +78,14 @@ fn print_help_page() {
     };
 
     command!()
-        .long_about(
+        .about(
             "Starts LeftWM if no arguments are supplied. If a subcommand is given, executes the \
              the corresponding leftwm program, e.g. 'leftwm theme' will execute 'leftwm-theme', if \
              it is installed.",
         )
-        .author(clap::crate_authors!("\n"))
-        .version(env!("CARGO_PKG_VERSION"))
         .subcommands(subcommands)
-        .help_template(
-            "\
-{name} {version}
-{author-with-newline}{about-with-newline}
-{usage-heading} {usage}
-
-{all-args}
-",
-        )
-        .print_long_help()
+        .help_template(leftwm::utils::get_help_template())
+        .print_help()
         .unwrap();
 }
 

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -107,6 +107,12 @@ fn parse_subcommands(args: &LeftwmArgs) -> ! {
 
     if is_subcommand(subcommand) {
         execute_subcommand(subcommand, subcommand_args);
+    } else if subcommand == "help" {
+        if !subcommand_args.is_empty() && is_subcommand(&subcommand_args[0]) {
+            execute_subcommand(&subcommand_args[0], vec!["--help".to_string()]);
+        } else {
+            println!("No such subcommand. Try 'leftwm --help' to find valid subcommands.");
+        }
     } else if subcommand == "--version" || subcommand == "-v" {
         println!("leftwm {}", env!("CARGO_PKG_VERSION"));
     } else {

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -108,7 +108,9 @@ fn parse_subcommands(args: &LeftwmArgs) -> ! {
     if is_subcommand(subcommand) {
         execute_subcommand(subcommand, subcommand_args);
     } else if subcommand == "help" {
-        if !subcommand_args.is_empty() && is_subcommand(&subcommand_args[0]) {
+        if subcommand_args.is_empty() {
+            print_help_page();
+        } else if is_subcommand(&subcommand_args[0]) {
             execute_subcommand(&subcommand_args[0], vec!["--help".to_string()]);
         } else {
             println!("No such subcommand. Try 'leftwm --help' to find valid subcommands.");

--- a/leftwm/src/utils/mod.rs
+++ b/leftwm/src/utils/mod.rs
@@ -1,1 +1,11 @@
 pub mod log;
+
+pub const fn get_help_template() -> &'static str {
+    "\
+{name} {version}
+{author-with-newline}{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}
+"
+}


### PR DESCRIPTION
# Description

Didn't get merged with #937, so I cherry-picked my commit over.
Now the Author and version is printed again with the help pages.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.