### PR TITLE
Make configuration errors more visible

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<()> {
             config.check_keybinds(verbose);
         }
         Err(e) => {
-            println!("Configuration failed. Reason: {e:?}");
+            println!("\x1b[1;91mERROR:\x1b[0m\x1b[1m Configuration failed. Reason: {e:?}");
         }
     }
     println!("\x1b[0;94m::\x1b[0m Checking environment . . .");


### PR DESCRIPTION
# Description

I had a bad configuration (which I noticed because default config was used instead), so I ran `leftwm-check` to check the problem, and at first I thought there was a bug and it didn't catch the error, but it turned out that I just missed the error because it doesn't bring attention to itself (compared to theme errors).

![configuration_error](https://github.com/leftwm/leftwm/assets/19240800/94c122e0-f986-4658-8e01-5a1c6b0ac80d)

WDYT about making it more visible just like some other errors?

![configuration_error_after](https://github.com/leftwm/leftwm/assets/19240800/a1954a19-14d9-4c1d-b1e7-4a9e8a8f8f96)



## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
