### PR TITLE
docs(themes/basic_eww): correct writing and improve formatting

### DIFF
--- a/themes/basic_eww/README.md
+++ b/themes/basic_eww/README.md
@@ -6,4 +6,4 @@ It is also possible to symlink instead of copy, though `eww` isn't to happy abou
 
 The legacy `eww` example was removed here. If you are still using that, pleas refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
 
-Since `eww` is still rapidly changing, if stuff breaks please check their [github](https://github.com/elkowar/eww) for documentation on changes and existing issues.
+Since `eww` is still rapidly changing, if stuff breaks please check their [GitHub](https://github.com/elkowar/eww) for documentation on changes and existing issues.

--- a/themes/basic_eww/README.md
+++ b/themes/basic_eww/README.md
@@ -2,7 +2,7 @@ This is a very basic README, merely containing a bunch of heads-up notes for usi
 
 **Important:**
 Copy the `eww-bar` folder to `~/.config/eww/` otherwise every `eww` command needs to pass the path to the folder where the `eww.yuck` and `eww.scss` files are located.
-It is also possible to symlink instead of copy, though `eww` isn't too happy about this and will log some errors, even though working just fine.
+It is also possible to symlink instead of copy, though `eww` isn't too happy about this and will log some errors. However, `eww` should still work correctly.
 
 The legacy `eww` example was removed here. If you are still using that, please refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
 

--- a/themes/basic_eww/README.md
+++ b/themes/basic_eww/README.md
@@ -1,6 +1,6 @@
 This is a very basic README, merely containing a bunch of heads-up notes for using `eww` with `leftwm`
 
-Important:
+**Important:**
 Copy the `eww-bar` folder to `~/.config/eww/` otherwise every `eww` command needs to pass the path to the folder where the `eww.yuck` and `eww.scss` files are located.
 It is also possible to symlink instead of copy, though `eww` isn't to happy about this and will log some errors, even though working just fine.
 

--- a/themes/basic_eww/README.md
+++ b/themes/basic_eww/README.md
@@ -4,6 +4,6 @@ Important:
 Copy the `eww-bar` folder to `~/.config/eww/` otherwise every `eww` command needs to pass the path to the folder where the `eww.yuck` and `eww.scss` files are located.
 It is also possible to symlink instead of copy, though `eww` isn't to happy about this and will log some errors, even though working just fine.
 
-The legacy eww example was removed here. If you are still using that, pleas refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
+The legacy `eww` example was removed here. If you are still using that, pleas refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
 
 Since `eww` is still rapidly changing, if stuff breaks please check their [github](https://github.com/elkowar/eww) for documentation on changes and existing issues.

--- a/themes/basic_eww/README.md
+++ b/themes/basic_eww/README.md
@@ -2,8 +2,8 @@ This is a very basic README, merely containing a bunch of heads-up notes for usi
 
 **Important:**
 Copy the `eww-bar` folder to `~/.config/eww/` otherwise every `eww` command needs to pass the path to the folder where the `eww.yuck` and `eww.scss` files are located.
-It is also possible to symlink instead of copy, though `eww` isn't to happy about this and will log some errors, even though working just fine.
+It is also possible to symlink instead of copy, though `eww` isn't too happy about this and will log some errors, even though working just fine.
 
-The legacy `eww` example was removed here. If you are still using that, pleas refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
+The legacy `eww` example was removed here. If you are still using that, please refer to the [leftwm-contrib repo](https://github.com/leftwm/leftwm-contrib/tree/main/examples/basic_eww/legacy_eww_xml_config).
 
 Since `eww` is still rapidly changing, if stuff breaks please check their [GitHub](https://github.com/elkowar/eww) for documentation on changes and existing issues.


### PR DESCRIPTION
# Description

Includes several changes to improve the `README.md` of the `themes/basic_eww` directory. It corrects phrasing, fixes typos, corrects the spelling of `GitHub`, highlights an important note, and adds backticks to format `eww`. 

These changes enhance the clarity and accuracy of the documentation.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
