### PR TITLE
feat(config): allow regexps in window_rules for window_class,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "mio",
  "nix 0.25.0",
  "once_cell",
+ "regex",
  "ron",
  "serde",
  "serde_json",

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -23,6 +23,7 @@ leftwm-core = { path = "../leftwm-core", version = '0.4.0' }
 liquid = "0.26.0"
 mio = "0.8.0"
 nix = "0.25.0"
+regex = "1"
 ron = "0.8.0"
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = "1.0.44"

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -64,10 +64,18 @@ const STATE_FILE: &str = "/tmp/leftwm.state";
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct WindowHook {
     /// `WM_CLASS` in X11
-    #[serde(deserialize_with = "from_regexps", serialize_with = "to_regexps")]
+    #[serde(
+        default,
+        deserialize_with = "from_regexps",
+        serialize_with = "to_config_strings"
+    )]
     pub window_class: Option<regex::Regex>,
     /// `_NET_WM_NAME` in X11
-    #[serde(deserialize_with = "from_regexps", serialize_with = "to_regexps")]
+    #[serde(
+        default,
+        deserialize_with = "from_regexps",
+        serialize_with = "to_config_strings"
+    )]
     pub window_title: Option<regex::Regex>,
     pub spawn_on_tag: Option<usize>,
     pub spawn_on_workspace: Option<i32>,
@@ -679,7 +687,7 @@ fn from_regexps<'de, D: Deserializer<'de>>(
     }
 }
 
-fn to_regexps<S: Serializer>(wc: &Option<regex::Regex>, s: S) -> Result<S::Ok, S::Error> {
+fn to_config_strings<S: Serializer>(wc: &Option<regex::Regex>, s: S) -> Result<S::Ok, S::Error> {
     match wc {
         Some(ref re) => s.serialize_some(re.as_str()),
         None => s.serialize_none(),

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -63,6 +63,9 @@ const STATE_FILE: &str = "/tmp/leftwm.state";
 /// windows whose `WM_CLASS` is "krita" will spawn on tag 3 (1-indexed) and not floating.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct WindowHook {
+    // Use serde default field attribute to fallback to None option in case of missing field in
+    // config. Without this attribute deserializer will fail on missing field due to it's inability
+    // to treat missing value as Option::None
     /// `WM_CLASS` in X11
     #[serde(
         default,

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -96,22 +96,12 @@ impl WindowHook {
     /// specific one to apply: matches by title are scored greater than by `WM_CLASS`.
     fn score_window(&self, window: &Window) -> u8 {
         let class_score = match (&self.window_class, &window.res_class) {
-            (Some(wc_re), Some(res_class)) => {
-                if wc_re.is_match(res_class) {
-                    return 1;
-                }
-                return 0;
-            }
+            (Some(wc_re), Some(res_class)) => u8::from(wc_re.replace(res_class, "") == ""),
             _ => 0,
         };
 
         let title_score = match (&self.window_title, &window.legacy_name) {
-            (Some(wt_re), Some(legacy_name)) => {
-                if wt_re.is_match(legacy_name) {
-                    return 1;
-                }
-                return 0;
-            }
+            (Some(wt_re), Some(legacy_name)) => u8::from(wt_re.replace(legacy_name, "") == ""),
             _ => 0,
         };
 

--- a/leftwm/src/config/mod.rs
+++ b/leftwm/src/config/mod.rs
@@ -664,6 +664,8 @@ impl Config {
     }
 }
 
+// Regular expression in leftwm config should correspond to RE2 syntax, described here:
+// https://github.com/google/re2/wiki/Syntax
 fn from_regex<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Regex>, D::Error> {
     let res: Option<String> = Deserialize::deserialize(deserializer)?;
     res.map_or(Ok(None), |s| {


### PR DESCRIPTION
Allow regexps for matching window_class and window_title in leftwm config.

Resolves: #977
Signed-off-by: Ilya Trefilov <ilya.trefilov@outlook.com>

# Description
This change introduces regexp matching of window_class, window_title in window_rules config field. 


Fixes #977

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:
Window rules allow to define how a window matching some properties should be spawned. As of now, a window can be matched by two properties:

    window_class, string or regular expression corresponding to the property WM_CLASS of a window in a X server.
    window_title, string or regular expression corresponding to the _NET_WM_NAME or the WM_NAME of a window. Both will be inspected if a window rule is defined by window_title. This takes precedence over window_class, since it is more specific.

The properties of a window can be inspected by launching [xprop](https://www.x.org/releases/X11R7.5/doc/man/man1/xprop.1.html) on a terminal and clicking the desired window.

Example:

    window_rules: [
      // windows whose WM_CLASS is "Navigator" will be spawn on tag 2 (by position, 1-indexed)
     ( window_class: "Navigator", spawn_on_tag: 2 ),
      // windows whose window title is "Pentablet" will be spawned floating on tag 9
     ( window_title: "Pentablet", spawn_on_tag: 9, spawn_floating: true ),
     // windows whose WM_CLASS matches `*.app_2.*` regular expression will spawn on tag 6
     ( window_class: "*.app_2.*", spawn_on_tag: 2 ),
     // windows whose window_title matches `*.app_5.*` regular expression will spawn on tag 5
     ( window_title: "*.app_5.*", spawn_on_tag: 5 ),

]

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
