### PR TITLE
Pinned tags

### DIFF
--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -161,7 +161,7 @@ impl XlibDisplayServer {
                     }
                     None => continue,
                 }
-                tracing::debug!("initial_events:: workspace options: {:?}", wsc.options);
+                tracing::debug!("workspace options: {:?}", wsc.options);
                 let e = DisplayEvent::ScreenCreate(screen, wsc.options.clone());
                 events.push(e);
             }

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             buildInputs = with pkgs; [
               xorg.libX11
               xorg.libXinerama
+              xorg.libXrandr
             ];
 
             inherit GIT_HASH;

--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -9,7 +9,7 @@ use crate::models::{Manager, Window, WindowType};
 use crate::state::State;
 pub use insert_behavior::InsertBehavior;
 use leftwm_layouts::Layout;
-pub use workspace_config::Workspace;
+pub use workspace_config::{Workspace, WorkspaceOptions, WorkspaceOutput};
 
 pub trait Config {
     fn create_list_of_tag_labels(&self) -> Vec<String>;
@@ -85,6 +85,7 @@ pub trait Config {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::workspace_config::Workspace;
     use super::*;
     use crate::models::Screen;
     use crate::models::Window;

--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -227,7 +227,7 @@ pub(crate) mod tests {
     #[test]
     fn ensure_command_handler_trait_boundary() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         assert!(TestConfig::command_handler("GoToTag2", &mut manager));
         assert_eq!(manager.state.focus_manager.tag_history, &[2, 1]);
     }
@@ -235,7 +235,7 @@ pub(crate) mod tests {
     #[test]
     fn check_wm_class_is_associated_with_predefined_tag() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let mut subject = Window::new(WindowHandle::MockHandle(1), None, None);
         subject.res_class = Some("ShouldGoToTag2".to_string());
         manager.window_created_handler(subject, 0, 0);

--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -4,12 +4,23 @@ use crate::models::Size;
 
 #[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq)]
 pub struct Workspace {
+    pub output: Option<WorkspaceOutput>,
+    pub options: Option<WorkspaceOptions>,
+}
+
+#[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq)]
+pub struct WorkspaceOptions {
+    pub max_window_width: Option<Size>,
+    pub layouts: Option<Vec<String>>,
+    pub pinned_tags: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq)]
+pub struct WorkspaceOutput {
+    pub output: String,
+    pub relative: Option<bool>,
     pub x: i32,
     pub y: i32,
     pub height: i32,
     pub width: i32,
-    pub output: String,
-    pub relative: Option<bool>,
-    pub max_window_width: Option<Size>,
-    pub layouts: Option<Vec<String>>,
 }

--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -4,7 +4,9 @@ use crate::models::Size;
 
 #[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq)]
 pub struct Workspace {
+    #[serde(flatten)]
     pub output: Option<WorkspaceOutput>,
+    #[serde(flatten)]
     pub options: Option<WorkspaceOptions>,
 }
 

--- a/leftwm-core/src/display_event.rs
+++ b/leftwm-core/src/display_event.rs
@@ -1,4 +1,5 @@
 use super::{models::Screen, models::Window, models::WindowHandle, Button, ModMask};
+use crate::config::WorkspaceOptions;
 use crate::models::WindowChange;
 use crate::Command;
 
@@ -16,7 +17,7 @@ pub enum DisplayEvent {
     MoveFocusTo(i32, i32),         // Focus the nearest window to this point.
     MoveWindow(WindowHandle, i32, i32),
     ResizeWindow(WindowHandle, i32, i32),
-    ScreenCreate(Screen),
+    ScreenCreate(Screen, Option<WorkspaceOptions>),
     SendCommand(Command),
     ConfigureXlibWindow(WindowHandle),
     ChangeToNormalMode,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -973,7 +973,7 @@ mod tests {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
         let tag_id = manager.state.tags.get(1).unwrap().id;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         for i in 1..=3 {
             manager.window_created_handler(
@@ -1021,7 +1021,7 @@ mod tests {
         let first_tag = manager.state.tags.get(1).unwrap().id;
         let second_tag = manager.state.tags.get(2).unwrap().id;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         for i in 1..=3 {
             manager.window_created_handler(
@@ -1131,7 +1131,7 @@ mod tests {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
         let tag_id = manager.state.tags.get(1).unwrap().id;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         for i in 1..=3 {
             manager.window_created_handler(
@@ -1179,7 +1179,7 @@ mod tests {
         let first_tag = manager.state.tags.get(1).unwrap().id;
         let second_tag = manager.state.tags.get(2).unwrap().id;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         for i in 1..=3 {
             manager.window_created_handler(
@@ -1294,8 +1294,8 @@ mod tests {
             "E39".to_string(),
             "F67".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
 
         assert!(manager.command_handler(&Command::GoToTag {
             tag: 1,
@@ -1337,8 +1337,8 @@ mod tests {
     #[test]
     fn go_to_tag_should_create_at_least_one_tag_per_screen_no_more() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         // no tag creation here but one tag per screen is created
         assert!(manager.command_handler(&Command::GoToTag {
             tag: 2,
@@ -1358,7 +1358,7 @@ mod tests {
     #[test]
     fn go_to_tag_should_return_false_on_invalid_input() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.state.tags = Tags::new();
         manager.state.tags.add_new("A15");
         manager.state.tags.add_new("B24");
@@ -1386,8 +1386,8 @@ mod tests {
             "E39".to_string(),
             "F67".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
 
         assert!(manager.command_handler(&Command::GoToTag {
             tag: 6,
@@ -1433,7 +1433,7 @@ mod tests {
             "E39".to_string(),
             "F67".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let state = &mut manager.state;
 
         state.focus_tag(&2);
@@ -1461,7 +1461,7 @@ mod tests {
     #[test]
     fn focus_window_top() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -1515,7 +1515,7 @@ mod tests {
     #[test]
     fn move_window_top() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -1557,7 +1557,7 @@ mod tests {
             "HT".to_string(),
             "NS".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -1585,7 +1585,7 @@ mod tests {
     #[test]
     fn move_window_to_next_or_prev_tag_should_be_able_to_keep_window_focused() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -1615,7 +1615,7 @@ mod tests {
     #[test]
     fn after_moving_second_window_remaining_single_window_has_no_border() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -1644,7 +1644,7 @@ mod tests {
     #[test]
     fn after_moving_single_window_to_another_single_window_both_have_borders() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -1671,7 +1671,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Used".to_string(), "Empty".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1692,7 +1692,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Emtpy_One".to_string(), "Empty".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1714,7 +1714,7 @@ mod tests {
             "C".to_string(),
             "D".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1768,7 +1768,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Used".to_string(), "Empty".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&2);
@@ -1789,7 +1789,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Emtpy_One".to_string(), "Empty".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&2);
 
@@ -1811,7 +1811,7 @@ mod tests {
             "C".to_string(),
             "D".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1864,7 +1864,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Used".to_string(), "Empty".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1889,7 +1889,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Emtpy_One".to_string(), "Used".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&2);
@@ -1915,7 +1915,7 @@ mod tests {
             "C".to_string(),
             "D".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.state.focus_tag(&1);
 
@@ -1969,7 +1969,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -1994,7 +1994,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["Emtpy_One".to_string(), "Used".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&2);
@@ -2021,7 +2021,7 @@ mod tests {
             "D".to_string(),
             "E".to_string(),
         ]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -2074,7 +2074,7 @@ mod tests {
             crate::config::tests::TestConfig,
             crate::display_servers::MockDisplayServer,
         > = Manager::new_test(vec!["A".to_string(), "B".to_string(), "C".to_string()]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&3);

--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -532,7 +532,7 @@ mod tests {
     #[test]
     fn show_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
         let first_tag = manager.state.tags.get(1).unwrap().id;
 
@@ -567,7 +567,7 @@ mod tests {
     #[test]
     fn hide_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
         let first_tag = manager.state.tags.get(1).unwrap().id;
 
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn toggle_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
 
         let mock_window = 1_u32;
@@ -667,7 +667,7 @@ mod tests {
     /// After releasing, the scratchpad should not be active anymore (no more windows)
     fn release_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
 
         // Setup
         let mock_window1 = 10_u32;
@@ -711,7 +711,7 @@ mod tests {
     /// After releasing 1 window, the rest should still be in the scratchpad
     fn release_scratchpad_multiple_windows_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
 
         // Setup
@@ -775,7 +775,7 @@ mod tests {
     #[test]
     fn attach_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
 
         // Setup
@@ -945,7 +945,7 @@ mod tests {
         }
 
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let nsp_tag = manager.state.tags.get_hidden_by_label("NSP").unwrap().id;
 
         // Setup
@@ -1056,7 +1056,7 @@ mod tests {
     #[test]
     fn change_focus_with_open_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
 
         // Setup
         let mock_window1 = 1_u32;
@@ -1166,7 +1166,7 @@ mod tests {
     #[test]
     fn focus_top_from_scratchpad_test() {
         let mut manager = Manager::new_test(vec!["AO".to_string(), "EU".to_string()]);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
 
         // Setup
         let mock_window1 = 1_u32;
@@ -1240,7 +1240,7 @@ mod tests {
     #[test]
     fn toggle_scratchpad_also_toggles_single_window_borders() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Default::default());
+        manager.screen_create_handler(Default::default(), None);
         let second_tag = manager.state.tags.get(2).unwrap().id;
 
         let scratchpad_pid = 1_u32;

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -10,7 +10,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     pub fn display_event_handler(&mut self, event: DisplayEvent) -> bool {
         let state = &mut self.state;
         match event {
-            DisplayEvent::ScreenCreate(s) => self.screen_create_handler(s),
+            DisplayEvent::ScreenCreate(s, ws_options) => self.screen_create_handler(s, ws_options),
             DisplayEvent::WindowCreate(w, x, y) => self.window_created_handler(w, x, y),
             DisplayEvent::WindowChange(w) => self.window_changed_handler(w),
             DisplayEvent::WindowDestroy(handle) => self.window_destroyed_handler(&handle),

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -277,8 +277,8 @@ mod tests {
     #[test]
     fn focusing_a_workspace_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         let expected = manager.state.workspaces[0].clone();
         manager.state.focus_workspace(&expected);
         let actual = manager
@@ -292,8 +292,8 @@ mod tests {
     #[test]
     fn focusing_a_workspace_should_focus_its_last_active_window() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         manager
             .state
             .focus_workspace(&manager.state.workspaces[0].clone());
@@ -334,8 +334,8 @@ mod tests {
     #[test]
     fn focusing_the_same_workspace_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         let ws = manager.state.workspaces[0].clone();
         manager.state.focus_workspace(&ws);
         let start_length = manager.state.focus_manager.workspace_history.len();
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn focusing_a_window_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -372,7 +372,7 @@ mod tests {
     #[test]
     fn focusing_the_same_window_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let window = Window::new(WindowHandle::MockHandle(1), None, None);
         manager.window_created_handler(window.clone(), -1, -1);
         manager.state.focus_window(&window.handle);
@@ -386,7 +386,7 @@ mod tests {
     #[test]
     fn focusing_a_tag_should_make_it_active() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let state = &mut manager.state;
         let expected: usize = 1;
         state.focus_tag(&expected);
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn focusing_the_same_tag_shouldnt_add_to_the_history() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let state = &mut manager.state;
         let tag: usize = 1;
         state.focus_tag(&tag);
@@ -410,8 +410,8 @@ mod tests {
     #[test]
     fn focusing_a_tag_should_focus_its_workspace() {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         manager.state.focus_tag(&1);
         let actual = manager
             .state
@@ -424,9 +424,9 @@ mod tests {
     #[test]
     fn focusing_a_workspace_should_focus_its_tag() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         let ws = manager.state.workspaces[1].clone();
         manager.state.focus_workspace(&ws);
         let actual = manager.state.focus_manager.tag(0).unwrap();
@@ -436,9 +436,9 @@ mod tests {
     #[test]
     fn focusing_a_window_should_focus_its_tag() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag(&2);
         manager.state.windows.push(window.clone());
@@ -450,9 +450,9 @@ mod tests {
     #[test]
     fn focusing_a_window_should_focus_workspace() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag(&2);
         manager.state.windows.push(window.clone());
@@ -469,7 +469,7 @@ mod tests {
     #[test]
     fn focusing_an_empty_tag_should_unfocus_any_focused_window() {
         let mut manager = Manager::new_test(vec![]);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         let mut window = Window::new(WindowHandle::MockHandle(1), None, None);
         window.tag(&1);
         manager.state.windows.push(window.clone());

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -22,8 +22,7 @@ impl State {
             let old_tag_ws = self
                 .workspaces
                 .iter()
-                .find(|ws| ws.tag == Some(old_tag) && ws.pinned_tags.contains(&old_tag))
-                .is_some();
+                .any(|ws| ws.tag == Some(old_tag) && ws.pinned_tags.contains(&old_tag));
 
             if let Some(ws) = self
                 .workspaces

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -21,7 +21,19 @@ impl State {
             ws.tag = Some(old_tag);
         }
 
+        if let Some(workspace) = self
+            .workspaces
+            .clone()
+            .into_iter()
+            .find(|w| w.pinned_tags.contains(&tag_id))
+        {
+            self.focus_workspace(&workspace);
+            tracing::debug!("tag is pinned to: {workspace:#?}");
+            *self.focus_manager.workspace_mut(&mut self.workspaces)? = workspace;
+        }
+
         self.focus_manager.workspace_mut(&mut self.workspaces)?.tag = new_tag;
+
         self.focus_tag(&tag_id);
         self.update_static();
 
@@ -37,8 +49,8 @@ mod tests {
     #[test]
     fn going_to_a_workspace_that_is_already_visible_should_not_duplicate_the_workspace() {
         let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-        manager.screen_create_handler(Screen::default());
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
+        manager.screen_create_handler(Screen::default(), None);
         manager.state.goto_tag_handler(1);
         assert_eq!(manager.state.workspaces[0].tag, Some(2));
         assert_eq!(manager.state.workspaces[1].tag, Some(1));

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -27,9 +27,9 @@ impl State {
             .into_iter()
             .find(|w| w.pinned_tags.contains(&tag_id))
         {
-            self.focus_workspace(&workspace);
             tracing::debug!("tag is pinned to: {workspace:#?}");
-            *self.focus_manager.workspace_mut(&mut self.workspaces)? = workspace;
+            self.focus_workspace(&workspace);
+            self.focus_tag(&tag_id);
         }
 
         self.focus_manager.workspace_mut(&mut self.workspaces)?.tag = new_tag;

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -41,7 +41,7 @@ impl State {
                             .map(|t| t.id)
                             .next();
                     } else {
-                        ws.tag = ws.pinned_tags.iter().next().copied();
+                        ws.tag = ws.pinned_tags.first().copied();
                     }
                 } else {
                     ws.tag = Some(old_tag);

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -484,7 +484,7 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.state.insert_behavior = InsertBehavior::Bottom;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -508,7 +508,7 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.state.insert_behavior = InsertBehavior::Top;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -531,7 +531,7 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.state.insert_behavior = InsertBehavior::AfterCurrent;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -563,7 +563,7 @@ mod tests {
         let mut manager = Manager::new_test(vec![]);
         manager.state.insert_behavior = InsertBehavior::BeforeCurrent;
 
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
             -1,
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn single_window_has_no_border() {
         let mut manager = Manager::new_test_with_border(vec![], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn multiple_windows_have_borders() {
         let mut manager = Manager::new_test_with_border(vec![], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -628,7 +628,7 @@ mod tests {
     #[test]
     fn remaining_single_window_has_no_border() {
         let mut manager = Manager::new_test_with_border(vec![], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         manager.window_created_handler(
             Window::new(WindowHandle::MockHandle(1), None, None),
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn single_windows_on_different_tags_have_no_border() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -666,7 +666,7 @@ mod tests {
     #[test]
     fn single_window_has_no_border_and_windows_on_another_tag_have_borders() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn remaining_single_window_on_another_tag_has_no_border() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string(), "2".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
 
         let mut first_window = Window::new(WindowHandle::MockHandle(1), None, None);
         first_window.tag(&1);
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     fn monocle_layout_only_has_single_windows() {
         let mut manager = Manager::new_test_with_border(vec!["1".to_string()], 1);
-        manager.screen_create_handler(Screen::default());
+        manager.screen_create_handler(Screen::default(), None);
         manager.state.layout_manager.set_layout(1, 1, MONOCLE);
         // manager.state.tags.get_mut(1).unwrap().set_layout(String::from("Monocle"));
         manager.window_created_handler(

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -47,8 +47,13 @@ impl LayoutManager {
 
         let mut available_layouts_per_ws: HashMap<usize, Vec<Layout>> = HashMap::new();
 
-        for (i, ws) in config.workspaces().unwrap_or_default().iter().enumerate() {
-            if let Some(ws_layout_names) = &ws.layouts {
+        for (i, ws) in config
+            .workspaces()
+            .unwrap_or_default()
+            .into_iter()
+            .enumerate()
+        {
+            if let Some(ws_layout_names) = ws.options.unwrap_or_default().layouts {
                 let wsid = i + 1;
                 for ws_layout_name in ws_layout_names {
                     if let Some(layout) = config
@@ -227,18 +232,22 @@ mod tests {
             layout_definitions: Layouts::default().layouts,
             workspaces: Some(vec![
                 crate::config::Workspace {
-                    layouts: Some(vec![
-                        layouts::CENTER_MAIN.to_string(),
-                        layouts::CENTER_MAIN_BALANCED.to_string(),
-                        layouts::MAIN_AND_DECK.to_string(),
-                    ]),
+                    options: Some(crate::config::WorkspaceOptions {
+                        layouts: Some(vec![
+                            layouts::CENTER_MAIN.to_string(),
+                            layouts::CENTER_MAIN_BALANCED.to_string(),
+                            layouts::MAIN_AND_DECK.to_string(),
+                        ]),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
+                crate::config::Workspace::default(),
                 crate::config::Workspace {
-                    ..Default::default()
-                },
-                crate::config::Workspace {
-                    layouts: Some(vec![]),
+                    options: Some(crate::config::WorkspaceOptions {
+                        layouts: Some(vec![]),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
             ]),

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -134,8 +134,7 @@ impl From<&State> for ManagerState {
         for ws in &state.workspaces {
             let tag_label = ws
                 .tag
-                .map(|tag_id| state.tags.get(tag_id).map(|tag| tag.label.clone()))
-                .unwrap_or(None)
+                .and_then(|tag_id| state.tags.get(tag_id).map(|tag| tag.label.clone()))
                 .unwrap_or(String::from("Unlabeled tag"));
 
             let layout_name: String = ws

--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -135,8 +135,8 @@ impl From<&State> for ManagerState {
             let tag_label = ws
                 .tag
                 .map(|tag_id| state.tags.get(tag_id).map(|tag| tag.label.clone()))
-                .unwrap()
-                .unwrap();
+                .unwrap_or(None)
+                .unwrap_or(String::from("Unlabeled tag"));
 
             let layout_name: String = ws
                 .tag

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -1,5 +1,5 @@
 use super::{DockArea, Size, WindowHandle, WorkspaceId};
-use crate::config::Workspace;
+use crate::config::WorkspaceOutput;
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 use x11_dl::xlib;
@@ -70,8 +70,8 @@ impl BBox {
     }
 }
 
-impl From<&Workspace> for Screen {
-    fn from(wsc: &Workspace) -> Self {
+impl From<&WorkspaceOutput> for Screen {
+    fn from(wsc: &WorkspaceOutput) -> Self {
         Self {
             bbox: BBox {
                 height: wsc.height,
@@ -80,7 +80,6 @@ impl From<&Workspace> for Screen {
                 y: wsc.y,
             },
             output: wsc.output.clone(),
-            max_window_width: wsc.max_window_width,
             ..Default::default()
         }
     }

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -177,7 +177,7 @@ impl Default for Tags {
 /// the same set of tags and windows are shared among
 /// all Workspaces, this means there aren't multiple instances of
 /// the same Tag on different Screens.
-#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tag {
     /// Unique identifier for the tag,
     /// this is automatically assigned by `LeftWM`.

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -94,6 +94,7 @@ impl Tags {
                 id: next_id,
                 label: label.to_string(),
                 hidden: true,
+                is_pinned: false,
             };
             let id = tag.id;
             self.hidden.push(tag);
@@ -105,6 +106,16 @@ impl Tags {
             );
             None
         }
+    }
+
+    /// Get all pinned tags
+    pub fn pinned(&self) -> Vec<&Tag> {
+        self.normal.iter().filter(|t| t.is_pinned).collect()
+    }
+
+    /// Get all non-pinned tags
+    pub fn non_pinned(&self) -> Vec<&Tag> {
+        self.normal.iter().filter(|t| !t.is_pinned).collect()
     }
 
     /// Get all normal tags
@@ -207,6 +218,9 @@ pub struct Tag {
     /// Hidden tags are internal only, and
     /// are unknown to other programs (eg. polybar)
     pub hidden: bool,
+
+    /// Indicated whether the tag is pinned to a workspace
+    pub is_pinned: bool,
 }
 
 impl Tag {
@@ -216,6 +230,7 @@ impl Tag {
             id,
             label: label.to_owned(),
             hidden: false,
+            is_pinned: false,
         }
     }
 

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -10,6 +10,7 @@ use super::WorkspaceId;
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Workspace {
     pub tag: Option<TagId>, // TODO: Make this a list.
+    pub pinned_tags: Vec<TagId>,
     pub margin: Margins,
     pub margin_multiplier: f32,
     pub gutters: Vec<Gutter>,
@@ -42,9 +43,10 @@ impl PartialEq for Workspace {
 
 impl Workspace {
     #[must_use]
-    pub fn new(bbox: BBox, id: usize) -> Self {
+    pub fn new(bbox: BBox, id: usize, pinned_tags: Option<Vec<TagId>>) -> Self {
         Self {
             tag: None,
+            pinned_tags: pinned_tags.unwrap_or_default(),
             margin: Margins::new(10),
             margin_multiplier: 1.0,
             gutters: vec![],
@@ -213,6 +215,7 @@ mod tests {
                 y: 0,
             },
             0,
+            None,
         );
         let w = Window::new(WindowHandle::MockHandle(1), None, None);
         assert!(
@@ -232,6 +235,7 @@ mod tests {
                 y: 0,
             },
             0,
+            None,
         );
         let tag = crate::models::Tag::new(TAG_ID, "test");
         subject.show_tag(&tag.id);

--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -28,6 +28,8 @@ fn main() {
 
     match exit_status {
         Ok(_) => tracing::info!("Completed"),
-        Err(err) => tracing::info!("Completed with error: {:?}", err),
+        Err(err) => {
+            tracing::info!("Completed with error: {:#?}", err);
+        }
     }
 }

--- a/leftwm/src/utils/log.rs
+++ b/leftwm/src/utils/log.rs
@@ -10,6 +10,9 @@ pub mod file;
 #[cfg(feature = "sys-log")]
 mod sys;
 
+/// # Panics
+///
+/// Will panic if can't get any subscriber
 pub fn setup_logging() {
     let subscribers = get_subscribers();
 


### PR DESCRIPTION
# Description

this PR is for adding the `pinned_tags` feature to the config, I'm submitting it even tho it's still WIP, but this could allow for reviews and critiques early on so it doesn't go too far without reviews and stuff

for now this supports pinning tags to a workspace, but lacks handling some edge cases

(also git history sucks but will fix it later)

the current breaking change is having to use `{ output: ... }` for the `workspaces` list, instead of `( output: ... )`

Fixes #978

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

add to the `pinned_tags` field of the config to the wiki page 

# Checklist:

- [ ] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)


# TODOs
- [x] add pinned_tags field to config (maybe could use tag index instead of tag name)
- [x] pin tags to workspaces
- [x] don't swap pinned tags out of the workspaces it's pinned at
- [x] fallback to a tag when moving a non-pinned tag to a workspace with pinned tags (swapping with pinned tags is prevented)
- [ ] move mouse to pinned tags when switching to it
- [ ] fix multiple workspaces with pinned tags
- [ ] add tests