### PR TITLE
add `ToggleMaximized` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implemented the new [leftwm-layouts](https://github.com/leftwm/leftwm-layouts) library (via #1000 by @hertg)
 - Added `IncreaseMainSize` / `DecreaseMainSize` as a replacement for the deprecated `IncreaseMainWidth` / `DecreaseMainWidth` (closes #545 via #1000 by @hertg)
+- Added `ToggleMaximized` command (closes #973 via #1121 by @bksalman)
 - Add support for multiple main windows on all layouts that have a main column, new commands are `IncreaseMainCount` and `DecreaseMainCount` (closes #516 via #1000 by @hertg)
 - use `unwrap_newtypes` extension in ron deserializer (via #1000 by @hertg)
 

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -289,6 +289,11 @@ fn from_set_state(
         WindowState::Fullscreen => xw.atoms.NetWMStateFullscreen,
         WindowState::Above => xw.atoms.NetWMStateAbove,
         WindowState::Below => xw.atoms.NetWMStateBelow,
+        WindowState::Maximized => {
+            xw.set_state(handle, toggle_to, xw.atoms.NetWMStateMaximizedVert);
+            xw.set_state(handle, toggle_to, xw.atoms.NetWMStateMaximizedHorz);
+            return None;
+        }
     };
     xw.set_state(handle, toggle_to, state);
     None

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -446,13 +446,25 @@ impl XWrap {
     /// Returns the states of a window.
     #[must_use]
     pub fn get_window_states(&self, window: xlib::Window) -> Vec<WindowState> {
-        self.get_window_states_atoms(window)
+        let window_states_atoms = self.get_window_states_atoms(window);
+
+        // if window is maximized both horizontally and vertically
+        // `WindowState::Maximized` is used
+        // instead of `WindowState::MaximizedVert` and `WindowState::MaximizedHorz`
+        let maximized = window_states_atoms.contains(&self.atoms.NetWMStateMaximizedVert)
+            && window_states_atoms.contains(&self.atoms.NetWMStateMaximizedHorz);
+
+        let mut window_states: Vec<WindowState> = window_states_atoms
             .iter()
             .map(|a| match a {
                 x if x == &self.atoms.NetWMStateModal => WindowState::Modal,
                 x if x == &self.atoms.NetWMStateSticky => WindowState::Sticky,
-                x if x == &self.atoms.NetWMStateMaximizedVert => WindowState::MaximizedVert,
-                x if x == &self.atoms.NetWMStateMaximizedHorz => WindowState::MaximizedHorz,
+                x if x == &self.atoms.NetWMStateMaximizedVert && !maximized => {
+                    WindowState::MaximizedVert
+                }
+                x if x == &self.atoms.NetWMStateMaximizedHorz && !maximized => {
+                    WindowState::MaximizedHorz
+                }
                 x if x == &self.atoms.NetWMStateShaded => WindowState::Shaded,
                 x if x == &self.atoms.NetWMStateSkipTaskbar => WindowState::SkipTaskbar,
                 x if x == &self.atoms.NetWMStateSkipPager => WindowState::SkipPager,
@@ -462,7 +474,13 @@ impl XWrap {
                 x if x == &self.atoms.NetWMStateBelow => WindowState::Below,
                 _ => WindowState::Modal,
             })
-            .collect()
+            .collect();
+
+        if maximized {
+            window_states.push(WindowState::Maximized);
+        }
+
+        window_states
     }
 
     /// Returns the atom states of a window.

--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -24,6 +24,7 @@ pub enum Command {
     },
     ToggleScratchPad(ScratchPadName),
     ToggleFullScreen,
+    ToggleMaximized,
     ToggleSticky,
     GoToTag {
         tag: TagId,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -951,13 +951,13 @@ mod tests {
                     .iter_mut()
                     .find(|w| w.handle == window_handle)
                 {
-                    if window_state == WindowState::Fullscreen {
+                    if window_state == WindowState::Fullscreen
+                        || window_state == WindowState::Maximized
+                    {
                         if toggle_to {
-                            window.set_states(vec![WindowState::Fullscreen]);
-                        } else if let Some(state_pos) = window
-                            .states()
-                            .iter()
-                            .position(|s| *s == WindowState::Fullscreen)
+                            window.set_states(vec![window_state]);
+                        } else if let Some(state_pos) =
+                            window.states().iter().position(|s| *s == window_state)
                         {
                             let mut states = window.states();
                             states.remove(state_pos);
@@ -1112,6 +1112,164 @@ mod tests {
         });
 
         manager.command_handler(&Command::ToggleFullScreen);
+        mock_update(&mut manager);
+
+        let actual_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
+        let actual_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
+
+        assert_eq!(
+            expected_first_tag_window_order,
+            actual_first_tag_window_order
+        );
+        assert_eq!(
+            expected_second_tag_window_order,
+            actual_second_tag_window_order
+        );
+    }
+
+    #[test]
+    fn toggle_maximized() {
+        let mut manager = Manager::new_test(vec!["1".to_string()]);
+        let tag_id = manager.state.tags.get(1).unwrap().id;
+
+        manager.screen_create_handler(Screen::default());
+
+        for i in 1..=3 {
+            manager.window_created_handler(
+                Window::new(WindowHandle::MockHandle(i), None, None),
+                -1,
+                -1,
+            );
+        }
+
+        let expected = get_current_handles(&mut manager, Some(tag_id));
+
+        assert!(!manager
+            .state
+            .windows
+            .iter()
+            .any(|w| w.has_state(&WindowState::Maximized)));
+
+        manager.command_handler(&Command::ToggleMaximized);
+
+        mock_update(&mut manager);
+        assert!(manager
+            .state
+            .windows
+            .iter()
+            .any(|w| w.has_state(&WindowState::Maximized)));
+
+        // Mess with the window positions
+        manager.state.windows.reverse();
+
+        let actual = get_current_handles(&mut manager, Some(tag_id));
+
+        assert_ne!(expected, actual);
+
+        manager.command_handler(&Command::ToggleMaximized);
+        mock_update(&mut manager);
+
+        let actual = get_current_handles(&mut manager, Some(tag_id));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn toggle_maximized_with_multiple_tags() {
+        let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
+
+        let first_tag = manager.state.tags.get(1).unwrap().id;
+        let second_tag = manager.state.tags.get(2).unwrap().id;
+
+        manager.screen_create_handler(Screen::default());
+
+        for i in 1..=3 {
+            manager.window_created_handler(
+                Window::new(WindowHandle::MockHandle(i), None, None),
+                -1,
+                -1,
+            );
+        }
+
+        let expected_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
+
+        assert!(!manager
+            .state
+            .windows
+            .iter()
+            .any(|w| w.has_state(&WindowState::Maximized)));
+
+        manager.command_handler(&Command::ToggleMaximized);
+        mock_update(&mut manager);
+
+        assert!(manager
+            .state
+            .windows
+            .iter()
+            .any(|w| w.has_state(&WindowState::Maximized)));
+
+        // Mess with the window positions
+        manager.state.windows.reverse();
+
+        assert!(manager.command_handler(&Command::GoToTag {
+            tag: 2,
+            swap: false
+        }));
+
+        for i in 4..=6 {
+            manager.window_created_handler(
+                Window::new(WindowHandle::MockHandle(i), None, None),
+                -1,
+                -1,
+            );
+        }
+
+        let expected_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
+
+        assert_eq!(
+            manager
+                .state
+                .windows
+                .iter()
+                .find(|w| w.has_state(&WindowState::Maximized))
+                .iter()
+                .count(),
+            1
+        );
+
+        manager.command_handler(&Command::ToggleMaximized);
+        mock_update(&mut manager);
+
+        assert_eq!(
+            manager
+                .state
+                .windows
+                .iter()
+                .filter(|w| w.has_state(&WindowState::Maximized))
+                .count(),
+            2
+        );
+
+        // Mess with the windows positions of the second tag
+        let (mut windows_first_tag, mut windows_second_tag) =
+            split_window_vec(manager.state.windows, first_tag);
+        windows_second_tag.reverse();
+        windows_first_tag.append(&mut windows_second_tag);
+        manager.state.windows = windows_first_tag;
+
+        manager.command_handler(&Command::GoToTag {
+            tag: 1,
+            swap: false,
+        });
+
+        manager.command_handler(&Command::ToggleMaximized);
+        mock_update(&mut manager);
+
+        manager.command_handler(&Command::GoToTag {
+            tag: 2,
+            swap: false,
+        });
+
+        manager.command_handler(&Command::ToggleMaximized);
         mock_update(&mut manager);
 
         let actual_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -68,6 +68,7 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
             scratchpad_handler::cycle_scratchpad_window(manager, scratchpad, Direction::Backward)
         }
 
+        Command::ToggleMaximized => toggle_state(state, WindowState::Maximized),
         Command::ToggleFullScreen => toggle_state(state, WindowState::Fullscreen),
         Command::ToggleSticky => toggle_state(state, WindowState::Sticky),
 
@@ -238,8 +239,8 @@ fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {
     let toggle_to = !window.has_state(&window_state);
     let tag_id = state.focus_manager.tag(0)?;
 
-    if window_state == WindowState::Fullscreen {
-        //Going to fullscreen, so we save the window order
+    if window_state == WindowState::Fullscreen || window_state == WindowState::Maximized {
+        //Going to fullscreen/maximized, so we save the window order
         //or else, we restore it!
         if toggle_to {
             let handles = state
@@ -269,6 +270,7 @@ fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {
     state.handle_window_focus(&handle);
     match window_state {
         WindowState::Fullscreen => Some(true),
+        WindowState::Maximized => Some(true),
         _ => Some(false),
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -261,6 +261,7 @@ fn insert_window(state: &mut State, window: &mut Window, layout: &str) {
                 // When in monocle we want the new window to be fullscreen if the previous window was
                 // fullscreen.
                 if was_fullscreen {
+                    // un-fullscreen window
                     let act = DisplayAction::SetState(
                         window.handle,
                         !window.is_fullscreen(),

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -256,9 +256,14 @@ fn insert_window(state: &mut State, window: &mut Window, layout: &str) {
             .iter_mut()
             .find(|w| for_active_workspace(w) && w.is_maximized())
         {
-            let act =
-                DisplayAction::SetState(fsw.handle, !fsw.is_maximized(), WindowState::Maximized);
-            state.actions.push_back(act);
+            if !window.floating() {
+                let act = DisplayAction::SetState(
+                    fsw.handle,
+                    !fsw.is_maximized(),
+                    WindowState::Maximized,
+                );
+                state.actions.push_back(act);
+            }
         }
         let monocle = layouts::MONOCLE;
         let main_and_deck = layouts::MAIN_AND_DECK;

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -251,6 +251,14 @@ fn insert_window(state: &mut State, window: &mut Window, layout: &str) {
                 DisplayAction::SetState(fsw.handle, !fsw.is_fullscreen(), WindowState::Fullscreen);
             state.actions.push_back(act);
             was_fullscreen = true;
+        } else if let Some(fsw) = state
+            .windows
+            .iter_mut()
+            .find(|w| for_active_workspace(w) && w.is_maximized())
+        {
+            let act =
+                DisplayAction::SetState(fsw.handle, !fsw.is_maximized(), WindowState::Maximized);
+            state.actions.push_back(act);
         }
         let monocle = layouts::MONOCLE;
         let main_and_deck = layouts::MAIN_AND_DECK;
@@ -261,7 +269,6 @@ fn insert_window(state: &mut State, window: &mut Window, layout: &str) {
                 // When in monocle we want the new window to be fullscreen if the previous window was
                 // fullscreen.
                 if was_fullscreen {
-                    // un-fullscreen window
                     let act = DisplayAction::SetState(
                         window.handle,
                         !window.is_fullscreen(),

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -242,6 +242,23 @@ impl Tag {
                 .for_each(|w| {
                     w.set_visible(true);
                 });
+        } else if let Some(window) = windows
+            .iter_mut()
+            .find(|w| w.has_tag(&self.id) && w.is_maximized())
+        {
+            window.set_visible(true);
+            window.normal = Xyhw::from(workspace.rect());
+            let handle = window.handle;
+            windows
+                .iter_mut()
+                .filter(|w| {
+                    w.has_tag(&self.id)
+                        && w.transient.unwrap_or_else(|| 0.into()) == handle
+                        && w.is_managed()
+                })
+                .for_each(|w| {
+                    w.set_visible(true);
+                });
         } else {
             // Don't bother updating the other windows when a window is fullscreen.
             // Mark all windows for this workspace as visible.

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -266,7 +266,7 @@ impl Tag {
                 .filter(|w| w.has_tag(&self.id) && w.is_managed() && w.floating())
                 .for_each(|w| {
                     w.set_visible(true);
-                    w.normal = workspace.xyhw
+                    w.normal = workspace.xyhw;
                 });
         } else {
             // Don't bother updating the other windows when a window is fullscreen.

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -259,6 +259,15 @@ impl Tag {
                 .for_each(|w| {
                     w.set_visible(true);
                 });
+
+            // Update the location and visibility of all floating windows.
+            windows
+                .iter_mut()
+                .filter(|w| w.has_tag(&self.id) && w.is_managed() && w.floating())
+                .for_each(|w| {
+                    w.set_visible(true);
+                    w.normal = workspace.xyhw
+                });
         } else {
             // Don't bother updating the other windows when a window is fullscreen.
             // Mark all windows for this workspace as visible.

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -263,7 +263,9 @@ impl Tag {
             // Update the location and visibility of all floating windows.
             windows
                 .iter_mut()
-                .filter(|w| w.has_tag(&self.id) && w.is_managed() && w.floating())
+                .filter(|w| {
+                    w.has_tag(&self.id) && w.is_managed() && w.floating() && !w.is_maximized()
+                })
                 .for_each(|w| {
                     w.set_visible(true);
                     w.normal = workspace.xyhw;

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -179,7 +179,7 @@ impl Window {
     }
     #[must_use]
     pub fn can_resize(&self) -> bool {
-        self.can_resize && self.is_managed()
+        self.can_resize && self.is_managed() && !self.is_fullscreen() && !self.is_maximized()
     }
 
     #[must_use]
@@ -227,7 +227,7 @@ impl Window {
     #[must_use]
     pub fn width(&self) -> i32 {
         let mut value;
-        if self.is_fullscreen() {
+        if self.is_fullscreen() || self.is_maximized() {
             value = self.normal.w();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap_or_default();
@@ -250,7 +250,7 @@ impl Window {
     #[must_use]
     pub fn height(&self) -> i32 {
         let mut value;
-        if self.is_fullscreen() {
+        if self.is_fullscreen() || self.is_maximized() {
             value = self.normal.h();
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap_or_default();
@@ -288,7 +288,7 @@ impl Window {
 
     #[must_use]
     pub fn x(&self) -> i32 {
-        if self.is_fullscreen() {
+        if self.is_fullscreen() || self.is_maximized() {
             self.normal.x()
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap_or_default();
@@ -300,7 +300,7 @@ impl Window {
 
     #[must_use]
     pub fn y(&self) -> i32 {
-        if self.is_fullscreen() {
+        if self.is_fullscreen() || self.is_maximized() {
             self.normal.y()
         } else if self.floating() && self.floating.is_some() {
             let relative = self.normal + self.floating.unwrap_or_default();

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -157,6 +157,11 @@ impl Window {
     }
 
     #[must_use]
+    pub fn is_maximized(&self) -> bool {
+        self.states.contains(&WindowState::Maximized)
+    }
+
+    #[must_use]
     pub fn is_sticky(&self) -> bool {
         self.states.contains(&WindowState::Sticky)
     }

--- a/leftwm-core/src/models/window_state.rs
+++ b/leftwm-core/src/models/window_state.rs
@@ -6,6 +6,7 @@ pub enum WindowState {
     Sticky,
     MaximizedVert,
     MaximizedHorz,
+    Maximized,
     Shaded,
     SkipTaskbar,
     SkipPager,

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -177,6 +177,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "SendWorkspaceToTag" => build_send_workspace_to_tag(rest),
         "SwapScreens" => Ok(Command::SwapScreens),
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),
+        "ToggleMaximized" => Ok(Command::ToggleMaximized),
         "ToggleSticky" => Ok(Command::ToggleSticky),
         // General
         "CloseWindow" => Ok(Command::CloseWindow),

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -73,6 +73,7 @@ fn print_commandlist() {
         UnloadTheme
         SoftReload
         ToggleFullScreen
+        ToggleMaximized
         ToggleSticky
         SwapScreens
         MoveWindowToNextTag

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -24,6 +24,7 @@ pub enum BaseCommand {
     PrevScratchPadWindow,
     ToggleScratchPad,
     ToggleFullScreen,
+    ToggleMaximized,
     ToggleSticky,
     GotoTag,
     ReturnToLastTag,


### PR DESCRIPTION
# Description

Add a `ToggleMaximized` command that covers everything except the bar, to make it easy to focus on a window without getting rid of the bar

Fixes #973

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

[External command wiki page](https://github.com/leftwm/leftwm/wiki/External-Commands) should be updated

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not neccesary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
- [x] add `ToggleMaximized` command
- [ ] ~~Maximize next/previous window when switched to (like when using monocle layout)~~
- [x] Add tests (like the fullscreen ones)
- [x] Keep floating windows on top
- [x] fix for floating windows not getting maximized 