### PR TITLE
[chorens] clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 default-members = ["leftwm", "leftwm-core", "display-servers/xlib-display-server"]
 members = ["leftwm", "leftwm-macros", "leftwm-core", "display-servers/xlib-display-server"]
+resolver = "2"
 
 [profile.optimized]
 inherits = "release"

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -199,10 +199,10 @@ impl XlibDisplayServer {
         match self.xw.get_all_windows() {
             Ok(handles) => handles.into_iter().for_each(|handle| {
                 let Ok(attrs) = self.xw.get_window_attrs(handle) else {
-                    return
+                    return;
                 };
                 let Some(state) = self.xw.get_wm_state(handle) else {
-                    return
+                    return;
                 };
                 if attrs.map_state == xlib::IsViewable || state == ICONIC_STATE {
                     if let Some(event) = self.xw.setup_window(handle) {

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -365,8 +365,16 @@ impl XWrap {
             if status == 0 {
                 return None;
             }
-            let Ok(res_name) = CString::from_raw(class_return.res_name.cast::<c_char>()).into_string() else  {return None};
-            let Ok(res_class) =CString::from_raw(class_return.res_class.cast::<c_char>()).into_string() else { return None};
+            let Ok(res_name) =
+                CString::from_raw(class_return.res_name.cast::<c_char>()).into_string()
+            else {
+                return None;
+            };
+            let Ok(res_class) =
+                CString::from_raw(class_return.res_class.cast::<c_char>()).into_string()
+            else {
+                return None;
+            };
             Some((res_name, res_class))
         }
     }

--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -134,7 +134,9 @@ impl XWrap {
                 }
                 states.push(atom);
             } else {
-                let Some(index) = states.iter().position(|s| s == &atom) else { return };
+                let Some(index) = states.iter().position(|s| s == &atom) else {
+                    return;
+                };
                 states.remove(index);
             }
             self.set_window_states_atoms(h, &states);

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -198,7 +198,9 @@ impl XWrap {
                 self.set_window_config(handle, changes, u32::from(unlock));
                 self.configure_window(window);
             }
-            let Some(state) = self.get_wm_state(handle) else {return};
+            let Some(state) = self.get_wm_state(handle) else {
+                return;
+            };
             // Only change when needed. This prevents task bar icons flashing (especially with steam).
             if window.visible() && state != NORMAL_STATE {
                 self.toggle_window_visibility(handle, true);

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -20,7 +20,7 @@ impl State {
     /// Focuses the given window.
     pub fn focus_window(&mut self, handle: &WindowHandle) {
         let Some(window) = self.focus_window_work(handle) else {
-            return
+            return;
         };
 
         // Make sure the focused window's workspace is focused.
@@ -100,7 +100,11 @@ impl State {
 
     /// Focuses the workspace containing a given point.
     pub fn focus_workspace_with_point(&mut self, x: i32, y: i32) {
-        let Some(focused_id) = self.focus_manager.workspace(&self.workspaces).map(|ws| ws.id) else {
+        let Some(focused_id) = self
+            .focus_manager
+            .workspace(&self.workspaces)
+            .map(|ws| ws.id)
+        else {
             return;
         };
 
@@ -151,7 +155,7 @@ impl State {
 
     fn focus_closest_window(&mut self, x: i32, y: i32) {
         let Some(ws) = self.workspaces.iter().find(|ws| ws.contains_point(x, y)) else {
-            return
+            return;
         };
         let mut dists: Vec<(i32, &Window)> = self
             .windows

--- a/leftwm-core/src/models/xyhw_change.rs
+++ b/leftwm-core/src/models/xyhw_change.rs
@@ -105,7 +105,7 @@ impl XyhwChange {
             false
         };
         let Some(mut xyhw) = window.strut else {
-            return false
+            return false;
         };
         changed = self.update(&mut xyhw) || changed;
         window.strut = Some(xyhw);

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -334,7 +334,7 @@ impl Children {
 
     /// Merge another `Children` into this `Children`.
     pub fn merge(&mut self, reaper: Self) {
-        self.inner.extend(reaper.inner.into_iter());
+        self.inner.extend(reaper.inner);
     }
 
     /// Remove all children precosses which finished
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let content = r###"
+        let content = r"
             [Desktop Action Gallery]
         Exec=fooview --gallery
         Name=Browse Gallery
@@ -417,7 +417,7 @@ mod tests {
         Exec=fooview --create-new
         Name=Create a new Foo!
         Icon=fooview-new
-                "###;
+                ";
 
         let entry = DesktopEntry::parse(content);
 

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -262,7 +262,7 @@ fn load_from_file() -> Result<Config> {
             .extensions(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES);
         let ron = to_string_pretty(&config, ron_pretty_conf).unwrap();
         let comment_header = String::from(
-            r#"//  _        ___                                      ___ _
+            r"//  _        ___                                      ___ _
 // | |      / __)_                                   / __|_)
 // | | ____| |__| |_ _ _ _ ____      ____ ___  ____ | |__ _  ____    ____ ___  ____
 // | |/ _  )  __)  _) | | |    \    / ___) _ \|  _ \|  __) |/ _  |  / ___) _ \|  _ \
@@ -271,7 +271,7 @@ fn load_from_file() -> Result<Config> {
 // A WindowManager for Adventurers                         (____/
 // For info about configuration please visit https://github.com/leftwm/leftwm/wiki
 
-"#,
+",
         );
         let ron_with_header = comment_header + &ron;
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -196,7 +196,7 @@ impl Default for Config {
             });
         }
 
-        let tags = vec!["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        let tags = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
             .iter()
             .map(|s| (*s).to_string())
             .collect();


### PR DESCRIPTION
# Description

While reviewing code github presented some clippy lints in unrelated code. This adresses those.
A thing where I am not 100% certain if about the implications is the resolver config in `Cargo.toml`, here is the clippy lint for this:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
Warning: note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

Also would be great, if anybody has an idea how githubs service to put clippy lints in code review is setup, so we could copy their flags in our Makefile checks.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
