### PR TITLE
Add optimized build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 default-members = ["leftwm", "leftwm-core", "display-servers/xlib-display-server"]
 members = ["leftwm", "leftwm-core", "display-servers/xlib-display-server"]
+
+[profile.optimized]
+inherits = "release"
+codegen-units = 1
+strip = "symbols"
+lto = "fat"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# The flags to pass to the `cargo build` command
-BUILDFLAGS := --release
-
 # Absolute path to project directory, required for symbolic links
 # or when 'make' is run from another directory.
 # - credit: https://stackoverflow.com/a/23324703/2726733
@@ -8,6 +5,18 @@ ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 SHARE_DIR := /usr/share/xsessions
 TARGET_DIR := /usr/local/bin
+
+# Set default profile if unset
+ifndef profile
+	profile := optimized
+endif
+
+# Set corresponding target folder name
+ifeq ($(profile),dev)
+	folder := debug
+else
+	folder := $(profile)
+endif
 
 # default rule is to run build/test
 all: build test
@@ -37,56 +46,45 @@ test-full-nix: test-full test-nix
 
 # builds the project
 build:
-	cd $(ROOT_DIR) && cargo build ${BUILDFLAGS}
+	@echo "Building with $(profile) profile"
+	@echo "Change the profile by adding profile=release or profile=dev to the command"
+	cd $(ROOT_DIR) && cargo build --profile $(profile)
 
 # removes the generated binaries
 clean:
 	cd $(ROOT_DIR) && cargo clean
 	rm $(ROOT_DIR)/result
-	@echo "build files have been cleaned"
+	@echo "Build files have been cleaned"
 
 # builds the project and installs the binaries (and .desktop)
 install: build
 	sudo cp $(ROOT_DIR)/leftwm.desktop /usr/share/xsessions/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
 	sudo install -s -Dm755\
-		$(ROOT_DIR)/target/release/leftwm\
-		$(ROOT_DIR)/target/release/leftwm-worker\
-		$(ROOT_DIR)/target/release/lefthk-worker\
-		$(ROOT_DIR)/target/release/leftwm-state\
-		$(ROOT_DIR)/target/release/leftwm-check\
-		$(ROOT_DIR)/target/release/leftwm-command\
+		$(ROOT_DIR)/target/$(folder)/leftwm\
+		$(ROOT_DIR)/target/$(folder)/leftwm-worker\
+		$(ROOT_DIR)/target/$(folder)/lefthk-worker\
+		$(ROOT_DIR)/target/$(folder)/leftwm-state\
+		$(ROOT_DIR)/target/$(folder)/leftwm-check\
+		$(ROOT_DIR)/target/$(folder)/leftwm-command\
 		-t $(TARGET_DIR)
 	cd $(ROOT_DIR) && cargo clean
-	@echo "binaries, '.desktop' file and manual page have been installed"
+	@echo "Binaries, '.desktop' file and manual page have been installed"
 
-# build the project and links the binaries, will also install the .desktop file
+# Function to build and link a specific profile
 install-linked: build
+	cd $(ROOT_DIR) && cargo build --profile $(profile)
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
-	sudo ln -sf $(ROOT_DIR)/target/release/leftwm $(TARGET_DIR)/leftwm
-	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-worker $(TARGET_DIR)/leftwm-worker
-	sudo ln -sf $(ROOT_DIR)/target/release/lefthk-worker $(TARGET_DIR)/lefthk-worker
-	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-state $(TARGET_DIR)/leftwm-state
-	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-check $(TARGET_DIR)/leftwm-check
-	sudo ln -sf $(ROOT_DIR)/target/release/leftwm-command $(TARGET_DIR)/leftwm-command
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm $(TARGET_DIR)/leftwm
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-worker $(TARGET_DIR)/leftwm-worker
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/lefthk-worker $(TARGET_DIR)/lefthk-worker
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-state $(TARGET_DIR)/leftwm-state
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-check $(TARGET_DIR)/leftwm-check
+	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-command $(TARGET_DIR)/leftwm-command
 	@echo "binaries have been linked, manpage and '.desktop' file have been installed"
 
-# same as above, but builds the project in debug mode (no optimisations, faster builds)
-install-linked-dev:
-	cd $(ROOT_DIR) && cargo build
-	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
-	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
-	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm $(TARGET_DIR)/leftwm
-	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-worker $(TARGET_DIR)/leftwm-worker
-	sudo ln -sf $(ROOT_DIR)/target/debug/lefthk-worker $(TARGET_DIR)/lefthk-worker
-	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-state $(TARGET_DIR)/leftwm-state
-	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-check $(TARGET_DIR)/leftwm-check
-	sudo ln -sf $(ROOT_DIR)/target/debug/leftwm-command $(TARGET_DIR)/leftwm-command
-	@echo "binaries have been linked, manpage and '.desktop' file have been linked."
-
-
-# uninstalls leftwm from the system, no matter if installed via 'install', 'install-linked' or 'install-linked-dev'
+# Uninstalls leftwm from the system.
 uninstall:
 	sudo rm -f $(SHARE_DIR)/leftwm.desktop
 	sudo rm /usr/local/share/man/man1/leftwm.1
@@ -97,4 +95,4 @@ uninstall:
 		$(TARGET_DIR)/leftwm-state\
 		$(TARGET_DIR)/leftwm-check\
 		$(TARGET_DIR)/leftwm-command
