### PR TITLE
Print `lefthk` warning only when no binary present

### DIFF
--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -1,4 +1,4 @@
-use std::{env, process::Command};
+use std::env;
 
 fn main() {
     let mut features_string = String::new();
@@ -13,7 +13,8 @@ fn main() {
 
     println!("cargo:rustc-env=LEFTWM_FEATURES={}", features_string);
 
-    match Command::new("lefthk-worker").spawn() {
+    #[cfg(feature = "lefthk")]
+    match std::process::Command::new("lefthk-worker").spawn() {
         Ok(mut p) => p.kill().unwrap(),
         Err(_) => println!("cargo:warning=When first time building with `lefthk` you need to completely restart `leftwm` in order to start the hotkey daemon proprerly. A `SoftReload` or `HardReload` will leave you with a session non responsive to keybinds but otherwise running well."),
     }

--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, process::Command};
 
 fn main() {
     let mut features_string = String::new();
@@ -13,5 +13,8 @@ fn main() {
 
     println!("cargo:rustc-env=LEFTWM_FEATURES={}", features_string);
 
-    println!("cargo:warning=When first time building with `lefthk` you need to completely restart `leftwm` in order to start the hotkey daemon proprerly. A `SoftReload` or `HardReload` will leave you with a session non responsive to keybinds but otherwise running well.");
+    match Command::new("lefthk-worker").spawn() {
+        Ok(mut p) => p.kill().unwrap(),
+        Err(_) => println!("cargo:warning=When first time building with `lefthk` you need to completely restart `leftwm` in order to start the hotkey daemon proprerly. A `SoftReload` or `HardReload` will leave you with a session non responsive to keybinds but otherwise running well."),
+    }
 }


### PR DESCRIPTION
# Description

Only print the warning message about necessary session restart only when no binary for `lefthk-worker` is found.
To be precise, we don't print on any error when trying to launch `lefthk-worker` as this means the same for the session state I guess.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
