### PR TITLE
Revert "Fix regression that `wmctrl` and `rofi` could not request focus for a window"

### DIFF
--- a/display-servers/xlib-display-server/src/event_translate_client_message.rs
+++ b/display-servers/xlib-display-server/src/event_translate_client_message.rs
@@ -1,8 +1,5 @@
 use super::{DisplayEvent, XWrap};
-use leftwm_core::{
-    models::{WindowChange, WindowHandle},
-    Command,
-};
+use leftwm_core::{models::WindowChange, Command};
 use std::convert::TryFrom;
 use std::os::raw::c_long;
 
@@ -35,7 +32,6 @@ pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<Displa
             }
         }
     }
-
     if event.message_type == xw.atoms.NetWMDesktop {
         let value = event.data.get_long(0);
         match usize::try_from(value) {
@@ -56,18 +52,9 @@ pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<Displa
             }
         }
     }
-
     if event.message_type == xw.atoms.NetActiveWindow {
-        // When an application client sends a Message with this atom and a WindowHandle
-        // we assume it wants to request `urgency` when the client is a pager or does
-        // not set `source indication` we focus the window
-        if event.data.get_short(0) == 1 {
-            xw.set_window_urgency(event.window, true);
-            return None;
-        };
-        return Some(DisplayEvent::HandleWindowFocus(WindowHandle::XlibHandle(
-            event.window,
-        )));
+        xw.set_window_urgency(event.window, true);
+        return None;
     }
 
     //if the client is trying to toggle fullscreen without changing the window state, change it too


### PR DESCRIPTION
Reverts leftwm/leftwm#887

as reported by @0323pin this PR creates issues with Firefox.
Sorry for the inconvenience if anyone affacted.