### PR TITLE
Misc clippy warnings

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -84,7 +84,7 @@ pub enum Command {
     Other(String),
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum FocusDeltaBehavior {
     Default,
     IgnoreUsed,

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -47,7 +47,7 @@ impl LayoutManager {
 
         let mut available_layouts_per_ws: HashMap<usize, Vec<Layout>> = HashMap::new();
 
-        for (i, ws) in config.workspaces().unwrap_or(vec![]).iter().enumerate() {
+        for (i, ws) in config.workspaces().unwrap_or_default().iter().enumerate() {
             if let Some(ws_layout_names) = &ws.layouts {
                 let wsid = i + 1;
                 for ws_layout_name in ws_layout_names {

--- a/leftwm-core/src/utils/return_pipe.rs
+++ b/leftwm-core/src/utils/return_pipe.rs
@@ -66,7 +66,7 @@ impl ReturnPipe {
         let display = env::var("DISPLAY")
             .ok()
             .and_then(|d| d.rsplit_once(':').map(|(_, r)| r.to_owned()))
-            .unwrap_or(String::from("0"));
+            .unwrap_or_else(|| String::from("0"));
 
         PathBuf::from(format!("return-{display}.pipe"))
     }

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -138,7 +138,8 @@ pub enum Error {
 async fn get_return_pipe() -> Result<ReturnPipe, Error> {
     let file_name = ReturnPipe::pipe_name();
 
-    let pipe_file = place_runtime_file(&file_name).or(Err(Error::CreateFile(file_name.clone())))?;
+    let pipe_file =
+        place_runtime_file(&file_name).map_err(|_| Error::CreateFile(file_name.clone()))?;
 
     ReturnPipe::new(pipe_file)
         .await


### PR DESCRIPTION
# Description

Fixing miscellaneous clippy warnings in the code.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.