### PR TITLE
Fix `leftwm-check` outputting default and dependencies

### DIFF
--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -62,12 +62,12 @@ tempfile = "3.2.0"
 
 [features]
 default = ["journald-log", "lefthk"]
-lefthk = ["lefthk-core"]
+lefthk = ["dep:lefthk-core"]
 
 # logging features
-journald-log = ["tracing-journald"]
-file-log = ["tracing-appender"]
-sys-log = ["syslog-tracing"]
+journald-log = ["dep:tracing-journald"]
+file-log = ["dep:tracing-appender"]
+sys-log = ["dep:syslog-tracing"]
 
 # Sleep on restart
 slow-dm-fix = []

--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -6,6 +6,7 @@ fn main() {
         if let Some(name) = name.strip_prefix("CARGO_FEATURE_") {
             let name = name.replace('_', "-");
             let name = name.to_lowercase();
+            let name = name.replace("default", "");
             features_string.push(' ');
             features_string.push_str(&name);
         }


### PR DESCRIPTION
Currently when `leftwm-check` outputs the enabled features and dependencies:
```
Enabled features: default journald-log lefthk lefthk-core tracing-journald
```
When the only enabled features are `journald-log` and `lefthk`. Using `feature = ["dep:dependency"]` is the intended way to do feature dependencies and therefore `leftwm-check` won't print all the dependencies it uses for those features:
```
Enabled features:  journald-log lefthk
```
I also trim `default` in `build.rs`.
This just basically makes `leftwm-check` a bit more readable.
