### PR TITLE
fix - when window gets detroyed, find the last focused

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -69,8 +69,14 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Process a collection of events, and apply them changes to a manager.
     /// Returns true if changes need to be rendered.
     pub fn window_destroyed_handler(&mut self, handle: &WindowHandle) -> bool {
-        // Find the next or previous window on the workspace.
-        let new_handle = self.get_next_or_previous_handle(handle);
+        // Get the previous focused window else find the next or previous window on the workspace.
+        let new_handle = if let Some(Some(last_focused_window)) =
+            self.state.focus_manager.window_history.get(1)
+        {
+            Some(*last_focused_window)
+        } else {
+            self.get_next_or_previous_handle(handle)
+        };
         // If there is a parent we would want to focus it.
         let (transient, floating, visible) =
             match self.state.windows.iter().find(|w| &w.handle == handle) {


### PR DESCRIPTION
# Description

This is a bug mentioned by @VuiMuich on the #1052 which happens when a dialog (i.e. asking for a password) gets destroyed and the focus goes to Main and not to the previous focused window. 
With this PR, the focus goes to the previous focused window (if there was one) or else, it use the default behavior, which is looking for a next/previous window on the same workspace.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
