### PR TITLE
Simplify async tests with `tokio::test`

### DIFF
--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -114,12 +114,8 @@ mod test {
     use crate::Manager;
     use tokio::io::{AsyncBufReadExt, BufReader};
 
-    #[test]
-    fn multiple_peers() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(multiple_peers_async());
-    }
-    async fn multiple_peers_async() {
+    #[tokio::test]
+    async fn multiple_peers() {
         let manager = Manager::new_test(vec![]);
         let state = &manager.state;
 
@@ -161,12 +157,8 @@ mod test {
         state_socket.shutdown().await;
     }
 
-    #[test]
-    fn get_update() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(get_update_async());
-    }
-    async fn get_update_async() {
+    #[tokio::test]
+    async fn get_update() {
         let manager = Manager::new_test(vec![]);
         let state = &manager.state;
 
@@ -194,12 +186,8 @@ mod test {
         state_socket.shutdown().await;
     }
 
-    #[test]
-    fn socket_cleanup() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(socket_cleanup_async());
-    }
-    async fn socket_cleanup_async() {
+    #[tokio::test]
+    async fn socket_cleanup() {
         let socket_file = temp_path().await.unwrap();
         let mut state_socket = StateSocket::default();
         state_socket.listen(socket_file.clone()).await.unwrap();
@@ -207,12 +195,8 @@ mod test {
         assert!(!socket_file.exists());
     }
 
-    #[test]
-    fn socket_already_bound() {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(socket_already_bound_async());
-    }
-    async fn socket_already_bound_async() {
+    #[tokio::test]
+    async fn socket_already_bound() {
         let socket_file = temp_path().await.unwrap();
         let mut old_socket = StateSocket::default();
         old_socket.listen(socket_file.clone()).await.unwrap();


### PR DESCRIPTION
# Description

Simple stylistic PR to simplify `state_socket` tests through `tokio::test`.

I'm not sure if the `block_on`s were intentional for some specific reason, please ignore the PR if they were. The tests remain the same other than that

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
