### PR TITLE
Add back output field to leftwm-state

### DIFF
--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Viewport {
     pub id: usize,
+    pub output: String,
     pub tag: String,
     pub h: u32,
     pub w: u32,
@@ -36,6 +37,7 @@ pub struct TagsForWorkspace {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DisplayWorkspace {
     pub id: usize,
+    pub output: String,
     pub h: u32,
     pub w: u32,
     pub x: i32,
@@ -100,6 +102,7 @@ fn viewport_into_display_workspace(
         .collect();
     DisplayWorkspace {
         id: viewport.id,
+        output: viewport.output.clone(),
         tags,
         h: viewport.h,
         w: viewport.w,
@@ -140,8 +143,18 @@ impl From<&State> for ManagerState {
                 .and_then(|tagid| state.layout_manager.layout_maybe(ws.id, tagid))
                 .map_or_else(|| String::from("N/A"), |layout| layout.name.clone());
 
+            let output = state
+                .screens
+                .iter()
+                .find(|s| s.id == Some(ws.id))
+                .map_or_else(
+                    || String::from("Not found (unreachable)"),
+                    |s| s.output.clone(),
+                );
+
             viewports.push(Viewport {
                 id: ws.id,
+                output,
                 tag: tag_label,
                 x: ws.xyhw.x(),
                 y: ws.xyhw.y(),


### PR DESCRIPTION
# Description

Fix an regression in #1043 that removed the output field from `leftwm-state`.

Fixes #1111

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: Independent clippy warnings were ignored.
