### PR TITLE
add `disable_cursor_reposition_on_resize` option to config

### DIFF
--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -56,6 +56,7 @@ pub trait Config {
     fn disable_tile_drag(&self) -> bool;
     fn disable_window_snap(&self) -> bool;
     fn sloppy_mouse_follows_focus(&self) -> bool;
+    fn reposition_cursor_on_resize(&self) -> bool;
 
     /// Attempt to write current state to a file.
     ///
@@ -214,6 +215,10 @@ pub(crate) mod tests {
         }
 
         fn auto_derive_workspaces(&self) -> bool {
+            true
+        }
+
+        fn reposition_cursor_on_resize(&self) -> bool {
             true
         }
     }

--- a/leftwm-core/src/handlers/mouse_combo_handler.rs
+++ b/leftwm-core/src/handlers/mouse_combo_handler.rs
@@ -23,9 +23,11 @@ impl State {
                 // Build the display to say whether we are ready to move/resize.
                 let act = self.build_action(modmask, button, handle, modifier);
                 if let Some(act) = act {
-                    if let DisplayAction::ReadyToResizeWindow(_) = act {
-                        let move_act = DisplayAction::MoveMouseOverPoint(bottom_right);
-                        self.actions.push_back(move_act);
+                    if self.reposition_cursor_on_resize {
+                        if let DisplayAction::ReadyToResizeWindow(_) = act {
+                            let move_act = DisplayAction::MoveMouseOverPoint(bottom_right);
+                            self.actions.push_back(move_act);
+                        }
                     }
                     self.actions.push_back(act);
                     return false;

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -30,6 +30,7 @@ pub struct State {
     pub default_width: i32,
     pub default_height: i32,
     pub disable_tile_drag: bool,
+    pub reposition_cursor_on_resize: bool,
     pub insert_behavior: InsertBehavior,
     pub single_window_border: bool,
 }
@@ -59,6 +60,7 @@ impl State {
             default_width: config.default_width(),
             default_height: config.default_height(),
             disable_tile_drag: config.disable_tile_drag(),
+            reposition_cursor_on_resize: config.reposition_cursor_on_resize(),
             insert_behavior: config.insert_behavior(),
             single_window_border: config.single_window_border(),
         }

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -195,6 +195,16 @@ focus_new_windows = true
 sloppy_mouse_follows_focus = true # Only active with the Sloppy behaviour
 \f[R]
 .fi
+.SS Cursor Behaviour on Resize
+.PP
+LeftWM automatically snaps the mouse to the lower right hand corner
+when a window is being resized. This behaviour is controlled by the
+disable_cursor_reposition_on_resize setting. When true, the
+cursor will not be repositioned on resize start. When false or unspecified,
+the cursor will be snapped to the lower right corner of the window which is
+being resized.
+.PP
+Default: \f[C]disable_cursor_reposition_on_resize = false\f[R]
 .SS Layouts
 .PP
 Leftwm supports variety of layouts, which define the way that windows are tiled in the workspace

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -199,6 +199,7 @@ pub struct Config {
     pub single_window_border: bool,
     pub sloppy_mouse_follows_focus: bool,
     pub auto_derive_workspaces: bool,
+    pub disable_cursor_reposition_on_resize: bool,
     #[cfg(feature = "lefthk")]
     pub keybind: Vec<Keybind>,
     pub state_path: Option<PathBuf>,
@@ -655,6 +656,10 @@ impl leftwm_core::Config for Config {
 
     fn auto_derive_workspaces(&self) -> bool {
         self.auto_derive_workspaces
+    }
+
+    fn reposition_cursor_on_resize(&self) -> bool {
+        !self.disable_cursor_reposition_on_resize
     }
 }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -237,6 +237,7 @@ impl Default for Config {
             max_window_width: None,
             state_path: None,
             sloppy_mouse_follows_focus: true,
+            disable_cursor_reposition_on_resize: false,
             auto_derive_workspaces: true,
         }
     }


### PR DESCRIPTION
# Description

personally it annoys me when the cursor snaps to the bottom right corner when resizing, and I searched for an issue to see if anyone agrees, and saw a couple of people, so I'm submitting a PR to add the option to disable it via an option in the config file.

also I just threw together this PR pretty quick, so maybe it needs some changes, so I just wanted to get it out there so we can discuss it here

addresses #1011 

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

this page: https://github.com/leftwm/leftwm/wiki/Config

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
