### PR TITLE
Fix regression on calculating window score

### DIFF
--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -106,8 +106,6 @@ impl WindowHook {
         let class_score = self.window_class.as_ref().map_or(0, |re| {
             u8::from(matches_any(re, vec![&window.res_class, &window.res_name]))
         });
-            _ => 0,
-        };
 
         let title_score = self.window_title.as_ref().map_or(0, |re| {
             u8::from(matches_any(re, vec![&window.legacy_name, &window.name]))

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -97,13 +97,21 @@ impl WindowHook {
     /// Multiple [`WindowHook`]s might match a `WM_CLASS` but we want the most
     /// specific one to apply: matches by title are scored greater than by `WM_CLASS`.
     fn score_window(&self, window: &Window) -> u8 {
-        let class_score = match (&self.window_class, &window.res_class) {
-            (Some(wc_re), Some(res_class)) => u8::from(wc_re.replace(res_class, "") == ""),
+        let class_score = match (&self.window_class, &window.res_class, &window.res_name) {
+            (Some(wc_re), Some(res_class), Some(res_name)) => {
+                u8::from(wc_re.replace(res_class, "") == "" || wc_re.replace(res_name, "") == "")
+            }
+            (Some(wc_re), Some(res_class), _) => u8::from(wc_re.replace(res_class, "") == ""),
+            (Some(wc_re), _, Some(res_name)) => u8::from(wc_re.replace(res_name, "") == ""),
             _ => 0,
         };
 
-        let title_score = match (&self.window_title, &window.legacy_name) {
-            (Some(wt_re), Some(legacy_name)) => u8::from(wt_re.replace(legacy_name, "") == ""),
+        let title_score = match (&self.window_title, &window.legacy_name, &window.name) {
+            (Some(wt_re), Some(legacy_name), Some(name)) => {
+                u8::from(wt_re.replace(legacy_name, "") == "" || wt_re.replace(name, "") == "")
+            }
+            (Some(wt_re), Some(legacy_name), _) => u8::from(wt_re.replace(legacy_name, "") == ""),
+            (Some(wt_re), _, Some(name)) => u8::from(wt_re.replace(name, "") == ""),
             _ => 0,
         };
 

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -97,23 +97,21 @@ impl WindowHook {
     /// Multiple [`WindowHook`]s might match a `WM_CLASS` but we want the most
     /// specific one to apply: matches by title are scored greater than by `WM_CLASS`.
     fn score_window(&self, window: &Window) -> u8 {
-        let class_score = match (&self.window_class, &window.res_class, &window.res_name) {
-            (Some(wc_re), Some(res_class), Some(res_name)) => {
-                u8::from(wc_re.replace(res_class, "") == "" || wc_re.replace(res_name, "") == "")
-            }
-            (Some(wc_re), Some(res_class), _) => u8::from(wc_re.replace(res_class, "") == ""),
-            (Some(wc_re), _, Some(res_name)) => u8::from(wc_re.replace(res_name, "") == ""),
+        // returns true if any of the items in the provided `Vec<&Option<String>>` is Some and matches the `&Regex`
+        let matches_any = |re: &Regex, strs: Vec<&Option<String>>| {
+            strs.iter()
+                .any(|str| str.as_ref().map_or(false, |s| re.replace(s, "") == ""))
+        };
+
+        let class_score = self.window_class.as_ref().map_or(0, |re| {
+            u8::from(matches_any(re, vec![&window.res_class, &window.res_name]))
+        });
             _ => 0,
         };
 
-        let title_score = match (&self.window_title, &window.legacy_name, &window.name) {
-            (Some(wt_re), Some(legacy_name), Some(name)) => {
-                u8::from(wt_re.replace(legacy_name, "") == "" || wt_re.replace(name, "") == "")
-            }
-            (Some(wt_re), Some(legacy_name), _) => u8::from(wt_re.replace(legacy_name, "") == ""),
-            (Some(wt_re), _, Some(name)) => u8::from(wt_re.replace(name, "") == ""),
-            _ => 0,
-        };
+        let title_score = self.window_title.as_ref().map_or(0, |re| {
+            u8::from(matches_any(re, vec![&window.legacy_name, &window.name]))
+        });
 
         class_score + 2 * title_score
     }


### PR DESCRIPTION
# Description

#986 (fe42fd0c0b6137823541510b3e118a52b28c673b) seems to introduce a small regression about calculating score window : for the class window, res_class and res_name was used and for the title window, name and legacy_name. Now, only res_class and legacy_name are used. This PR reintroduce the old behaviour.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
