### PR TITLE
make floating windows stay on top of maximized windows

### DIFF
--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -246,6 +246,7 @@ impl Tag {
             .iter_mut()
             .find(|w| w.has_tag(&self.id) && w.is_maximized())
         {
+            // Update maximized window
             window.set_visible(true);
             window.normal = Xyhw::from(workspace.rect());
             let handle = window.handle;
@@ -260,10 +261,12 @@ impl Tag {
                     w.set_visible(true);
                 });
 
-            // Update the location and visibility of non-normal + non-maximized windows.
+            // Update all windows except normal non-floating windoows and maximized window
             windows
                 .iter_mut()
-                .filter(|w| w.has_tag(&self.id) && !w.is_normal() && !w.is_maximized())
+                .filter(|w| {
+                    w.has_tag(&self.id) && (!w.is_normal() || w.floating()) && !w.is_maximized()
+                })
                 .for_each(|w| {
                     w.set_visible(true);
                     // Don't change docks and desktop xyhw

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -96,25 +96,32 @@ impl State {
                 w.r#type == WindowType::Normal && w.floating()
             });
 
+        // Maximized windows.
+        let (level5, maximized, other): (Vec<WindowHandle>, Vec<Window>, Vec<Window>) =
+            partition_windows(other.iter(), |w| {
+                w.r#type == WindowType::Normal && w.is_maximized()
+            });
+
         // Tiled windows.
-        let (level5, tiled, other): (Vec<WindowHandle>, Vec<Window>, Vec<Window>) =
+        let (level6, tiled, other): (Vec<WindowHandle>, Vec<Window>, Vec<Window>) =
             partition_windows(other.iter(), |w| w.r#type == WindowType::Normal);
 
         // Last docks.
-        let level6: Vec<WindowHandle> = other.iter().map(|w| w.handle).collect();
+        let level7: Vec<WindowHandle> = other.iter().map(|w| w.handle).collect();
 
         self.windows = [
             fullscreen_children,
             fullscreen_windows,
             dialogs,
             floating,
+            maximized,
             tiled,
             other,
         ]
         .concat();
 
         let fullscreen: Vec<WindowHandle> = [level1, level2].concat();
-        let handles: Vec<WindowHandle> = [level3, level4, level5, level6].concat();
+        let handles: Vec<WindowHandle> = [level3, level4, level5, level6, level7].concat();
         let act = DisplayAction::SetWindowOrder(fullscreen, handles);
         self.actions.push_back(act);
     }


### PR DESCRIPTION
# Description

in my #1121 PR I meant to make floating windows go on top of maximized windows at all times, had some regression in this regard in #1126 

Fixes #943

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

nuffin

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
