### PR TITLE
Fix fullscreen resize and respect margins

### DIFF
--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -135,14 +135,22 @@ fn prepare_window(state: &mut State, handle: WindowHandle) {
         // Un-pin window if maximized or in fullscreen
         if w.is_fullscreen() {
             w.reset_float_offset();
-            state.actions.push_back(DisplayAction::SetState(handle, false, WindowState::Fullscreen));
+            state.actions.push_back(DisplayAction::SetState(
+                handle,
+                false,
+                WindowState::Fullscreen,
+            ));
             w.drop_state(&WindowState::Fullscreen);
             // Force update for all windows
             state.mode = Mode::ReadyToResize(handle);
         }
         if w.is_maximized() {
             w.reset_float_offset();
-            state.actions.push_back(DisplayAction::SetState(handle, false, WindowState::Maximized));
+            state.actions.push_back(DisplayAction::SetState(
+                handle,
+                false,
+                WindowState::Maximized,
+            ));
             w.drop_state(&WindowState::Maximized);
             w.drop_state(&WindowState::MaximizedHorz);
             w.drop_state(&WindowState::MaximizedVert);

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -1,7 +1,7 @@
 use super::{Config, DisplayEvent, Manager, Mode};
 use crate::display_action::DisplayAction;
 use crate::display_servers::DisplayServer;
-use crate::models::WindowHandle;
+use crate::models::{WindowHandle, WindowState};
 use crate::State;
 
 impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
@@ -132,6 +132,23 @@ fn from_configure_xlib_window(state: &mut State, handle: WindowHandle) -> bool {
 // Save off the info about position of the window when we start to move/resize.
 fn prepare_window(state: &mut State, handle: WindowHandle) {
     if let Some(w) = state.windows.iter_mut().find(|w| w.handle == handle) {
+        // Un-pin window if maximized or in fullscreen
+        if w.is_fullscreen() {
+            w.reset_float_offset();
+            state.actions.push_back(DisplayAction::SetState(handle, false, WindowState::Fullscreen));
+            w.drop_state(&WindowState::Fullscreen);
+            // Force update for all windows
+            state.mode = Mode::ReadyToResize(handle);
+        }
+        if w.is_maximized() {
+            w.reset_float_offset();
+            state.actions.push_back(DisplayAction::SetState(handle, false, WindowState::Maximized));
+            w.drop_state(&WindowState::Maximized);
+            w.drop_state(&WindowState::MaximizedHorz);
+            w.drop_state(&WindowState::MaximizedVert);
+            // Force update for all windows
+            state.mode = Mode::ReadyToResize(handle);
+        }
         if w.floating() {
             let offset = w.get_floating_offsets().unwrap_or_default();
             w.start_loc = Some(offset);
@@ -142,6 +159,8 @@ fn prepare_window(state: &mut State, handle: WindowHandle) {
             w.set_floating_offsets(Some(floating));
             w.start_loc = Some(floating);
             w.set_floating(true);
+            // Force update for all windows
+            state.mode = Mode::ReadyToResize(handle);
         }
     }
     state.move_to_top(&handle);

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -179,7 +179,7 @@ impl Window {
     }
     #[must_use]
     pub fn can_resize(&self) -> bool {
-        self.can_resize && self.is_managed() && !self.is_fullscreen() && !self.is_maximized()
+        self.can_resize && self.is_managed()
     }
 
     #[must_use]
@@ -197,6 +197,10 @@ impl Window {
 
     pub fn set_states(&mut self, states: Vec<WindowState>) {
         self.states = states;
+    }
+
+    pub fn drop_state(&mut self, state: &WindowState) {
+        self.states.retain(|s| s != state);
     }
 
     #[must_use]

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -227,9 +227,9 @@ impl Window {
     #[must_use]
     pub fn width(&self) -> i32 {
         let mut value;
-        if self.is_fullscreen() || self.is_maximized() {
+        if self.is_fullscreen() {
             value = self.normal.w();
-        } else if self.floating() && self.floating.is_some() {
+        } else if self.floating() && self.floating.is_some() && !self.is_maximized() {
             let relative = self.normal + self.floating.unwrap_or_default();
             value = relative.w() - (self.border * 2);
         } else {
@@ -250,9 +250,9 @@ impl Window {
     #[must_use]
     pub fn height(&self) -> i32 {
         let mut value;
-        if self.is_fullscreen() || self.is_maximized() {
+        if self.is_fullscreen() {
             value = self.normal.h();
-        } else if self.floating() && self.floating.is_some() {
+        } else if self.floating() && self.floating.is_some() && !self.is_maximized() {
             let relative = self.normal + self.floating.unwrap_or_default();
             value = relative.h() - (self.border * 2);
         } else {
@@ -288,9 +288,9 @@ impl Window {
 
     #[must_use]
     pub fn x(&self) -> i32 {
-        if self.is_fullscreen() || self.is_maximized() {
+        if self.is_fullscreen() {
             self.normal.x()
-        } else if self.floating() && self.floating.is_some() {
+        } else if self.floating() && self.floating.is_some() && !self.is_maximized() {
             let relative = self.normal + self.floating.unwrap_or_default();
             relative.x()
         } else {
@@ -300,9 +300,9 @@ impl Window {
 
     #[must_use]
     pub fn y(&self) -> i32 {
-        if self.is_fullscreen() || self.is_maximized() {
+        if self.is_fullscreen() {
             self.normal.y()
-        } else if self.floating() && self.floating.is_some() {
+        } else if self.floating() && self.floating.is_some() && !self.is_maximized() {
             let relative = self.normal + self.floating.unwrap_or_default();
             relative.y()
         } else {


### PR DESCRIPTION
# Description

This pr supersedes #1134, I used a simpler solution to respect the margins.

I also fixed the issue where the window wouldn't drop out of fullscreen/maximized when resized/moved.

There is also a slightly changed resize behavior now: When resizing a tiled window, the back ones instantly take it's space instead of after letting the window go. Tell me if you like it, it's just a question of using the third forced update statement or not.

This pr closes #1134

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Clippy and fmt currently fail due to the new rust version, but nothing is related to my code
- [x] Tests run fine
