### PR TITLE
Workspace selection for window placement

### DIFF
--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -56,6 +56,7 @@ pub trait Config {
     fn disable_tile_drag(&self) -> bool;
     fn disable_window_snap(&self) -> bool;
     fn sloppy_mouse_follows_focus(&self) -> bool;
+    fn create_follows_cursor(&self) -> bool;
     fn reposition_cursor_on_resize(&self) -> bool;
 
     /// Attempt to write current state to a file.
@@ -220,6 +221,10 @@ pub(crate) mod tests {
 
         fn reposition_cursor_on_resize(&self) -> bool {
             true
+        }
+
+        fn create_follows_cursor(&self) -> bool {
+            false
         }
     }
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -374,8 +374,8 @@ fn setup_window(
         .or(state.focus_manager.workspace(&state.workspaces)); // Else, use the workspace which has the focus.
 
     // If no workspace was found, put the window on tag 1.
-    // As it shouldn't happen, this function should either be made fallible or logs should be printed somewhere
     let Some(ws) = ws else {
+        tracing::warn!("setup_window failed to identify workspace. Falling back to tag 1");
         window.tag = Some(1);
         if is_scratchpad(state, window) {
             if let Some(scratchpad_tag) = state.tags.get_hidden_by_label("NSP") {

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -359,14 +359,19 @@ fn setup_window(
     is_first: &mut bool,
     on_same_tag: &mut bool,
 ) {
-    // When adding a window we add to the workspace under the cursor, This isn't necessarily the
-    // focused workspace. If the workspace is empty, it might not have received focus. This is so
-    // the workspace that has windows on its is still active not the empty workspace.
-    let ws: Option<&Workspace> = state
-        .workspaces
-        .iter()
-        .find(|ws| ws.xyhw.contains_point(xy.0, xy.1) && state.focus_manager.behaviour.is_sloppy())
-        .or_else(|| state.focus_manager.workspace(&state.workspaces)); // Backup plan.
+    // Identify the workspace in which to create the window.
+    let ws = state
+        .focus_manager
+        .create_follows_cursor() // If the window must be created under the cursor...
+        .then_some(
+            // ...look for the workspace with the cursor.
+            state
+                .workspaces
+                .iter()
+                .find(|ws| ws.xyhw.contains_point(xy.0, xy.1)),
+        )
+        .flatten()
+        .or(state.focus_manager.workspace(&state.workspaces)); // Else, use the workspace which has the focus.
 
     if let Some(ws) = ws {
         // Setup basic variables.

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -442,7 +442,7 @@ fn setup_window(
         return;
     }
 
-    // Setup a window is workspace is `None`. This shouldn't really happen.
+    // Setup a window if workspace is `None`. This shouldn't really happen.
     window.tag = Some(1);
     if is_scratchpad(state, window) {
         if let Some(scratchpad_tag) = state.tags.get_hidden_by_label("NSP") {

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -42,6 +42,7 @@ pub struct FocusManager {
     pub tag_history: VecDeque<TagId>,
     pub tags_last_window: HashMap<TagId, WindowHandle>,
     pub sloppy_mouse_follows_focus: bool,
+    pub create_follows_cursor: bool,
     pub last_mouse_position: Option<(i32, i32)>,
 }
 
@@ -55,6 +56,7 @@ impl FocusManager {
             tag_history: Default::default(),
             tags_last_window: Default::default(),
             sloppy_mouse_follows_focus: config.sloppy_mouse_follows_focus(),
+            create_follows_cursor: config.create_follows_cursor(),
             last_mouse_position: None,
         }
     }
@@ -110,5 +112,9 @@ impl FocusManager {
             return windows.iter_mut().find(|w| w.handle == handle);
         }
         None
+    }
+
+    pub fn create_follows_cursor(&self) -> bool {
+        self.create_follows_cursor
     }
 }

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -205,6 +205,23 @@ the cursor will be snapped to the lower right corner of the window which is
 being resized.
 .PP
 Default: \f[C]disable_cursor_reposition_on_resize = false\f[R]
+.SS Window Creation and Cursor Focus
+.PP
+In multi-workspace layouts (such as with multiple monitors), LeftWM
+will, by default, create the new window on the workspace where the cursor
+is currently located, even if that workspace is not the workspace which is focused.
+In Click-to-Focus and Driven Focus modes, however, it is often desirable to create
+the window in the focused workspace, not the one wherein the mouse is located. The
+\f[C]create_follows_cursor\f[R] feature allows for changing this behavior.
+New windows will be created in the workspace:
+.IP "-"
+.B  Containing the cursor
+when unset (\f[C]None\f[R]), \f[C]Some(true)\f[R], or when the cursor is in \f[C]Sloppy\f[R] mode
+.IP "-" 
+.B Which is focused
+when set to \f[C]Some(false)\f[R]
+.PP
+Default: \f[C]create_follows_cursor = None\f[R]
 .SS Layouts
 .PP
 Leftwm supports variety of layouts, which define the way that windows are tiled in the workspace

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -198,6 +198,7 @@ pub struct Config {
     pub focus_new_windows: bool,
     pub single_window_border: bool,
     pub sloppy_mouse_follows_focus: bool,
+    pub create_follows_cursor: Option<bool>,
     pub auto_derive_workspaces: bool,
     pub disable_cursor_reposition_on_resize: bool,
     #[cfg(feature = "lefthk")]
@@ -660,6 +661,14 @@ impl leftwm_core::Config for Config {
 
     fn reposition_cursor_on_resize(&self) -> bool {
         !self.disable_cursor_reposition_on_resize
+    }
+
+    // Determines if a new window should be created under the cursor or on the workspace which has the focus
+    fn create_follows_cursor(&self) -> bool {
+        // If follow behaviour has been explicitly set, use that value.
+        // If not, set it to true in Sloppy mode only.
+        self.create_follows_cursor
+            .unwrap_or(self.focus_behaviour == FocusBehaviour::Sloppy)
     }
 }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -237,6 +237,7 @@ impl Default for Config {
             max_window_width: None,
             state_path: None,
             sloppy_mouse_follows_focus: true,
+            create_follows_cursor: None,
             disable_cursor_reposition_on_resize: false,
             auto_derive_workspaces: true,
         }


### PR DESCRIPTION
# Description

This PR introduces the new configuration option `create_follows_cursor: Option<bool>`.

New windows will follow:
- the cursor if set to `Some(true)`
- the focus if set to `Some(false)`
- the cursor in `Sloppy` mode / the focus in any other mode if set to `None` or unset

Fixes #781

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

The [FocusBehaviour](https://github.com/leftwm/leftwm/wiki/Config#focus-behaviour) section of the documentation and man page should be updated accordingly with a paragraph resembling the description of this PR.

# Checklist:

- [x] Ran `make test-full` locally **BUT TESTS SEEM TO BE BROKEN**
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
