### PR TITLE
Space comments consistently

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,6 @@ See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documen
 # Checklist:
 
 - [ ] Ran `make test-full` locally with no errors or warnings reported
-  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
+  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
 - [ ] Manual page has been updated accordingly
 - [ ] Wiki pages have been updated accordingly (to perform **after** merge)

--- a/display-servers/xlib-display-server/src/event_translate_client_message.rs
+++ b/display-servers/xlib-display-server/src/event_translate_client_message.rs
@@ -57,7 +57,7 @@ pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<Displa
         return None;
     }
 
-    //if the client is trying to toggle fullscreen without changing the window state, change it too
+    // if the client is trying to toggle fullscreen without changing the window state, change it too
     if event.message_type == xw.atoms.NetWMState
         && (event.data.get_long(1) == xw.atoms.NetWMStateFullscreen as c_long
             || event.data.get_long(2) == xw.atoms.NetWMStateFullscreen as c_long)
@@ -65,13 +65,13 @@ pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<Displa
         let set_fullscreen = event.data.get_long(0) == 1;
         let toggle_fullscreen = event.data.get_long(0) == 2;
         let mut states = xw.get_window_states_atoms(event.window);
-        //determine what to change the state to
+        // determine what to change the state to
         let fullscreen = if toggle_fullscreen {
             !states.contains(&xw.atoms.NetWMStateFullscreen)
         } else {
             set_fullscreen
         };
-        //update the list of states
+        // update the list of states
         if fullscreen {
             states.push(xw.atoms.NetWMStateFullscreen);
         } else {
@@ -79,11 +79,11 @@ pub fn from_event(xw: &XWrap, event: xlib::XClientMessageEvent) -> Option<Displa
         }
         states.sort_unstable();
         states.dedup();
-        //set the windows state
+        // set the windows state
         xw.set_window_states_atoms(event.window, &states);
     }
 
