### PR TITLE
Refactor file handling

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,18 +1,12 @@
 use anyhow::{bail, Result};
 use clap::{arg, command};
-use leftwm::{Config, ThemeSetting};
-use ron::{
-    extensions::Extensions,
-    ser::{to_string_pretty, PrettyConfig},
-    Options,
+use leftwm::utils::file_handler::{load_from_file, write_to_file};
+use leftwm::ThemeSetting;
+use std::{
+    env, fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
 };
-use std::env;
-use std::fs;
-use std::fs::File;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::path::PathBuf;
 use xdg::BaseDirectories;
 
 #[tokio::main]
@@ -51,6 +45,53 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    pub(crate) fn check_elogind(verbose: bool) -> Result<()> {
+        // We assume that if it is in the path it's all good
+        // We also cross-reference the ENV variable
+        match (
+            std::env::var("XDG_RUNTIME_DIR"),
+            leftwm::is_program_in_path("loginctl"),
+        ) {
+            (Ok(val), true) => {
+                if verbose {
+                    println!(":: XDG_RUNTIME_DIR: {val}, LOGINCTL OKAY");
+                }
+
+                println!("\x1b[0;92m    -> Environment OK \x1b[0m");
+
+                Ok(())
+            }
+            (Ok(val), false) => {
+                if verbose {
+                    println!(":: XDG_RUNTIME_DIR: {val}, LOGINCTL not installed");
+                }
+
+                println!("\x1b[0;92m    -> Environment OK (has XDG_RUNTIME_DIR) \x1b[0m");
+
+                Ok(())
+            }
+            (Err(e), false) => {
+                if verbose {
+                    println!(":: XDG_RUNTIME_DIR_ERROR: {e:?}, LOGINCTL BAD");
+                }
+
+                bail!(
+                    "Elogind not installed/operating and no alternative XDG_RUNTIME_DIR is set. \
+                See https://github.com/leftwm/leftwm/wiki/XDG_RUNTIME_DIR for more information."
+                );
+            }
+            (Err(e), true) => {
+                if verbose {
+                    println!(":: XDG_RUNTIME_DIR: {e:?}, LOGINCTL OKAY");
+                }
+                println!(
+                    "\x1b[1;93mWARN: Elogind/systemd installed but XDG_RUNTIME_DIR not set.\nThis may be because elogind isn't started. \x1b[0m",
+                );
+                Ok(())
+            }
+        }
+    }
+
     match check_enabled_features() {
         Ok(_) => {}
         Err(err) => {
@@ -81,121 +122,6 @@ async fn main() -> Result<()> {
     check_theme(verbose);
 
     Ok(())
-}
-
-/// Loads configuration from either specified file (preferred) or default.
-/// # Errors
-///
-/// Errors if file cannot be read. Indicates filesystem error
-/// (inadequate permissions, disk full, etc.)
-/// If a path is specified and does not exist, returns `LeftError`.
-pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
-    let config_filename = if let Some(fspath) = fspath {
-        println!("\x1b[1;35mNote: Using file {fspath} \x1b[0m");
-        PathBuf::from(fspath)
-    } else {
-        let ron_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.ron")?;
-        let toml_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.toml")?;
-        if Path::new(&ron_file).exists() {
-            ron_file
-        } else if Path::new(&toml_file).exists() {
-            println!(
-                "\x1b[1;93mWARN: TOML as config format is about to be deprecated.
-      Please consider migrating to RON manually or by using `leftwm-check -m`.\x1b[0m"
-            );
-            toml_file
-        } else {
-            let config = Config::default();
-            write_to_file(&ron_file, &config)?;
-            return Ok(config);
-        }
-    };
-
-    if verbose {
-        dbg!(&config_filename);
-    }
-    let contents = fs::read_to_string(&config_filename)?;
-    if verbose {
-        dbg!(&contents);
-    }
-    if config_filename.as_path().extension() == Some(std::ffi::OsStr::new("ron")) {
-        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
-        let config: Config = ron.from_str(&contents)?;
-        Ok(config)
-    } else {
-        let config = toml::from_str(&contents)?;
-        Ok(config)
-    }
-}
-
-fn write_to_file(ron_file: &Path, config: &Config) -> Result<(), anyhow::Error> {
-    let ron_pretty_conf = PrettyConfig::new()
-        .depth_limit(2)
-        .extensions(Extensions::IMPLICIT_SOME);
-    let ron = to_string_pretty(&config, ron_pretty_conf)?;
-    let comment_header = String::from(
-        r#"//  _        ___                                      ___ _
-// | |      / __)_                                   / __|_)
-// | | ____| |__| |_ _ _ _ ____      ____ ___  ____ | |__ _  ____    ____ ___  ____
-// | |/ _  )  __)  _) | | |    \    / ___) _ \|  _ \|  __) |/ _  |  / ___) _ \|  _ \
-// | ( (/ /| |  | |_| | | | | | |  ( (__| |_| | | | | |  | ( ( | |_| |  | |_| | | | |
-// |_|\____)_|   \___)____|_|_|_|   \____)___/|_| |_|_|  |_|\_|| (_)_|   \___/|_| |_|
-// A WindowManager for Adventurers                         (____/
-// For info about configuration please visit https://github.com/leftwm/leftwm/wiki
-
-"#,
-    );
-    let ron_with_header = comment_header + &ron;
-    let mut file = File::create(ron_file)?;
-    file.write_all(ron_with_header.as_bytes())?;
-    Ok(())
-}
-
-fn check_elogind(verbose: bool) -> Result<()> {
-    // We assume that if it is in the path it's all good
-    // We also cross-reference the ENV variable
-    match (
-        std::env::var("XDG_RUNTIME_DIR"),
-        leftwm::is_program_in_path("loginctl"),
-    ) {
-        (Ok(val), true) => {
-            if verbose {
-                println!(":: XDG_RUNTIME_DIR: {val}, LOGINCTL OKAY");
-            }
-
-            println!("\x1b[0;92m    -> Environment OK \x1b[0m");
-
-            Ok(())
-        }
-        (Ok(val), false) => {
-            if verbose {
-                println!(":: XDG_RUNTIME_DIR: {val}, LOGINCTL not installed");
-            }
-
-            println!("\x1b[0;92m    -> Environment OK (has XDG_RUNTIME_DIR) \x1b[0m");
-
-            Ok(())
-        }
-        (Err(e), false) => {
-            if verbose {
-                println!(":: XDG_RUNTIME_DIR_ERROR: {e:?}, LOGINCTL BAD");
-            }
-
-            bail!(
-                "Elogind not installed/operating and no alternative XDG_RUNTIME_DIR is set. \
-                See https://github.com/leftwm/leftwm/wiki/XDG_RUNTIME_DIR for more information."
-            );
-        }
-        (Err(e), true) => {
-            if verbose {
-                println!(":: XDG_RUNTIME_DIR: {e:?}, LOGINCTL OKAY");
-            }
-            println!(
-                "\x1b[1;93mWARN: Elogind/systemd installed but XDG_RUNTIME_DIR not set.\nThis may be because elogind isn't started. \x1b[0m",
-            );
-            Ok(())
-        }
-    }
 }
 
 /// Checks if `.config/leftwm/theme/current/` is a valid path

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -11,6 +11,7 @@ use super::BaseCommand;
 use super::ThemeSetting;
 #[cfg(feature = "lefthk")]
 use crate::config::keybind::Keybind;
+use crate::utils::file_handler::write_to_file;
 use anyhow::Result;
 use leftwm_core::{
     config::{InsertBehavior, ScratchPad, Workspace},
@@ -20,19 +21,15 @@ use leftwm_core::{
     DisplayAction, DisplayServer, Manager,
 };
 use regex::Regex;
-use ron::{
-    extensions::Extensions,
-    ser::{to_string_pretty, PrettyConfig},
-    Options,
-};
+use ron::{extensions::Extensions, Options};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::convert::TryInto;
-use std::default::Default;
-use std::env;
-use std::fs;
-use std::fs::File;
-use std::io::prelude::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    convert::TryInto,
+    default::Default,
+    env,
+    fs::{self, File},
+    path::{Path, PathBuf},
+};
 use xdg::BaseDirectories;
 
 /// Path to file where state will be dumped upon soft reload.
@@ -245,27 +242,7 @@ fn load_from_file() -> Result<Config> {
         tracing::debug!("Config file not found. Using default config file.");
 
         let config = Config::default();
-        let ron_pretty_conf = PrettyConfig::new()
-            .depth_limit(2)
-            .extensions(Extensions::IMPLICIT_SOME);
-        let ron = to_string_pretty(&config, ron_pretty_conf).unwrap();
-        let comment_header = String::from(
-            r#"//  _        ___                                      ___ _
-// | |      / __)_                                   / __|_)
-// | | ____| |__| |_ _ _ _ ____      ____ ___  ____ | |__ _  ____    ____ ___  ____
-// | |/ _  )  __)  _) | | |    \    / ___) _ \|  _ \|  __) |/ _  |  / ___) _ \|  _ \
-// | ( (/ /| |  | |_| | | | | | |  ( (__| |_| | | | | |  | ( ( | |_| |  | |_| | | | |
-// |_|\____)_|   \___)____|_|_|_|   \____)___/|_| |_|_|  |_|\_|| (_)_|   \___/|_| |_|
-// A WindowManager for Adventurers                         (____/
-// For info about configuration please visit https://github.com/leftwm/leftwm/wiki
-
-"#,
-        );
-        let ron_with_header = comment_header + &ron;
-
-        let mut file = File::create(&config_file_ron)?;
-        file.write_all(ron_with_header.as_bytes())?;
-
+        write_to_file(&config_file_ron, &config)?;
         Ok(config)
     }
 }

--- a/leftwm/src/lib.rs
+++ b/leftwm/src/lib.rs
@@ -7,3 +7,4 @@ mod theme_setting;
 pub use command::*;
 pub use config::*;
 pub use theme_setting::*;
+// pub use utils::file_handler::*;

--- a/leftwm/src/theme_setting.rs
+++ b/leftwm/src/theme_setting.rs
@@ -1,8 +1,7 @@
+use crate::utils::file_handler::load_theme_file;
 use anyhow::Result;
 use leftwm_core::models::{Gutter, Margins};
-use ron::{extensions::Extensions, Options};
 use serde::{Deserialize, Serialize};
-use std::fs;
 use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -50,18 +49,6 @@ impl Default for ThemeSetting {
             background_color: Some("#333333".to_owned()),
             on_new_window_cmd: None,
         }
-    }
-}
-
-fn load_theme_file(path: impl AsRef<Path>) -> Result<ThemeSetting> {
-    let contents = fs::read_to_string(&path)?;
-    if path.as_ref().extension() == Some(std::ffi::OsStr::new("ron")) {
-        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
-        let from_file: ThemeSetting = ron.from_str(&contents)?;
-        Ok(from_file)
-    } else {
-        let from_file: ThemeSetting = toml::from_str(&contents)?;
-        Ok(from_file)
     }
 }
 

