### PR TITLE
Clippy and fmt

### DIFF
--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -611,7 +611,7 @@ mod tests {
         manager.window_created_handler(Window::new(window_handle, None, Some(mock_window)), -1, -1);
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
-            value: "".to_string(),
+            value: String::new(),
             x: None,
             y: None,
             height: None,
@@ -1251,7 +1251,7 @@ mod tests {
         manager.window_created_handler(scratchpad, -1, -1);
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
-            value: "".to_string(),
+            value: String::new(),
             x: None,
             y: None,
             height: None,

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -67,7 +67,7 @@ impl Nanny {
 
     /// Runs a script if it exits
     fn run_script(path: &Path) -> Result<Child> {
-        Command::new(&path)
+        Command::new(path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .spawn()
@@ -297,7 +297,7 @@ pub fn register_child_hook(flag: Arc<AtomicBool>) {
 pub fn exec_shell(command: &str, children: &mut Children) -> Option<ChildID> {
     let child = Command::new("sh")
         .arg("-c")
-        .arg(&command)
+        .arg(command)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .spawn()

--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -2,13 +2,14 @@ use std::env;
 
 fn main() {
     let mut features_string = String::new();
-    env::vars()
-        .for_each(|(name, _)| if name.starts_with("CARGO_FEATURE_") {
-            let name = name[14..].replace("_", "-");
+    env::vars().for_each(|(name, _)| {
+        if let Some(name) = name.strip_prefix("CARGO_FEATURE_") {
+            let name = name.replace('_', "-");
             let name = name.to_lowercase();
             features_string.push(' ');
             features_string.push_str(&name);
-        });
+        }
+    });
 
     println!("cargo:rustc-env=LEFTWM_FEATURES={}", features_string);
 

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -136,7 +136,7 @@ fn write_to_file(ron_file: &Path, config: &Config) -> Result<(), anyhow::Error> 
 "#,
     );
     let ron_with_header = comment_header + &ron;
-    let mut file = File::create(&ron_file)?;
+    let mut file = File::create(ron_file)?;
     file.write_all(ron_with_header.as_bytes())?;
     Ok(())
 }
@@ -266,10 +266,10 @@ fn check_current_theme_set(filepath: &Option<PathBuf>, verbose: bool) -> Result<
     match &filepath {
         Some(p) => {
             if verbose {
-                if fs::symlink_metadata(&p)?.file_type().is_symlink() {
+                if fs::symlink_metadata(p)?.file_type().is_symlink() {
                     println!(
                         "Found symlink `current`, pointing to theme folder: {:?}",
-                        fs::read_link(&p).unwrap()
+                        fs::read_link(p).unwrap()
                     );
                 } else {
                     println!("\x1b[1;93mWARN: Found `current` theme folder: {:?}. Use of a symlink is recommended, instead.\x1b[0m", p);
@@ -313,7 +313,7 @@ fn check_up_file(filepath: PathBuf) -> Result<()> {
 
 fn check_theme_toml(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
     let metadata = fs::metadata(&filepath)?;
-    let contents = fs::read_to_string(&filepath.as_path())?;
+    let contents = fs::read_to_string(filepath.as_path())?;
 
     if metadata.is_file() {
         if verbose {
@@ -341,7 +341,7 @@ fn check_theme_toml(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
 
 fn check_theme_ron(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
     let metadata = fs::metadata(&filepath)?;
-    let contents = fs::read_to_string(&filepath.as_path())?;
+    let contents = fs::read_to_string(filepath.as_path())?;
 
     if metadata.is_file() {
         if verbose {
@@ -363,9 +363,9 @@ fn check_theme_ron(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
 }
 
 fn check_feature<T, E, F>(name: &str, predicate: F) -> Result<()>
-    where
-        F: FnOnce() -> Result<T, E>,
-        E: std::fmt::Debug,
+where
+    F: FnOnce() -> Result<T, E>,
+    E: std::fmt::Debug,
 {
     match predicate() {
         Ok(_) => Ok(println!("\x1b[0;92m    -> {} OK\x1b[0m", name)),
@@ -374,10 +374,13 @@ fn check_feature<T, E, F>(name: &str, predicate: F) -> Result<()>
 }
 
 fn check_enabled_features() {
-    println!("\x1b[0;94m::\x1b[0m Enabled features:{}", env!("LEFTWM_FEATURES"));
+    println!(
+        "\x1b[0;94m::\x1b[0m Enabled features:{}",
+        env!("LEFTWM_FEATURES")
+    );
 
     println!("\x1b[0;94m::\x1b[0m Checking feature dependencies . . .");
 
     #[cfg(feature = "journald-log")]
-    check_feature("journald-log", || tracing_journald::layer()).unwrap();
+    check_feature("journald-log", tracing_journald::layer).unwrap();
 }

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -368,7 +368,10 @@ where
     E: std::fmt::Debug,
 {
     match predicate() {
-        Ok(_) => Ok(println!("\x1b[0;92m    -> {} OK\x1b[0m", name)),
+        Ok(_) => {
+            println!("\x1b[0;92m    -> {} OK\x1b[0m", name);
+            Ok(())
+        }
         Err(err) => bail!("Check for feature {} failed: {:?}", name, err),
     }
 }

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -67,7 +67,7 @@ impl std::convert::From<BaseCommand> for String {
             BaseCommand::GotoTag => "GoToTag".to_owned(),
             BaseCommand::MoveToTag => "SendWindowToTag".to_owned(),
             BaseCommand::MoveToLastWorkspace => "MoveWindowToLastWorkspace".to_owned(),
-            BaseCommand::Execute => "".to_owned(),
+            BaseCommand::Execute => String::new(),
             _ => format!("{:?}", command),
         }
     }

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -567,7 +567,7 @@ impl leftwm_core::Config for Config {
 
     fn save_state(&self, state: &State) {
         let path = self.state_file();
-        let state_file = match File::create(&path) {
+        let state_file = match File::create(path) {
             Ok(file) => file,
             Err(err) => {
                 tracing::error!("Cannot create file at path {}: {}", path.display(), err);


### PR DESCRIPTION
# Description

Sometimes I am a bit of a moron and merge without letting CI finish, so here is a fix for the missed `fmt`.
But this gives the chance to fix some clippy lints that are unrelated to the previously merged PR and are new in rust 1.65 I guess.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
