### PR TITLE
Update workspaces on screen change

### DIFF
--- a/display-servers/xlib-display-server/src/xwrap.rs
+++ b/display-servers/xlib-display-server/src/xwrap.rs
@@ -20,7 +20,7 @@ use tokio::sync::{oneshot, Notify};
 use tokio::time::Duration;
 
 use x11_dl::xlib;
-use x11_dl::xrandr::Xrandr;
+use x11_dl::xrandr::{self, Xrandr};
 
 mod getters;
 mod mouse;
@@ -38,6 +38,7 @@ pub const ROOT_EVENT_MASK: c_long = xlib::SubstructureRedirectMask
     | xlib::ButtonPressMask
     | xlib::PointerMotionMask
     | xlib::StructureNotifyMask;
+const XRANDR_EVENT_MASK: c_int = xrandr::RRCrtcChangeNotifyMask; //xrandr::RRScreenChangeNotifyMask;
 
 const BUTTONMASK: c_long = xlib::ButtonPressMask | xlib::ButtonReleaseMask | xlib::ButtonMotionMask;
 const MOUSEMASK: c_long = BUTTONMASK | xlib::PointerMotionMask;
@@ -107,6 +108,7 @@ pub struct XWrap {
     pub atoms: XAtom,
     cursors: XCursor,
     colors: Colors,
+    pub xrandr_event_base: Option<i32>,
     pub managed_windows: Vec<xlib::Window>,
     pub focused_window: xlib::Window,
     pub tag_labels: Vec<String>,
@@ -228,6 +230,7 @@ impl XWrap {
             atoms,
             cursors,
             colors,
+            xrandr_event_base: None,
             managed_windows: vec![],
             focused_window: root,
             tag_labels: vec![],
@@ -296,7 +299,22 @@ impl XWrap {
             );
         }
 
+        // Subscribe to xlib and xrandr events
         self.subscribe_to_event(root, ROOT_EVENT_MASK);
+        if let Ok(xrandr) = Xrandr::open() {
+            unsafe {
+                (xrandr.XRRSelectInput)(self.display, root, XRANDR_EVENT_MASK);
+
+                // Set xrandr event base (used in event translation)
+                self.xrandr_event_base = Some(0);
+                (xrandr.XRRQueryExtension)(
+                    self.display,
+                    self.xrandr_event_base.as_mut().unwrap(),
+                    &mut 0,
+                );
+            }
+            tracing::trace!("Xrandr extension available. Xrandr events requested.");
+        }
 
         // EWMH compliance.
         unsafe {


### PR DESCRIPTION
# Description

Update workspace configuration on `XRRCrtcChangeNotifyEvent`s from Xrandr (When anything of the monitor configuration gets changed).

# State of draft
- [x] Read `XRRCrtcChangeNotifyEvent`s from xlib Events
- [ ] Update workspace(s) corresponding to the Crtc

## Details about `XRRCrtcChangeNotifyEvent`
From my research, a **crtc** is a virtual output that gets rendered by X11, whilst an **output** is a reference to the actual monitor (or similar, I am not really sure about that). The **screen** is the entire rendered area, i.e. everything covered by the DISPLAY env variable.

An `XRRCrtcChangeNotifyEvent` gets emitted, when one of said crtc's is changed. So for example, when a output is disabled, is moved, or the resolution changes. It also gets emitted for crtc that automatically move in place for the disabled crtc/output (beacause one crtc must always be at `x:0, y:0`). 


## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
