### PR TITLE
add 'unreleased' section to changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add `SwapWindowTop` command as an alternative to `MoveWindowTop` (via #1005 by @emiliode)
+
 ## [0.4.1]
 ### Fixed
 - Temp fix for MainWidth inconsistency until layout-lib


### PR DESCRIPTION
# Description

Add `[Unreleased]` section to changelog and already include #1005. 

We can keep the Changelog up-to-date continuously rather than having to write the whole thing on next release :)

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update