--- a/leftwm/src/utils.rs
+++ b/leftwm/src/utils.rs
@@ -1,3 +1,4 @@
+pub mod file_handler;
 pub mod log;
 
 pub const fn get_help_template() -> &'static str {

--- a/leftwm/src/utils/file_handler.rs
+++ b/leftwm/src/utils/file_handler.rs
@@ -1,0 +1,93 @@
+use crate::{Config, ThemeSetting};
+use anyhow::{self, Result};
+use ron::{
+    extensions::Extensions,
+    ser::{to_string_pretty, PrettyConfig},
+    Options,
+};
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::{Path, PathBuf},
+};
+use xdg::BaseDirectories;
+
+/// Loads configuration from either specified file (preferred) or default.
+/// # Errors
+///
+/// Errors if file cannot be read. Indicates filesystem error
+/// (inadequate permissions, disk full, etc.)
+/// If a path is specified and does not exist, returns `LeftError`.
+pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
+    let config_filename = if let Some(fspath) = fspath {
+        println!("\x1b[1;35mNote: Using file {fspath} \x1b[0m");
+        PathBuf::from(fspath)
+    } else {
+        let ron_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.ron")?;
+        let toml_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.toml")?;
+        if Path::new(&ron_file).exists() {
+            ron_file
+        } else if Path::new(&toml_file).exists() {
+            println!(
+                "\x1b[1;93mWARN: TOML as config format is about to be deprecated.
+      Please consider migrating to RON manually or by using `leftwm-check -m`.\x1b[0m"
+            );
+            toml_file
+        } else {
+            let config = Config::default();
+            write_to_file(&ron_file, &config)?;
+            return Ok(config);
+        }
+    };
+
+    if verbose {
+        dbg!(&config_filename);
+    }
+    let contents = fs::read_to_string(&config_filename)?;
+    if verbose {
+        dbg!(&contents);
+    }
+    if config_filename.as_path().extension() == Some(std::ffi::OsStr::new("ron")) {
+        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
+        let config: Config = ron.from_str(&contents)?;
+        Ok(config)
+    } else {
+        let config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+}
+
+pub fn write_to_file(ron_file: &Path, config: &Config) -> Result<(), anyhow::Error> {
+    let ron_pretty_conf = PrettyConfig::new()
+        .depth_limit(2)
+        .extensions(Extensions::IMPLICIT_SOME);
+    let ron = to_string_pretty(&config, ron_pretty_conf)?;
+    let comment_header = String::from(
+        r#"//  _        ___                                      ___ _
+// | |      / __)_                                   / __|_)
+// | | ____| |__| |_ _ _ _ ____      ____ ___  ____ | |__ _  ____    ____ ___  ____
+// | |/ _  )  __)  _) | | |    \    / ___) _ \|  _ \|  __) |/ _  |  / ___) _ \|  _ \
+// | ( (/ /| |  | |_| | | | | | |  ( (__| |_| | | | | |  | ( ( | |_| |  | |_| | | | |
+// |_|\____)_|   \___)____|_|_|_|   \____)___/|_| |_|_|  |_|\_|| (_)_|   \___/|_| |_|
+// A WindowManager for Adventurers                         (____/
+// For info about configuration please visit https://github.com/leftwm/leftwm/wiki
+
+"#,
+    );
+    let ron_with_header = comment_header + &ron;
+    let mut file = File::create(ron_file)?;
+    file.write_all(ron_with_header.as_bytes())?;
+    Ok(())
+}
+
+pub fn load_theme_file(path: impl AsRef<Path>) -> Result<ThemeSetting> {
+    let contents = fs::read_to_string(&path)?;
+    if path.as_ref().extension() == Some(std::ffi::OsStr::new("ron")) {
+        let ron = Options::default().with_default_extension(Extensions::IMPLICIT_SOME);
+        let from_file: ThemeSetting = ron.from_str(&contents)?;
+        Ok(from_file)
+    } else {
+        let from_file: ThemeSetting = toml::from_str(&contents)?;
+        Ok(from_file)
+    }
+}


### PR DESCRIPTION
# Description

So far this is just a refactor to get started with cleaning up file handling.

I am still considering if pulling all the `path` handling into a similar module in `leftwm-core`, or if this would be kind of redundant, as many `Path` and `PathBuf` references are tied directly to the respective lib anyways.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