-	@echo "binaries and manpage have been uninstalled and '.desktop' file has been removed"
+	@echo "Binaries and manpage have been uninstalled and '.desktop' file has been removed"

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ simple black screen on login.  For a more customized look, install a theme.
 
    ```bash
    # With systemd logging (view with 'journalctl -f -t leftwm-worker')
-   cargo build --profile release
+   cargo build --profile optimized
    ```
 
 3. And press the following keybind to reload leftwm

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ For conveniece we also have a Makefile with the following rules:
 | install-dev | installs by symlinking, copies `leftwm.desktop`, no clean |
 | uninstall | removes `leftwm-*` files from `/usr/bin` and `leftwm.desktop` file |
 
-Note that for `build`, `install` and `install-linked`, you can specify the build profile to use. Currently available are `dev`, `release` and `release-optimized`.
+Note that for `build`, `install` and `install-linked`, you can specify the build profile to use by adding the `profile=<profile-name>` argument. Currently available are `dev`, `release` and `release-optimized`.
 
 ## Starting with startx or a login such as slim
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ sudo cp PATH_TO_LEFTWM/leftwm.desktop /usr/share/xsessions
 3. Build leftwm
 
    ```bash
-   cargo build --release
+   cargo build --profile optimized
    ```
 
 4. Copy leftwm executables to the /usr/bin folder
@@ -233,6 +233,10 @@ If your goal is to continuously build leftwm and keep up to date with the latest
 prefer to symlink the leftwm executables instead of copying them.  If you choose to install this
 way, make sure you do not move the build directory as it will break your installation.
 
+Note that if you want to build leftwm with an other build profile, you will have to change the
+`--profile <profile-name>` option and the target folder to `target/<profile-name>`.
+Currently available are `dev`, `release` and `optimized`.
+
 1. Dependencies: Rust, Cargo
 2. Clone the repository and cd into the directory
 
@@ -245,24 +249,24 @@ way, make sure you do not move the build directory as it will break your install
 
    ```bash
    # With systemd logging (view with 'journalctl -f -t leftwm-worker')
-   cargo build --release
+   cargo build --profile optimized
  
    # OR with sys-log
-   cargo build --release --no-default-features --features=lefthk,sys-log
+   cargo build --profile optimized --no-default-features --features=lefthk,sys-log
   
    # OR without lefthk (please bring you own keybind daemon like `sxhkd` or similar) and file logging
-   cargo build --release --no-default-features --features=file-log
+   cargo build --profile optimized --no-default-features --features=file-log
    ```
 
 4. Create the symlinks
 
    ```bash
-   sudo ln -s "$(pwd)"/target/release/leftwm /usr/bin/leftwm
-   sudo ln -s "$(pwd)"/target/release/leftwm-worker /usr/bin/leftwm-worker
-   sudo ln -s "$(pwd)"/target/release/lefthk-worker /usr/bin/lefthk-worker
-   sudo ln -s "$(pwd)"/target/release/leftwm-state /usr/bin/leftwm-state
-   sudo ln -s "$(pwd)"/target/release/leftwm-check /usr/bin/leftwm-check
-   sudo ln -s "$(pwd)"/target/release/leftwm-command /usr/bin/leftwm-command
+   sudo ln -s "$(pwd)"/target/optimized/leftwm /usr/bin/leftwm
+   sudo ln -s "$(pwd)"/target/optimized/leftwm-worker /usr/bin/leftwm-worker
+   sudo ln -s "$(pwd)"/target/optimized/lefthk-worker /usr/bin/lefthk-worker
+   sudo ln -s "$(pwd)"/target/optimized/leftwm-state /usr/bin/leftwm-state
+   sudo ln -s "$(pwd)"/target/optimized/leftwm-check /usr/bin/leftwm-check
+   sudo ln -s "$(pwd)"/target/optimized/leftwm-command /usr/bin/leftwm-command
    ```
 
 5. Copy leftwm.desktop to xsessions folder
@@ -286,7 +290,7 @@ simple black screen on login.  For a more customized look, install a theme.
 
    ```bash
    # With systemd logging (view with 'journalctl -f -t leftwm-worker')
-   cargo build --release
+   cargo build --profile release
    ```
 
 3. And press the following keybind to reload leftwm
@@ -304,11 +308,13 @@ For conveniece we also have a Makefile with the following rules:
 | all | implies `build` and `test` |
 | test | runs same tests as CI on github |
 | test-full | same as `test` but additionally with pedantic clippy lints |
-| build | builds with cargo flag `--release` |
+| build | builds with cargo profile `optimized` by default; read build output on how to change the profile. |
 | clean | clean all buildfiles |
 | install | install by copying binaries to `/usr/bin`, also places `leftwm.desktop` file to `/usr/share/xsession` and cleans build files |
 | install-dev | installs by symlinking, copies `leftwm.desktop`, no clean |
 | uninstall | removes `leftwm-*` files from `/usr/bin` and `leftwm.desktop` file |
+
+Note that for `build`, `install` and `install-linked`, you can specify the build profile to use. Currently available are `dev`, `release` and `release-optimized`.
 
 ## Starting with startx or a login such as slim
 


### PR DESCRIPTION
# Description

- Added an `optimized` build profile.
- Adjusted `Makefile`, can now build with any profile.
  Specify profile=<profile> in the make command arguments to select. Default is `optimized`.
- Adjusted `README.md` to account for changes.

## Type of change

- [x] Development change (no change visible to user)
  Except they notice the slight performance increase or lower binary size
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  In the extremely rare case of some user scripts relying on `make install-linked-dev`
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.


### Btw
I lerned to hate Makefile syntax. And oh boy, do I hate it.