### PR TITLE
Less latency to get XScreens and XRootOfScreens

### DIFF
--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -634,7 +634,6 @@ impl XWrap {
 
     /// Returns all the roots of the display.
     // `XRootWindowOfScreen`: https://tronche.com/gui/x/xlib/display/screen-information.html#RootWindowOfScreen
-    #[must_use]
     fn get_roots(&self) -> impl Iterator<Item = xlib::Window> + '_ {
         self.get_xscreens()
             .map(|mut s| unsafe { (self.xlib.XRootWindowOfScreen)(&mut s) })
@@ -725,16 +724,12 @@ impl XWrap {
     /// Returns all the xscreens of the display.
     // `XScreenCount`: https://tronche.com/gui/x/xlib/display/display-macros.html#ScreenCount
     // `XScreenOfDisplay`: https://tronche.com/gui/x/xlib/display/display-macros.html#ScreensOfDisplay
-    #[must_use]
     fn get_xscreens(&self) -> impl Iterator<Item = xlib::Screen> + '_ {
         let screen_count = unsafe { (self.xlib.XScreenCount)(self.display) };
 
         let screen_ids = 0..screen_count;
 
-        screen_ids.map(|screen_id| {
-            let screen = unsafe { *(self.xlib.XScreenOfDisplay)(self.display, screen_id) };
-
-            screen
-        })
+        screen_ids
+            .map(|screen_id| unsafe { *(self.xlib.XScreenOfDisplay)(self.display, screen_id) })
     }
 }

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -269,11 +269,8 @@ impl XWrap {
                 .collect()
         } else {
             // NON-XINERAMA
-            let roots: Result<Vec<xlib::XWindowAttributes>, _> = self
-                .get_roots()
-                .iter()
-                .map(|w| self.get_window_attrs(*w))
-                .collect();
+            let roots: Result<Vec<xlib::XWindowAttributes>, _> =
+                self.get_roots().map(|w| self.get_window_attrs(w)).collect();
             let roots = roots.expect("Error: No screen were detected");
             roots.iter().map(Screen::from).collect()
         }
@@ -638,11 +635,9 @@ impl XWrap {
     /// Returns all the roots of the display.
     // `XRootWindowOfScreen`: https://tronche.com/gui/x/xlib/display/screen-information.html#RootWindowOfScreen
     #[must_use]
-    fn get_roots(&self) -> Vec<xlib::Window> {
+    fn get_roots(&self) -> impl Iterator<Item = xlib::Window> + '_ {
         self.get_xscreens()
-            .into_iter()
             .map(|mut s| unsafe { (self.xlib.XRootWindowOfScreen)(&mut s) })
-            .collect()
     }
 
     /// Returns a text property for a window.
@@ -731,13 +726,15 @@ impl XWrap {
     // `XScreenCount`: https://tronche.com/gui/x/xlib/display/display-macros.html#ScreenCount
     // `XScreenOfDisplay`: https://tronche.com/gui/x/xlib/display/display-macros.html#ScreensOfDisplay
     #[must_use]
-    fn get_xscreens(&self) -> Vec<xlib::Screen> {
-        let mut screens = Vec::new();
+    fn get_xscreens(&self) -> impl Iterator<Item = xlib::Screen> + '_ {
         let screen_count = unsafe { (self.xlib.XScreenCount)(self.display) };
-        for screen_id in 0..(screen_count) {
+
+        let screen_ids = 0..screen_count;
+
+        screen_ids.map(|screen_id| {
             let screen = unsafe { *(self.xlib.XScreenOfDisplay)(self.display, screen_id) };
-            screens.push(screen);
-        }
-        screens
+
+            screen
+        })
     }
 }

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -30,7 +30,7 @@ impl State {
             .find(|ws| ws.is_displaying(&window))
             .map(|ws| ws.id)
         {
-            let _ = self.focus_workspace_work(workspace_id);
+            _ = self.focus_workspace_work(workspace_id);
         }
 
         // Make sure the focused window's tag is focused.


### PR DESCRIPTION
# Description

Allows for iterating through the user's XScreens and XRootOfScreens without allocating on the heap

Fixes #(issue)

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
