### PR TITLE
Fix ron options on check theme ron file

### DIFF
--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -366,7 +366,9 @@ fn check_theme_ron(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
             println!("Found: {}", filepath.display());
         }
 
-        match ron::from_str::<ThemeSetting>(&contents) {
+        let ron = Options::default()
+            .with_default_extension(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES);
+        match ron.from_str::<ThemeSetting>(&contents) {
             Ok(_) => {
                 if verbose {
                     println!("The theme file looks OK.");


### PR DESCRIPTION
# Description

leftwm check is throwing

```
ERROR: Could not parse theme file: 2:17: Expected option
```

On a theme file without `#![enable(implicit_some)]`

This PR change check to use same options used by `load_theme_file` function

## Type of change

- [X] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

N/A

# Checklist:

- [X] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
