### PR TITLE
handle theme templates within Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # - credit: https://stackoverflow.com/a/23324703/2726733
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-SHARE_DIR := /usr/share/xsessions
+SHARE_DIR := /usr/share
 TARGET_DIR := /usr/local/bin
 
 # Set default profile if unset
@@ -58,8 +58,10 @@ clean:
 
 # builds the project and installs the binaries (and .desktop)
 install: build
-	sudo cp $(ROOT_DIR)/leftwm.desktop /usr/share/xsessions/
+	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/xsessions/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
+	sudo mkdir $(SHARE_DIR)/leftwm
+	sudo cp -r $(ROOT_DIR)/themes $(SHARE_DIR)/leftwm
 	sudo install -s -Dm755\
 		$(ROOT_DIR)/target/$(folder)/leftwm\
 		$(ROOT_DIR)/target/$(folder)/leftwm-worker\
@@ -69,25 +71,28 @@ install: build
 		$(ROOT_DIR)/target/$(folder)/leftwm-command\
 		-t $(TARGET_DIR)
 	cd $(ROOT_DIR) && cargo clean
-	@echo "Binaries, '.desktop' file and manual page have been installed"
+	@echo "Binaries, '.desktop' file, theme templates and manual page have been installed"
 
 # Function to build and link a specific profile
 install-linked: build
 	cd $(ROOT_DIR) && cargo build --profile $(profile)
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
+	sudo mkdir $(SHARE_DIR)/leftwm
+	sudo cp -r $(ROOT_DIR)/themes $(SHARE_DIR)/leftwm
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm $(TARGET_DIR)/leftwm
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-worker $(TARGET_DIR)/leftwm-worker
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/lefthk-worker $(TARGET_DIR)/lefthk-worker
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-state $(TARGET_DIR)/leftwm-state
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-check $(TARGET_DIR)/leftwm-check
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-command $(TARGET_DIR)/leftwm-command
-	@echo "binaries have been linked, manpage and '.desktop' file have been installed"
+	@echo "binaries have been linked, manpage, theme templates and '.desktop' file have been installed"
 
 # Uninstalls leftwm from the system.
 uninstall:
 	sudo rm -f $(SHARE_DIR)/leftwm.desktop
 	sudo rm /usr/local/share/man/man1/leftwm.1
+	sudo rm -f $(SHARE_DIR)/leftwm
 	sudo rm -f\
 		$(TARGET_DIR)/leftwm\
 		$(TARGET_DIR)/leftwm-worker\
@@ -95,4 +100,4 @@ uninstall:
 		$(TARGET_DIR)/leftwm-state\
 		$(TARGET_DIR)/leftwm-check\
 		$(TARGET_DIR)/leftwm-command
-	@echo "Binaries and manpage have been uninstalled and '.desktop' file has been removed"
+	@echo "Binaries and manpage have been uninstalled and '.desktop' file and theme templates have been removed"


### PR DESCRIPTION
# Description

Recently in a thread on the discord, @mautamu asked whether the theme templates of the repo get installed to a general accessible path.
With this PR the makefile installs the theme templates from the repo directory `./themes` to `/usr/share/leftwm` (and removes the directory with the uninstall), same as both our AUR packages do.

Should we reflect this in the Docs somewhere?

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:



# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
