### PR TITLE
Better error message for invalid liquid template strings

### DIFF
--- a/leftwm-core/src/errors.rs
+++ b/leftwm-core/src/errors.rs
@@ -14,4 +14,6 @@ pub enum LeftError {
     XdgBaseDirError(#[from] xdg::BaseDirectoriesError),
     #[error("Stream error")]
     StreamError,
+    #[error("Liquid parsing error")]
+    LiquidParsingError,
 }


### PR DESCRIPTION
# Description

While playing around with the `liquid` templates for `leftwm state`, I found that when an invalid template string was inserted, `leftwm state` would panic.

This PR changes the error output on wrong input `{{window_title}` from:
```
thread 'main' panicked at 'Unable to parse template: Error { inner: InnerError { msg: Owned(" --> 1:3\n  |\n1 | {{window_title}\n  |   ^---\n  |\n  = expected Literal"), user_backtrace: [Trace { trace: None, context: [] }], cause: None } }', leftwm/src/bin/leftwm-state.rs:92:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
to
```
liquid:  --> 1:3
  |
1 | {{workspaces}
  |   ^---
  |
  = expected Literal

Error: LiquidParsingError
```

Fixes #(issue) (I did not find any)

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Should not be necessary

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
