### PR TITLE
feat: Derive `leftwm-command -l` list from BaseCommand enum using Proc Macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "lefthk-core",
  "leftwm-core",
  "leftwm-layouts",
+ "leftwm-macros",
  "liquid",
  "mio",
  "nix 0.26.2",
@@ -619,6 +620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ad24b8d3f59f0176ba4dc57a90955b16fd6e6c8a4fa384abf97f3861db6d073"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "leftwm-macros"
+version = "0.4.2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 default-members = ["leftwm", "leftwm-core", "display-servers/xlib-display-server"]
-members = ["leftwm", "leftwm-core", "display-servers/xlib-display-server"]
+members = ["leftwm", "leftwm-macros", "leftwm-core", "display-servers/xlib-display-server"]
 
 [profile.optimized]
 inherits = "release"

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -84,7 +84,7 @@ pub enum Command {
     Other(String),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum FocusDeltaBehavior {
     Default,
     IgnoreUsed,

--- a/leftwm-macros/Cargo.toml
+++ b/leftwm-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "leftwm-macros"
+version = "0.4.2"
+rust-version = "1.65.0"
+authors = ["Lex Childs <lexchilds@gmail.com>"]
+categories = ["window manager"]
+edition = "2021"
+keywords = ["wm", "window", "manager"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/leftwm/leftwm"
+description = "A window manager for Adventurers"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = {version = "1", features = ["nightly"]}
+quote = "1"
+syn = {version = "2.0.17", features = ["full", "parsing", "fold"]}

--- a/leftwm-macros/src/lib.rs
+++ b/leftwm-macros/src/lib.rs
@@ -19,15 +19,13 @@ fn parse_enum_doc_comment(attrs: &[syn::Attribute]) -> String {
     for attr in attrs {
         let meta = &attr.meta;
         if let syn::Meta::NameValue(meta) = meta {
-            if let syn::Expr::Lit(syn::ExprLit { lit, .. }) = &meta.value {
-                if let syn::Lit::Str(l) = lit {
-                    ret.push_str(&format!("\n          {}", l.value().trim()));
-                }
+            if let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(l), .. }) = &meta.value {
+                ret.push_str(&format!("\n          {}", l.value().trim()));
             }
         }
     }
 
-    return ret;
+    ret
 }
 
 #[proc_macro_derive(VariantNames)]
@@ -49,9 +47,9 @@ pub fn derive_variant_names(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input as DeriveInput);
 
     // Get the enum name for use later
-    let ref name = input.ident;
+    let name = &input.ident;
     // Get the variants
-    let ref data = input.data;
+    let data = &input.data;
 
     let mut variant_checker_functions;
 
@@ -68,7 +66,7 @@ pub fn derive_variant_names(input: TokenStream) -> TokenStream {
             for variant in &data_enum.variants {
                 let doc = parse_enum_doc_comment(&variant.attrs);
 
-                names.push(format!("{} {}", variant.ident.to_string(), doc))
+                names.push(format!("{} {}", variant.ident, doc))
             }
 
             // Construct the variant_names function for the Enum using `names`

--- a/leftwm-macros/src/lib.rs
+++ b/leftwm-macros/src/lib.rs
@@ -19,7 +19,11 @@ fn parse_enum_doc_comment(attrs: &[syn::Attribute]) -> String {
     for attr in attrs {
         let meta = &attr.meta;
         if let syn::Meta::NameValue(meta) = meta {
-            if let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(l), .. }) = &meta.value {
+            if let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(l),
+                ..
+            }) = &meta.value
+            {
                 ret.push_str(&format!("\n          {}", l.value().trim()));
             }
         }

--- a/leftwm-macros/src/lib.rs
+++ b/leftwm-macros/src/lib.rs
@@ -1,0 +1,76 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Error};
+
+macro_rules! derive_error {
+    ($string: tt) => {
+        Error::new(Span::call_site(), $string)
+            .to_compile_error()
+            .into()
+    };
+}
+
+#[proc_macro_derive(VariantNames)]
+/// Returns a Vec<String> for the Enum to which it applies.
+///
+/// # Example:
+/// ```
+/// #[derive(VariantNames)]
+/// enum LeftWm {
+///   One,
+///   Two
+/// }
+///
+/// assert_eq!(LeftWm::variant_names(), vec!["One", "Two"]);
+/// ```
+///
+/// The purpose of this macro is for serializing options of the BaseCommand for `leftwm-command`
+pub fn derive_variant_names(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input as DeriveInput);
+
+    // Get the enum name for use later
+    let ref name = input.ident;
+    // Get the variants
+    let ref data = input.data;
+
+    let mut variant_checker_functions;
+
+    match data {
+        // Only if data is an enum, we do parsing
+        Data::Enum(data_enum) => {
+            // data_enum is of type syn::DataEnum
+            // https://doc.servo.org/syn/struct.DataEnum.html
+
+            variant_checker_functions = TokenStream2::new();
+
+            // For each variant, push its name onto `names`
+            let mut names = Vec::new();
+
+            for variant in &data_enum.variants {
+                names.push(variant.ident.to_string())
+            }
+
+            // Construct the variant_names function for the Enum using `names`
+            variant_checker_functions.extend(quote! {
+                pub fn variant_names() -> Vec<String> {
+                    return vec![#(#names,)*].into_iter().map(String::from).collect();
+                }
+            });
+        }
+        _ => return derive_error!("VariantNames can only be implemented for enums"),
+    };
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let expanded = quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            #variant_checker_functions
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.21"
 git-version = "0.3.5"
 lefthk-core = { version = '0.1.8', optional = true }
 leftwm-core = { path = "../leftwm-core", version = '0.4.2' }
+leftwm-macros = {path = "../leftwm-macros", version = '0.4.2'}
 leftwm-layouts = "0.8.4"
 liquid = "0.26.0"
 mio = "0.8.0"

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{arg, command};
 use leftwm_core::CommandPipe;
+use leftwm::BaseCommand;
 use leftwm_core::ReturnPipe;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -68,6 +69,8 @@ fn print_commandlist() {
         "
         Available Commands:
 
+        {}
+
         Commands without arguments:
 
         UnloadTheme
@@ -122,7 +125,7 @@ fn print_commandlist() {
 
         For more information please visit:
         https://github.com/leftwm/leftwm/wiki/External-Commands
-         "
+         ", BaseCommand::variant_names().join("\n        ")
     );
 }
 

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{arg, command};
-use leftwm_core::CommandPipe;
 use leftwm::BaseCommand;
+use leftwm_core::CommandPipe;
 use leftwm_core::ReturnPipe;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -78,7 +78,8 @@ fn print_commandlist() {
 
     For more information please visit:
     https://github.com/leftwm/leftwm/wiki/External-Commands
-         ", BaseCommand::variant_names().join("\n        ")
+         ",
+        BaseCommand::variant_names().join("\n        ")
     );
 }
 

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -67,64 +67,17 @@ fn get_command() -> clap::Command {
 fn print_commandlist() {
     println!(
         "
-        Available Commands:
-
+    Available Commands:
         {}
+        SendWorkspaceToTag     Args: <workspace_index> <tag_index> (int)
+        SendWindowToTag        Args: <tag_index> (int)
 
-        Commands without arguments:
-
-        UnloadTheme
-        SoftReload
-        ToggleFullScreen
-        ToggleSticky
-        SwapScreens
-        MoveWindowToNextTag
-        MoveWindowToPreviousTag
-        MoveWindowToLastWorkspace
-        MoveWindowToNextWorkspace
-        MoveWindowToPreviousWorkspace
-        FloatingToTile
-        TileToFloating
-        ToggleFloating
-        MoveWindowUp
-        MoveWindowDown
-        MoveWindowTop
-        FocusWindowUp
-        FocusWindowDown
-        FocusWindowTop
-        FocusWorkspaceNext
-        FocusWorkspacePrevious
-        IncreaseMainSize
-        DecreaseMainSize
-        IncreaseMainCount
-        DecreaseMainCount
-        NextLayout
-        PreviousLayout
-        RotateTag
-        ReturnToLastTag
-        CloseWindow
-
-        Commands with arguments:
+    Note about commands with arguments:
             Use quotations for the command and arguments, like this:
             leftwm-command \"<command> <args>\"
 
-        LoadTheme              Args: <Path_to/theme.ron>
-            Note: `theme.toml` will be deprecated but stays for backwards compatibility for a while
-        AttachScratchPad       Args: <ScratchpadName>
-        ReleaseScratchPad      Args: <tag_index> or <ScratchpadName>
-        NextScratchPadWindow   Args: <ScratchpadName>
-        PrevScratchPadWindow   Args: <ScratchpadName>
-        ToggleScratchPad       Args: <ScratchpadName>
-        SendWorkspaceToTag     Args: <workspaxe_index> <tag_index> (int)
-        SendWindowToTag        Args: <tag_index> (int)
-        SetLayout              Args: <LayoutName>
-        SetMarginMultiplier    Args: <multiplier-value> (float)
-        FocusWindow            Args: <WindowClass> or <visible-window-index> (int)
-        FocusNextTag           Args: <behavior> (string, optional)
-        FocusPreviousTag       Args: <behavior> (string, optional)
-
-        For more information please visit:
-        https://github.com/leftwm/leftwm/wiki/External-Commands
+    For more information please visit:
+    https://github.com/leftwm/leftwm/wiki/External-Commands
          ", BaseCommand::variant_names().join("\n        ")
     );
 }

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-
+use leftwm_macros::VariantNames;
 /*  TODO this code is temporary. Due to the limitations of TOML we cannot serialize leftwm_core::Command
 *      easily. If we replace TOML by JSON/JSON5/YAML we will be able to remove this code and a
 *      bunch of validation in leftwm-check.rs. This requires to deprecate the TOML config file,
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 // Because this is temporary, we will allow this clippy lint to be bypassed
 #[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(VariantNames, Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum BaseCommand {
     Execute,
     CloseWindow,

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use leftwm_macros::VariantNames;
+use serde::{Deserialize, Serialize};
 /*  TODO this code is temporary. Due to the limitations of TOML we cannot serialize leftwm_core::Command
 *      easily. If we replace TOML by JSON/JSON5/YAML we will be able to remove this code and a
 *      bunch of validation in leftwm-check.rs. This requires to deprecate the TOML config file,
@@ -18,10 +18,15 @@ pub enum BaseCommand {
     SwapTags,
     SoftReload,
     HardReload,
+    /// Args: <ScratchpadName>
     AttachScratchPad,
+    /// Args: <tag_index> or <ScratchpadName>
     ReleaseScratchPad,
+    /// Args: <ScratchpadName>
     NextScratchPadWindow,
+    /// Args: <ScratchpadName>
     PrevScratchPadWindow,
+    /// Args: <ScratchpadName>
     ToggleScratchPad,
     ToggleFullScreen,
     ToggleSticky,
@@ -34,14 +39,19 @@ pub enum BaseCommand {
     MoveWindowDown,
     MoveWindowTop,
     SwapWindowTop,
+    /// Args: <behavior> (string, optional)
     FocusNextTag,
+    /// Args: <behavior> (string, optional)
     FocusPreviousTag,
+    /// Args: <WindowClass> or <visible-window-index> (int)
     FocusWindow,
     FocusWindowUp,
     FocusWindowDown,
     FocusWindowTop,
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
+    /// Args: <tag_index> (int)
+    /// Note: Please use `SendWindowToTag` instead.
     MoveToTag,
     MoveWindowToNextTag,
     MoveWindowToPreviousTag,
@@ -50,17 +60,22 @@ pub enum BaseCommand {
     MoveWindowToPreviousWorkspace,
     NextLayout,
     PreviousLayout,
+    /// Args: <LayoutName>
     SetLayout,
     RotateTag,
+    /// Note: This is deprecated and will be dropped in a future release.
     IncreaseMainWidth, //deprecated
+    /// Note: This is deprecated and will be dropped in a future release.
     DecreaseMainWidth, //deprecated
     IncreaseMainSize,
     DecreaseMainSize,
     IncreaseMainCount,
     DecreaseMainCount,
+    /// Args: <multiplier-value> (float)
     SetMarginMultiplier,
-    // Custom commands
     UnloadTheme,
+    /// Args: <Path_to/theme.ron>
+    /// Note: `theme.toml` will be deprecated but stays for backwards compatibility for a while
     LoadTheme,
 }
 


### PR DESCRIPTION
# Description

Good afternoon,

This change implements #1095 by using a proc macro to collect the variants of the `BaseCommand` enum and their documentation comments for publication in `leftwm-command --list`.

Opens:
- [ ] Format: Is the format appropriate, or do we want to try for closer to what we have?
- [ ] Names: How do we want to handle variants which differ in name from what's expected, e.g. `GoToTag`, `SendWorkspaceToTag` or `SendWindowToTag`
- [ ] Do we want to derive from `Command` instead? Could then get the arguments for each.


Fixes #1095

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
