### PR TITLE
Improvements to leftwm-log

### DIFF
--- a/leftwm/src/bin/leftwm-log.rs
+++ b/leftwm/src/bin/leftwm-log.rs
@@ -6,6 +6,7 @@ fn main() {
     let follow = matches.get_flag("follow");
     let level = matches.get_count("verbose");
 
+    #[allow(unreachable_patterns)]
     match matches.get_one::<Id>("log").map(clap::Id::as_str) {
         #[cfg(feature = "journald-log")]
         Some("journald") | None => journald_log(follow, level),

--- a/leftwm/src/bin/leftwm-log.rs
+++ b/leftwm/src/bin/leftwm-log.rs
@@ -4,14 +4,15 @@ use std::process::{exit, Command};
 fn main() {
     let matches = get_command().get_matches();
     let follow = matches.get_flag("follow");
+    let level = matches.get_count("verbose");
 
     match matches.get_one::<Id>("log").map(clap::Id::as_str) {
         #[cfg(feature = "journald-log")]
-        Some("journald") | None => journald_log(follow),
+        Some("journald") | None => journald_log(follow, level),
         #[cfg(feature = "sys-log")]
         Some("syslog") | None => syslog(follow),
         #[cfg(feature = "file-log")]
-        Some("file") | None => file_log(follow),
+        Some("file") | None => file_log(follow, level),
         #[cfg(not(any(feature = "journald-log", feature = "sys-log", feature = "file-log")))]
         _ => {
             eprintln!("Failed to execute: logging not enabled");
@@ -30,6 +31,7 @@ fn get_command() -> clap::Command {
             arg!(-S --syslog "use syslog (default if built with no journald support)"),
             arg!(-F --file "use file (default if built with no syslog support)"),
             arg!(-f --follow "output appended data as the log grows"),
+            arg!(-v --verbose... "verbosity level"),
         ])
         .group(
             ArgGroup::new("log")
@@ -39,12 +41,13 @@ fn get_command() -> clap::Command {
 }
 
 #[cfg(feature = "journald-log")]
-fn journald_log(follow: bool) {
-    let flag = if follow { " -f" } else { "" };
+fn journald_log(follow: bool, level: u8) {
+    let follow_flag = if follow { " -f" } else { "" };
+    let level_flag = level + 4; // Default level is warn (4)
     match &mut Command::new("/bin/sh")
         .args([
             "-c",
-            format!("journalctl{flag} $(which leftwm-worker) $(which lefthk-worker) $(which leftwm-command)").as_str(),
+            format!("journalctl{follow_flag} -p {level_flag} $(which leftwm-worker) $(which lefthk-worker) $(which leftwm-command)").as_str(),
         ])
         .spawn()
     {
@@ -81,18 +84,24 @@ fn syslog(follow: bool) {
 }
 
 #[cfg(feature = "file-log")]
-fn file_log(follow: bool) {
-    let cmd = match follow {
-        true => "tail -f",
-        false => "cat",
+fn file_log(follow: bool, level: u8) {
+    let cmd = if follow { "tail -f" } else { "cat" };
+    let filter = match level {
+        0 => "ERROR|WARN",
+        1 => "ERROR|WARN|INFO",
+        2 => "ERROR|WARN|INFO|DEBUG",
+        _ => "ERROR|WARN|INFO|DEBUG|TRACE",
     };
+    const TIME_REGEX: &'static str =
+        "[0-9]{4}-[01][1-9]-[1-3][0-9]T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{6}Z.{10}";
     match {
         let file_path = leftwm::utils::log::file::get_log_path();
-        println!("output from {}:", file_path.display());
+        println!("Output from {file_path} - {filter}:");
         &mut Command::new("/bin/sh")
             .args([
                 "-c",
-                format!("{cmd} {}", file_path.to_str().unwrap()).as_str(),
+                format!("{cmd} {file_path} | grep -E \"{TIME_REGEX}{filter}\"")
+                .as_str(),
             ])
             .spawn()
     } {

--- a/leftwm/src/bin/leftwm-log.rs
+++ b/leftwm/src/bin/leftwm-log.rs
@@ -92,16 +92,17 @@ fn file_log(follow: bool, level: u8) {
         2 => "ERROR|WARN|INFO|DEBUG",
         _ => "ERROR|WARN|INFO|DEBUG|TRACE",
     };
-    const TIME_REGEX: &'static str =
+    const TIME_REGEX: &str =
         "[0-9]{4}-[01][1-9]-[1-3][0-9]T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{6}Z.{10}";
     match {
         let file_path = leftwm::utils::log::file::get_log_path();
+        // ugly shadowing to make the borrow checker happy
+        let file_path = file_path.to_string_lossy();
         println!("Output from {file_path} - {filter}:");
         &mut Command::new("/bin/sh")
             .args([
                 "-c",
-                format!("{cmd} {file_path} | grep -E \"{TIME_REGEX}{filter}\"")
-                .as_str(),
+                format!("{cmd} {file_path} | grep -E \"{TIME_REGEX}{filter}\"").as_str(),
             ])
             .spawn()
     } {


### PR DESCRIPTION
# Description

General improvements for leftwm-log
- [x] Prettier matching solution and locking all functions behind a feature gate
- [ ] Requested verbosity option
  Default level is WARN, each `-v` increases it up to `-vvv` with TRACE.
  - [ ] can't do syslog implementation

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

**TODO**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
