### PR TITLE
Add Command SwapWindowTop 

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -41,6 +41,9 @@ pub enum Command {
     MoveWindowTop {
         swap: bool,
     },
+    SwapWindowTop {
+        swap: bool,
+    },
     FocusNextTag,
     FocusPreviousTag,
     FocusWindow(String),

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -93,6 +93,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         // Move Window
         "MoveWindowDown" => Ok(Command::MoveWindowDown),
         "MoveWindowTop" => build_move_window_top(rest),
+        "SwapWindowTop" => build_swap_window_top(rest),
         "MoveWindowUp" => Ok(Command::MoveWindowUp),
         "MoveWindowToNextTag" => build_move_window_to_next_tag(rest),
         "MoveWindowToPreviousTag" => build_move_window_to_previous_tag(rest),
@@ -252,6 +253,15 @@ fn build_move_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error
         bool::from_str(raw)?
     };
     Ok(Command::MoveWindowTop { swap })
+}
+
+fn build_swap_window_top(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
+    let swap = if raw.is_empty() {
+        true
+    } else {
+        bool::from_str(raw)?
+    };
+    Ok(Command::SwapWindowTop { swap })
 }
 
 fn build_move_window_to_next_tag(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -33,6 +33,7 @@ pub enum BaseCommand {
     MoveWindowUp,
     MoveWindowDown,
     MoveWindowTop,
+    SwapWindowTop,
     FocusNextTag,
     FocusPreviousTag,
     FocusWindow,

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -56,6 +56,9 @@ impl Keybind {
             BaseCommand::FocusWindowTop if value_is_some => {
                 bool::from_str(&self.value).context("invalid boolean value for FocusWindowTop")?;
             }
+            BaseCommand::SwapWindowTop if value_is_some => {
+                bool::from_str(&self.value).context("invalid boolean value for SwapWindowTop")?;
+            }
             BaseCommand::MoveToTag => {
                 usize::from_str(&self.value).context("invalid index value for SendWindowToTag")?;
             }


### PR DESCRIPTION
# Description

This PR introduces a new Command `SwapWindowTop`, which swaps the current window with the window on top of the stack, without changing the order of the other windows. 

Fixes #1004 

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:
Add section to (https://github.com/leftwm/leftwm/wiki/Config#keybind-commands) : 
### SwapWindowTop 
Swaps the focused window with the window on top of the stack in the current workspace.  Takes an Optional argument swap, if set to false, calling the command while the top window is focused results in no action. Otherwise it will swap the top window with the one below it.  By default swap is set to true 


Add row to the External Commands table with the same describtion

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