-    //update the window states
+    // update the window states
     if event.message_type == xw.atoms.NetWMState {
         let handle = event.window.into();
         let mut change = WindowChange::new(handle);

--- a/display-servers/xlib-display-server/src/event_translate_property_notify.rs
+++ b/display-servers/xlib-display-server/src/event_translate_property_notify.rs
@@ -106,7 +106,7 @@ fn build_change_for_size_hints(xw: &XWrap, window: xlib::Window) -> Option<Windo
     let mut change = WindowChange::new(handle);
     let hint = xw.get_hint_sizing_as_xyhw(window)?;
     if hint.x.is_none() && hint.y.is_none() && hint.w.is_none() && hint.h.is_none() {
-        //junk hint; change change anything
+        // junk hint; change change anything
         return None;
     }
     let mut xyhw = Xyhw::default();

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -29,7 +29,7 @@ impl DisplayServer for XlibDisplayServer {
     fn new(config: &impl Config) -> Self {
         let mut wrap = XWrap::new();
 
-        wrap.init(config); //setup events masks
+        wrap.init(config); // setup events masks
 
         let root = wrap.get_default_root();
         let instance = Self {

--- a/display-servers/xlib-display-server/src/xatom.rs
+++ b/display-servers/xlib-display-server/src/xatom.rs
@@ -59,8 +59,8 @@ pub struct XAtom {
     pub NetCurrentDesktop: xlib::Atom,
     pub NetDesktopNames: xlib::Atom,
     pub NetWMDesktop: xlib::Atom,
-    pub NetWMStrutPartial: xlib::Atom, //net version - Reserve Screen Space
-    pub NetWMStrut: xlib::Atom,        //old version
+    pub NetWMStrutPartial: xlib::Atom, // net version - Reserve Screen Space
+    pub NetWMStrut: xlib::Atom,        // old version
 
     pub UTF8String: xlib::Atom,
 }

--- a/display-servers/xlib-display-server/src/xwrap/mouse.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mouse.rs
@@ -63,7 +63,7 @@ impl XWrap {
     // `XGrabPointer`: https://tronche.com/gui/x/xlib/input/XGrabPointer.html
     pub fn grab_pointer(&self, cursor: c_ulong) {
         unsafe {
-            //grab the mouse
+            // grab the mouse
             (self.xlib.XGrabPointer)(
                 self.display,
                 self.root,
@@ -82,7 +82,7 @@ impl XWrap {
     // `XUngrabPointer`: https://tronche.com/gui/x/xlib/input/XUngrabPointer.html
     pub fn ungrab_pointer(&self) {
         unsafe {
-            //release the mouse grab
+            // release the mouse grab
             (self.xlib.XUngrabPointer)(self.display, xlib::CurrentTime);
         }
     }

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -13,7 +13,7 @@ impl DisplayServer for MockDisplayServer {
         Self { screens: vec![] }
     }
 
-    //testing a couple mock event
+    // testing a couple mock event
     fn get_next_events(&mut self) -> Vec<DisplayEvent> {
         vec![]
     }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -239,8 +239,8 @@ fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {
     let tag_id = state.focus_manager.tag(0)?;
 
     if window_state == WindowState::Fullscreen {
-        //Going to fullscreen, so we save the window order
-        //or else, we restore it!
+        // Going to fullscreen, so we save the window order
+        // or else, we restore it!
         if toggle_to {
             let handles = state
                 .windows
@@ -385,7 +385,7 @@ fn return_to_last_tag(state: &mut State) -> Option<bool> {
 fn focus_window(state: &mut State, param: &str) -> Option<bool> {
     match param.parse::<usize>() {
         Ok(index) if index > 0 => {
-            //1-based index seems more user-friendly to me in this context
+            // 1-based index seems more user-friendly to me in this context
             let handle = state
                 .windows
                 .iter()
@@ -484,7 +484,7 @@ fn swap_tags(state: &mut State) -> Option<bool> {
     if state.workspaces.len() >= 2 && state.focus_manager.workspace_history.len() >= 2 {
         let hist_a = *state.focus_manager.workspace_history.get(0)?;
         let hist_b = *state.focus_manager.workspace_history.get(1)?;
-        //Update workspace tags
+        // Update workspace tags
         let mut temp = None;
         std::mem::swap(&mut state.workspaces.get_mut(hist_a)?.tag, &mut temp);
         std::mem::swap(&mut state.workspaces.get_mut(hist_b)?.tag, &mut temp);
@@ -541,7 +541,7 @@ fn set_layout(layout: &str, state: &mut State) -> Option<bool> {
     // When switching to Monocle or MainAndDeck layout while in Driven
     // or ClickTo focus mode, we check if the focus is given to a visible window.
     if state.focus_manager.behaviour != FocusBehaviour::Sloppy {
-        //if the currently focused window is floating, nothing will be done
+        // if the currently focused window is floating, nothing will be done
         let focused_window = state.focus_manager.window_history.get(0);
         let is_focused_floating = match state
             .windows
@@ -597,8 +597,8 @@ fn floating_to_tile(state: &mut State) -> Option<bool> {
     if window.must_float() {
         return None;
     }
-    //Not ideal as is_floating and must_float are connected so have to check
-    //them separately
+    // Not ideal as is_floating and must_float are connected so have to check
+    // them separately
     if !window.floating() {
         return None;
     }
@@ -617,8 +617,8 @@ fn tile_to_floating(state: &mut State) -> Option<bool> {
     if window.must_float() {
         return None;
     }
-    //Not ideal as is_floating and must_float are connected so have to check
-    //them separately
+    // Not ideal as is_floating and must_float are connected so have to check
+    // them separately
     if window.floating() {
         return None;
     }
@@ -998,7 +998,7 @@ mod tests {
             .iter()
             .any(|w| w.has_state(&WindowState::Fullscreen)));
 
-        //Mess with the window positions
+        // Mess with the window positions
         manager.state.windows.reverse();
 
         let actual = get_current_handles(&mut manager, Some(tag_id));
@@ -1046,7 +1046,7 @@ mod tests {
             .iter()
             .any(|w| w.has_state(&WindowState::Fullscreen)));
 
-        //Mess with the window positions
+        // Mess with the window positions
         manager.state.windows.reverse();
 
         assert!(manager.command_handler(&Command::GoToTag {
@@ -1088,7 +1088,7 @@ mod tests {
             2
         );
 
-        //Mess with the windows positions of the second tag
+        // Mess with the windows positions of the second tag
         let (mut windows_first_tag, mut windows_second_tag) =
             split_window_vec(manager.state.windows, first_tag);
         windows_second_tag.reverse();

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -124,7 +124,7 @@ impl State {
             .map(|w| w.handle);
         match handle_found {
             Some(found) => self.focus_window(&found),
-            //backup plan, move focus closest window in workspace
+            // backup plan, move focus closest window in workspace
             None => self.focus_closest_window(x, y),
         }
     }
@@ -224,7 +224,7 @@ impl State {
     }
 
     fn focus_workspace_work(&mut self, ws_id: usize) -> bool {
-        //no new history if no change
+        // no new history if no change
         if let Some(fws) = self.focus_manager.workspace(&self.workspaces) {
             if fws.id == ws_id {
                 return false;

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -700,7 +700,7 @@ mod tests {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string()], 1);
         manager.screen_create_handler(Screen::default());
         manager.state.layout_manager.set_layout(1, 1, MONOCLE);
-        //manager.state.tags.get_mut(1).unwrap().set_layout(String::from("Monocle"));
+        // manager.state.tags.get_mut(1).unwrap().set_layout(String::from("Monocle"));
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,

--- a/leftwm-core/src/handlers/window_resize_handler.rs
+++ b/leftwm-core/src/handlers/window_resize_handler.rs
@@ -21,7 +21,7 @@ fn process_window(window: &mut Window, offset_w: i32, offset_h: i32) {
     window.set_floating(true);
     let mut offset = window.get_floating_offsets().unwrap_or_default();
     let start = window.start_loc.unwrap_or_default();
-    //offset.clear_minmax();
+    // offset.clear_minmax();
     offset.set_w(start.w() + offset_w);
     offset.set_h(start.h() + offset_h);
     window.set_floating_offsets(Some(offset));

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -115,7 +115,7 @@ impl Tags {
     /// Get a list of all tags, including hidden ones.
     /// The hidden tags are at the end of the list.
     pub fn all(&self) -> Vec<&Tag> {
-        //&self.normal.append(&self.hidden)
+        // &self.normal.append(&self.hidden)
         let mut result: Vec<&Tag> = vec![];
         self.normal.iter().for_each(|tag| result.push(tag));
         self.hidden.iter().for_each(|tag| result.push(tag));
@@ -125,7 +125,7 @@ impl Tags {
     /// Get a list of all tags as mutable, including hidden ones.
     /// The hidden tags are at the end of the list
     pub fn all_mut(&mut self) -> Vec<&mut Tag> {
-        //&self.normal.append(&self.hidden)
+        // &self.normal.append(&self.hidden)
         let mut result: Vec<&mut Tag> = vec![];
         self.normal.iter_mut().for_each(|tag| result.push(tag));
         self.hidden.iter_mut().for_each(|tag| result.push(tag));

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -116,7 +116,7 @@ impl Window {
 
     pub fn set_floating(&mut self, value: bool) {
         if !self.is_floating && value && self.floating.is_none() {
-            //NOTE: We float relative to the normal position.
+            // NOTE: We float relative to the normal position.
             self.reset_float_offset();
         }
         self.is_floating = value;

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -141,7 +141,7 @@ impl Workspace {
     pub fn height(&self) -> i32 {
         let top = self.margin.top as f32;
         let bottom = self.margin.bottom as f32;
-        //Only one side
+        // Only one side
         let gutter = self.get_gutter(&Side::Top) + self.get_gutter(&Side::Bottom);
         self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32 - gutter
     }
@@ -152,7 +152,7 @@ impl Workspace {
     pub fn width(&self) -> i32 {
         let left = self.margin.left as f32;
         let right = self.margin.right as f32;
-        //Only one side
+        // Only one side
         let gutter = self.get_gutter(&Side::Left) + self.get_gutter(&Side::Right);
         self.xyhw_avoided.w() - (self.margin_multiplier * (left + right)) as i32 - gutter
     }

--- a/leftwm-core/src/models/xyhw.rs
+++ b/leftwm-core/src/models/xyhw.rs
@@ -250,15 +250,15 @@ impl Xyhw {
     pub const fn without(&self, other: &Self) -> Self {
         let mut without = *self;
         if other.w > other.h {
-            //horizontal trim
+            // horizontal trim
             if other.y > self.y + (self.h / 2) {
-                //bottom check
+                // bottom check
                 let bottom_over = (without.y + without.h) - other.y;
                 if bottom_over > 0 {
                     without.h -= bottom_over;
                 }
             } else {
-                //top check
+                // top check
                 let top_over = (other.y + other.h) - without.y;
                 if top_over > 0 {
                     without.y += top_over;
@@ -266,16 +266,16 @@ impl Xyhw {
                 }
             }
         } else {
-            //vertical trim
+            // vertical trim
             let left_over = (other.x + other.w) - without.x;
             if other.x > self.x + (self.w / 2) {
-                //right check
+                // right check
                 let right_over = (without.x + without.w) - other.x;
                 if right_over > 0 {
                     without.w -= right_over;
                 }
             } else {
-                //left check
+                // left check
                 if left_over > 0 {
                     without.x += left_over;
                     without.w -= left_over;

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -284,7 +284,7 @@ impl DesktopEntry {
     }
 
     fn split_line(line: &str) -> Option<(&str, &str)> {
-        line.find('=')?; //Check we have an equals, if we don't return None
+        line.find('=')?; // Check we have an equals, if we don't return None
         line.split_once('=')
     }
     fn split_to_set(value: &str) -> HashSet<String> {

--- a/leftwm-core/src/utils/modmask_lookup.rs
+++ b/leftwm-core/src/utils/modmask_lookup.rs
@@ -10,7 +10,7 @@ pub fn into_modmask(keys: &[String]) -> ModMask {
     for s in keys {
         mask |= into_mod(s);
     }
-    //clean the mask
+    // clean the mask
     mask &= !(xlib::Mod2Mask | xlib::LockMask);
     mask & (xlib::ShiftMask
         | xlib::ControlMask
@@ -27,8 +27,8 @@ pub fn into_mod(key: &str) -> ModMask {
         "Shift" => xlib::ShiftMask,
         "Control" => xlib::ControlMask,
         "Mod1" | "Alt" => xlib::Mod1Mask,
-        //"Mod2" => xlib::Mod2Mask,     // NOTE: we are ignoring the state of Numlock
-        //"NumLock" => xlib::Mod2Mask,  // this is left here as a reminder
+        // "Mod2" => xlib::Mod2Mask,     // NOTE: we are ignoring the state of Numlock
+        // "NumLock" => xlib::Mod2Mask,  // this is left here as a reminder
         "Mod3" => xlib::Mod3Mask,
         "Mod4" | "Super" => xlib::Mod4Mask,
         "Mod5" => xlib::Mod5Mask,

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -52,8 +52,8 @@ pub enum BaseCommand {
     PreviousLayout,
     SetLayout,
     RotateTag,
-    IncreaseMainWidth, //deprecated
-    DecreaseMainWidth, //deprecated
+    IncreaseMainWidth, // deprecated
+    DecreaseMainWidth, // deprecated
     IncreaseMainSize,
     DecreaseMainSize,
     IncreaseMainCount,

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -229,8 +229,8 @@ impl Default for Config {
             focus_new_windows: true, // default behaviour: focuses windows on creation
             single_window_border: true,
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,
-            modkey: "Mod4".to_owned(),     //win key
-            mousekey: Some("Mod4".into()), //win key
+            modkey: "Mod4".to_owned(),     // win key
+            mousekey: Some("Mod4".into()), // win key
             #[cfg(feature = "lefthk")]
             keybind: commands,
             theme_setting: ThemeSetting::default(),

--- a/themes/basic_eww/eww-bar/eww.scss
+++ b/themes/basic_eww/eww-bar/eww.scss
@@ -1,5 +1,5 @@
 * {
-  all: unset; //Unsets everything so you can style everything from scratch
+  all: unset; // Unsets everything so you can style everything from scratch
 }
 
 //Global Styles


### PR DESCRIPTION
# Description

Spaced the doc comments consistently
Also silently fixing a self-made typo

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
