### PR TITLE
Notify user when CommandPipe's Drop impl fails to unlock pipe file

### DIFF
--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -23,11 +23,16 @@ impl Drop for CommandPipe {
 
         // Open fifo for write to unblock pending open for read operation that prevents tokio runtime
         // from shutting down.
-        std::fs::OpenOptions::new()
+        if let Err(err) = std::fs::OpenOptions::new()
             .write(true)
             .custom_flags(nix::fcntl::OFlag::O_NONBLOCK.bits())
-            .open(self.pipe_file.clone())
-            .ok();
+            .open(&self.pipe_file)
+        {
+            eprintln!(
+                "Failed to open {} when dropping CommandPipe: {err}",
+                self.pipe_file.display()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Notifies stderr when CommandPipe's Drop impl fails to open pipe file with `O_NONBLOCK`. Also stops cloning `self.pipe_file` when doing so

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
