### PR TITLE
Improve performance of `set_layout`

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -431,35 +431,35 @@ fn set_layout(layout: Layout, state: &mut State) -> Option<bool> {
             None => false,
         };
         if !is_focused_floating {
-            let mut to_focus: Option<Window> = None;
+            let mut to_focus = None;
 
             if layout == Layout::Monocle {
                 to_focus = state
                     .windows
                     .iter()
-                    .find(|w| w.has_tag(&tag_id) && w.is_managed() && !w.floating())
-                    .cloned();
+                    .find(|w| w.has_tag(&tag_id) && w.is_managed() && !w.floating());
             } else if layout == Layout::MainAndDeck {
-                let tags_windows = state
-                    .windows
-                    .iter()
-                    .filter(|w| w.has_tag(&tag_id) && w.is_managed() && !w.floating())
-                    .collect::<Vec<&Window>>();
-                if let (Some(mw), Some(tdw)) = (tags_windows.get(0), tags_windows.get(1)) {
-                    // If the focused window is the main or the top of the deck, we don't do
-                    // anything.
-                    if let Some(&Some(h)) = focused_window {
+                if let Some(&Some(h)) = focused_window {
+                    let mut tags_windows = state
+                        .windows
+                        .iter()
+                        .filter(|w| w.has_tag(&tag_id) && w.is_managed() && !w.floating());
+
+                    let mw = tags_windows.next();
+                    let tdw = tags_windows.next();
+
+                    if let (Some(mw), Some(tdw)) = (mw, tdw) {
+                        // If the focused window is the main or the top of the deck, we don't do
+                        // anything.
                         if mw.handle != h && tdw.handle != h {
-                            if let Some(w) = tags_windows.get(1).copied() {
-                                to_focus = Some(w.clone());
-                            }
+                            to_focus = Some(tdw);
                         }
                     }
                 }
             }
 
-            if let Some(w) = to_focus {
-                state.focus_window(&w.handle);
+            if let Some(handle) = to_focus.map(|w| w.handle) {
+                state.focus_window(&handle);
             }
         }
     }


### PR DESCRIPTION
# Description

(Yet more performance PRs :pleading_face:  please bear with me)

Attempts to improve performance of `set_layout`  by not allocating stuff on the heap, hopefully reducing latency

## Changes:

```rust
           let tags_windows = state
                    .windows
                    .iter()
                    .filter(|w| w.has_tag(&tag_id) && w.is_managed() && !w.floating())
                    .collect::<Vec<&Window>>();
```

Here we were allocating a Vec of Window references when we only need the first two results of this filter, which we can do from Iterators alone

```rust
if let Some(w) = tags_windows.get(1).copied() {
      to_focus = Some(w.clone());
}
```

`to_focus` now gets set to `tdw` directly since `tdw` was the second element of the list anyways. `to_focus` is now just a reference to `Window`, since we'll just need its handle at the end of the function

I also moved up the `focused_window.is_some()` check since we don't have to work to do if it's None

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
