### PR TITLE
`command_pipe`: avoid heap allocating command parts when possible

### DIFF
--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -188,9 +188,9 @@ fn build_toggle_scratchpad(raw: &str) -> Result<Command, Box<dyn std::error::Err
 
 fn build_go_to_tag(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
     let headless = without_head(raw, "GoToTag ");
-    let parts: Vec<&str> = headless.split(' ').collect();
-    let tag: TagId = parts.first().ok_or("missing argument tag_id")?.parse()?;
-    let swap: bool = parts.get(1).ok_or("missing argument swap")?.parse()?;
+    let mut parts = headless.split(' ');
+    let tag: TagId = parts.next().ok_or("missing argument tag_id")?.parse()?;
+    let swap: bool = parts.next().ok_or("missing argument swap")?.parse()?;
     Ok(Command::GoToTag { tag, swap })
 }
 
@@ -284,15 +284,15 @@ fn build_move_window_to_previous_tag(raw: &str) -> Result<Command, Box<dyn std::
 
 fn build_increase_main_width(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
     let headless = without_head(raw, "IncreaseMainWidth ");
-    let parts: Vec<&str> = headless.split(' ').collect();
-    let change: i8 = parts.first().ok_or("missing argument change")?.parse()?;
+    let mut parts = headless.split(' ');
+    let change: i8 = parts.next().ok_or("missing argument change")?.parse()?;
     Ok(Command::IncreaseMainWidth(change))
 }
 
 fn build_decrease_main_width(raw: &str) -> Result<Command, Box<dyn std::error::Error>> {
     let headless = without_head(raw, "DecreaseMainWidth ");
-    let parts: Vec<&str> = headless.split(' ').collect();
-    let change: i8 = parts.first().ok_or("missing argument change")?.parse()?;
+    let mut parts = headless.split(' ');
+    let change: i8 = parts.next().ok_or("missing argument change")?.parse()?;
     Ok(Command::DecreaseMainWidth(change))
 }
 


### PR DESCRIPTION
# Description

Sometimes command args get collected into a `Vec<&str>` during parsing, which is not needed.
By switching to using the `Split` iterator directly we can lower the latency of these parsing operations

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
