### PR TITLE
fix `template.liquid` for `basic_lemonbar` example theme

### DIFF
--- a/themes/basic_lemonbar/template.liquid
+++ b/themes/basic_lemonbar/template.liquid
@@ -19,4 +19,4 @@
 %{c}
 {{ window_title }}
 %{r}
-{{ localtime }}   
+{{ "now" | date "%H:%M" }}   


### PR DESCRIPTION
# Description

as raised on discord, the template was outdated.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

The `liquid templating` section in the wiki should be checked, if it mentions the deprected `{{ localtime }}`

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
