### PR TITLE
Exclude NetBSD in `build.rs` and avoid build-hangs

### DIFF
--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -13,7 +13,7 @@ fn main() {
 
     println!("cargo:rustc-env=LEFTWM_FEATURES={}", features_string);
 
-    #[cfg(feature = "lefthk")]
+    #[cfg(all(feature = "lefthk", not(target_os = "netbsd")))]
     match std::process::Command::new("lefthk-worker").spawn() {
         Ok(mut p) => p.kill().unwrap(),
         Err(_) => println!("cargo:warning=When first time building with `lefthk` you need to completely restart `leftwm` in order to start the hotkey daemon proprerly. A `SoftReload` or `HardReload` will leave you with a session non responsive to keybinds but otherwise running well."),


### PR DESCRIPTION
# Description

Discussion with @VuiMuich on the latest commit.

Fixes build on NetBSD

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).
Not required.

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported

`cargo-fmt` is happy 😄 