### PR TITLE
Bump `lefthk` to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,16 +543,19 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lefthk-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc9c7fbe62556de24a1cc06990be6d4ed9d26711d58163e43a7231cedd015b7"
+checksum = "c9551a0424abef2e998b6d60b1e58ba865bcdd513c89f2695616f7b84e59ac04"
 dependencies = [
- "log",
+ "inventory",
  "mio",
- "nix 0.23.2",
+ "nix",
+ "ron",
+ "serde",
  "signal-hook",
  "thiserror",
  "tokio",
+ "tracing",
  "x11-dl",
  "xdg",
 ]
@@ -567,7 +576,7 @@ dependencies = [
  "leftwm-macros",
  "liquid",
  "mio",
- "nix 0.27.1",
+ "nix",
  "once_cell",
  "regex",
  "ron",
@@ -597,7 +606,7 @@ dependencies = [
  "futures",
  "leftwm-layouts",
  "mio",
- "nix 0.27.1",
+ "nix",
  "serde",
  "serde_json",
  "signal-hook",
@@ -718,15 +727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,19 +745,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = "1.13.0"
 dirs-next = "2.0.0"
 futures = "0.3.21"
 git-version = "0.3.5"
-lefthk-core = { version = '0.1.8', optional = true }
+lefthk-core = { version = '0.1.9', optional = true }
 leftwm-core = { path = "../leftwm-core", version = '0.4.2' }
 leftwm-macros = {path = "../leftwm-macros", version = '0.4.2'}
 leftwm-layouts = "0.8.4"

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -4,6 +4,7 @@ use super::BaseCommand;
 use crate::Config;
 #[cfg(feature = "lefthk")]
 use anyhow::{ensure, Context, Result};
+use lefthk_core::config::Command;
 #[cfg(feature = "lefthk")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "lefthk")]
@@ -104,7 +105,7 @@ impl Keybind {
             head
         };
         Ok(lefthk_core::config::Keybind {
-            command: lefthk_core::config::Command::Execute(command),
+            command: lefthk_core::config::command::Execute::new(&command).normalize(),
             modifier: self
                 .modifier
                 .as_ref()

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -4,6 +4,7 @@ use super::BaseCommand;
 use crate::Config;
 #[cfg(feature = "lefthk")]
 use anyhow::{ensure, Context, Result};
+#[cfg(feature = "lefthk")]
 use lefthk_core::config::Command;
 #[cfg(feature = "lefthk")]
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
# Description

Simple change to bump `lefthk` to 0.1.9, and support the new command types that come with that version.

## Todo

- [x] change `lefthk` version in `leftwm/Cargo.toml` (after `lefthk` update).

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
