### PR TITLE
snap cursor to bottom-right of the window when resizing

### DIFF
--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -19,9 +19,17 @@ impl State {
         if let Some(window) = self.windows.iter().find(|w| w.handle == handle) {
             if !self.disable_tile_drag || window.floating() {
                 let modifier = utils::modmask_lookup::into_modmask(&self.mousekey);
+                let win = window.clone();
                 // Build the display to say whether we are ready to move/resize.
                 let act = self.build_action(modmask, button, handle, modifier);
                 if let Some(act) = act {
+                    if let DisplayAction::ReadyToResizeWindow(_) = act {
+                        let move_act = DisplayAction::MoveMouseOverPoint((
+                            win.x() + win.width(),
+                            win.y() + win.height(),
+                        ));
+                        self.actions.push_back(move_act);
+                    }
                     self.actions.push_back(act);
                     return false;
                 }


### PR DESCRIPTION
# Description

This PR makes the cursor move to the bottom-right corner of the window in the beginning of a resize

Fixes #1003 

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
