### PR TITLE
use `implicit_some` extension in ron deserializer

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,6 +1,11 @@
 use anyhow::{bail, Result};
 use clap::{arg, command};
 use leftwm::{Config, ThemeSetting};
+use ron::{
+    extensions::Extensions,
+    ser::{to_string_pretty, PrettyConfig},
+    Options,
+};
 use std::env;
 use std::fs;
 use std::fs::File;
@@ -110,7 +115,8 @@ pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
         dbg!(&contents);
     }
     if config_filename.as_path().extension() == Some(std::ffi::OsStr::new("ron")) {
-        let config = ron::from_str(&contents)?;
+        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
+        let config: Config = ron.from_str(&contents)?;
         Ok(config)
     } else {
         let config = toml::from_str(&contents)?;
@@ -119,10 +125,10 @@ pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
 }
 
 fn write_to_file(ron_file: &Path, config: &Config) -> Result<(), anyhow::Error> {
-    let ron_pretty_conf = ron::ser::PrettyConfig::new()
+    let ron_pretty_conf = PrettyConfig::new()
         .depth_limit(2)
-        .extensions(ron::extensions::Extensions::IMPLICIT_SOME);
-    let ron = ron::ser::to_string_pretty(&config, ron_pretty_conf)?;
+        .extensions(Extensions::IMPLICIT_SOME);
+    let ron = to_string_pretty(&config, ron_pretty_conf)?;
     let comment_header = String::from(
         r#"//  _        ___                                      ___ _
 // | |      / __)_                                   / __|_)

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -19,13 +19,18 @@ use leftwm_core::{
     state::State,
     DisplayAction, DisplayServer, Manager,
 };
+use ron::{
+    extensions::Extensions,
+    ser::{to_string_pretty, PrettyConfig},
+    Options,
+};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::default::Default;
 use std::env;
 use std::fs;
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::prelude::Write;
 use std::path::{Path, PathBuf};
 use xdg::BaseDirectories;
 
@@ -205,8 +210,9 @@ fn load_from_file() -> Result<Config> {
 
     if Path::new(&config_file_ron).exists() {
         tracing::debug!("Config file '{}' found.", config_file_ron.to_string_lossy());
+        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
         let contents = fs::read_to_string(config_file_ron)?;
-        let config = ron::from_str(&contents)?;
+        let config: Config = ron.from_str(&contents)?;
 
         if check_workspace_ids(&config) {
             Ok(config)
@@ -233,10 +239,10 @@ fn load_from_file() -> Result<Config> {
         tracing::debug!("Config file not found. Using default config file.");
 
         let config = Config::default();
-        let ron_pretty_conf = ron::ser::PrettyConfig::new()
+        let ron_pretty_conf = PrettyConfig::new()
             .depth_limit(2)
-            .extensions(ron::extensions::Extensions::IMPLICIT_SOME);
-        let ron = ron::ser::to_string_pretty(&config, ron_pretty_conf).unwrap();
+            .extensions(Extensions::IMPLICIT_SOME);
+        let ron = to_string_pretty(&config, ron_pretty_conf).unwrap();
         let comment_header = String::from(
             r#"//  _        ___                                      ___ _
 // | |      / __)_                                   / __|_)

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use leftwm_core::models::{Gutter, Margins};
+use ron::{extensions::Extensions, Options};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -55,7 +56,8 @@ impl Default for ThemeSetting {
 fn load_theme_file(path: impl AsRef<Path>) -> Result<ThemeSetting> {
     let contents = fs::read_to_string(&path)?;
     if path.as_ref().extension() == Some(std::ffi::OsStr::new("ron")) {
-        let from_file: ThemeSetting = ron::from_str(&contents)?;
+        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
+        let from_file: ThemeSetting = ron.from_str(&contents)?;
         Ok(from_file)
     } else {
         let from_file: ThemeSetting = toml::from_str(&contents)?;


### PR DESCRIPTION
# Description

This activates the `implicit_some` extension of ron by default for all deserialisation. If the file (config or theme) explicitly activates it should be no issue.
This is especially helpfull since #922 made all fields of `theme.ron` optional.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
