### PR TITLE
Better manage paths in `event_loop`

### DIFF
--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -307,10 +307,7 @@ impl Children {
 impl FromIterator<Child> for Children {
     fn from_iter<T: IntoIterator<Item = Child>>(iter: T) -> Self {
         Self {
-            inner: iter
-                .into_iter()
-                .map(|child| (child.id(), child))
-                .collect::<HashMap<_, _>>(),
+            inner: iter.into_iter().map(|child| (child.id(), child)).collect(),
         }
     }
 }


### PR DESCRIPTION
# Description

No longer enforce that paths for `CommandPipe` need to be valid UTF-8 and drop a few heap allocations that were not needed, such as [this one](https://github.com/leftwm/leftwm/pull/1016/files#diff-f84f186acc1305f6ea6ffbf0647456df4ce1d52d2f1bebc6fc27548f59080292L184) or [this one](https://github.com/leftwm/leftwm/pull/1016/files#diff-f84f186acc1305f6ea6ffbf0647456df4ce1d52d2f1bebc6fc27548f59080292L199)

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
