### PR TITLE
Refactor window sorting

### DIFF
--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -100,7 +100,7 @@ impl DisplayServer for XlibDisplayServer {
             DisplayAction::Unfocus(h, f) => from_unfocus(xw, h, f),
             DisplayAction::ReplayClick(h, b) => from_replay_click(xw, h, b),
             DisplayAction::SetState(h, t, s) => from_set_state(xw, h, t, s),
-            DisplayAction::SetWindowOrder(fs, ws) => from_set_window_order(xw, fs, ws),
+            DisplayAction::SetWindowOrder(ws) => from_set_window_order(xw, ws),
             DisplayAction::MoveToTop(h) => from_move_to_top(xw, h),
             DisplayAction::ReadyToMoveWindow(h) => from_ready_to_move_window(xw, h),
             DisplayAction::ReadyToResizeWindow(h) => from_ready_to_resize_window(xw, h),
@@ -299,11 +299,7 @@ fn from_set_state(
     None
 }
 
-fn from_set_window_order(
-    xw: &mut XWrap,
-    fullscreen: Vec<WindowHandle>,
-    windows: Vec<WindowHandle>,
-) -> Option<DisplayEvent> {
+fn from_set_window_order(xw: &mut XWrap, windows: Vec<WindowHandle>) -> Option<DisplayEvent> {
     // Unmanaged windows.
     let unmanaged: Vec<WindowHandle> = xw
         .get_all_windows()
@@ -311,10 +307,10 @@ fn from_set_window_order(
         .iter()
         .filter(|&w| *w != xw.get_default_root())
         .map(|&w| w.into())
-        .filter(|&h| !windows.iter().any(|&w| w == h) || !fullscreen.iter().any(|&w| w == h))
+        .filter(|h| !windows.iter().any(|w| w == h))
         .collect();
-    let all: Vec<WindowHandle> = [fullscreen, unmanaged, windows].concat();
-    xw.restack(all);
+    // Unmanaged windows on top.
+    xw.restack([unmanaged, windows].concat());
     None
 }
 

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -41,7 +41,7 @@ impl XWrap {
         }
         w.legacy_name = legacy_name;
         w.r#type = r#type.clone();
-        w.set_states(states);
+        w.states = states;
         if let Some(trans) = trans {
             w.transient = Some(trans.into());
         }

--- a/leftwm-core/src/display_action.rs
+++ b/leftwm-core/src/display_action.rs
@@ -28,7 +28,7 @@ pub enum DisplayAction {
 
     /// Sets the "z-index" order of the windows
     /// first in the array is top most
-    SetWindowOrder(Vec<WindowHandle>, Vec<WindowHandle>),
+    SetWindowOrder(Vec<WindowHandle>),
 
     /// Raises a given window.
     MoveToTop(WindowHandle),

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -237,7 +237,7 @@ fn focus_previous_used_tag(state: &mut State) -> Option<bool> {
 fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {
     let window = state.focus_manager.window(&state.windows)?;
     let handle = window.handle;
-    let toggle_to = !window.has_state(&window_state);
+    let toggle_to = !window.states.contains(&window_state);
     let tag_id = state.focus_manager.tag(0)?;
 
     if window_state == WindowState::Fullscreen || window_state == WindowState::Maximized {
@@ -954,13 +954,9 @@ mod tests {
                         || window_state == WindowState::Maximized
                     {
                         if toggle_to {
-                            window.set_states(vec![window_state]);
-                        } else if let Some(state_pos) =
-                            window.states().iter().position(|s| *s == window_state)
-                        {
-                            let mut states = window.states();
-                            states.remove(state_pos);
-                            window.set_states(states);
+                            window.states = vec![window_state];
+                        } else {
+                            window.states.retain(|s| s != &window_state);
                         }
                     }
                 }
@@ -989,7 +985,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Fullscreen)));
+            .any(|w| w.states.contains(&WindowState::Fullscreen)));
 
         manager.command_handler(&Command::ToggleFullScreen);
 
@@ -998,7 +994,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Fullscreen)));
+            .any(|w| w.states.contains(&WindowState::Fullscreen)));
 
         // Mess with the window positions
         manager.state.windows.reverse();
@@ -1037,7 +1033,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Fullscreen)));
+            .any(|w| w.states.contains(&WindowState::Fullscreen)));
 
         manager.command_handler(&Command::ToggleFullScreen);
         mock_update(&mut manager);
@@ -1046,7 +1042,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Fullscreen)));
+            .any(|w| w.states.contains(&WindowState::Fullscreen)));
 
         // Mess with the window positions
         manager.state.windows.reverse();
@@ -1071,7 +1067,7 @@ mod tests {
                 .state
                 .windows
                 .iter()
-                .find(|w| w.has_state(&WindowState::Fullscreen))
+                .find(|w| w.states.contains(&WindowState::Fullscreen))
                 .iter()
                 .count(),
             1
@@ -1085,7 +1081,7 @@ mod tests {
                 .state
                 .windows
                 .iter()
-                .filter(|w| w.has_state(&WindowState::Fullscreen))
+                .filter(|w| w.states.contains(&WindowState::Fullscreen))
                 .count(),
             2
         );
@@ -1147,7 +1143,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Maximized)));
+            .any(|w| w.states.contains(&WindowState::Maximized)));
 
         manager.command_handler(&Command::ToggleMaximized);
 
@@ -1156,7 +1152,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Maximized)));
+            .any(|w| w.states.contains(&WindowState::Maximized)));
 
         // Mess with the window positions
         manager.state.windows.reverse();
@@ -1195,7 +1191,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Maximized)));
+            .any(|w| w.states.contains(&WindowState::Maximized)));
 
         manager.command_handler(&Command::ToggleMaximized);
         mock_update(&mut manager);
@@ -1204,7 +1200,7 @@ mod tests {
             .state
             .windows
             .iter()
-            .any(|w| w.has_state(&WindowState::Maximized)));
+            .any(|w| w.states.contains(&WindowState::Maximized)));
 
         // Mess with the window positions
         manager.state.windows.reverse();
@@ -1229,7 +1225,7 @@ mod tests {
                 .state
                 .windows
                 .iter()
-                .find(|w| w.has_state(&WindowState::Maximized))
+                .find(|w| w.states.contains(&WindowState::Maximized))
                 .iter()
                 .count(),
             1
@@ -1243,7 +1239,7 @@ mod tests {
                 .state
                 .windows
                 .iter()
-                .filter(|w| w.has_state(&WindowState::Maximized))
+                .filter(|w| w.states.contains(&WindowState::Maximized))
                 .count(),
             2
         );

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -140,7 +140,7 @@ fn prepare_window(state: &mut State, handle: WindowHandle) {
                 false,
                 WindowState::Fullscreen,
             ));
-            w.drop_state(&WindowState::Fullscreen);
+            w.states.retain(|s| s != &WindowState::Fullscreen);
             // Force update for all windows
             state.mode = Mode::ReadyToResize(handle);
         }
@@ -151,9 +151,9 @@ fn prepare_window(state: &mut State, handle: WindowHandle) {
                 false,
                 WindowState::Maximized,
             ));
-            w.drop_state(&WindowState::Maximized);
-            w.drop_state(&WindowState::MaximizedHorz);
-            w.drop_state(&WindowState::MaximizedVert);
+            w.states.retain(|s| s != &WindowState::Maximized);
+            w.states.retain(|s| s != &WindowState::MaximizedHorz);
+            w.states.retain(|s| s != &WindowState::MaximizedVert);
             // Force update for all windows
             state.mode = Mode::ReadyToResize(handle);
         }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -22,22 +22,6 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         // Setup any predifined hooks.
         self.config
             .setup_predefined_window(&mut self.state, &mut window);
-
-        if let Some(transient_handle) = window.transient {
-            if let Some(parent) = self
-                .state
-                .windows
-                .iter()
-                .find(|w| w.handle == transient_handle)
-            {
-                if parent.is_fullscreen() || parent.is_maximized() {
-                    let act = DisplayAction::SetState(window.handle, true, WindowState::Above);
-                    self.state.actions.push_back(act);
-                    window.states.push(WindowState::Above);
-                }
-            }
-        }
-
         let mut is_first = false;
         let mut on_same_tag = true;
         // Random value

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -22,6 +22,22 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
         // Setup any predifined hooks.
         self.config
             .setup_predefined_window(&mut self.state, &mut window);
+
+        if let Some(transient_handle) = window.transient {
+            if let Some(parent) = self
+                .state
+                .windows
+                .iter()
+                .find(|w| w.handle == transient_handle)
+            {
+                if parent.is_fullscreen() || parent.is_maximized() {
+                    let act = DisplayAction::SetState(window.handle, true, WindowState::Above);
+                    self.state.actions.push_back(act);
+                    window.states.push(WindowState::Above);
+                }
+            }
+        }
+
         let mut is_first = false;
         let mut on_same_tag = true;
         // Random value

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -58,7 +58,7 @@ pub struct Window {
     pub border: i32,
     pub margin: Margins,
     pub margin_multiplier: f32,
-    states: Vec<WindowState>,
+    pub states: Vec<WindowState>,
     pub requested: Option<Xyhw>,
     pub normal: Xyhw,
     pub start_loc: Option<Xyhw>,
@@ -193,24 +193,6 @@ impl Window {
 
     pub fn set_height(&mut self, height: i32) {
         self.normal.set_h(height);
-    }
-
-    pub fn set_states(&mut self, states: Vec<WindowState>) {
-        self.states = states;
-    }
-
-    pub fn drop_state(&mut self, state: &WindowState) {
-        self.states.retain(|s| s != state);
-    }
-
-    #[must_use]
-    pub fn has_state(&self, state: &WindowState) -> bool {
-        self.states.contains(state)
-    }
-
-    #[must_use]
-    pub fn states(&self) -> Vec<WindowState> {
-        self.states.clone()
     }
 
     pub fn apply_margin_multiplier(&mut self, value: f32) {

--- a/leftwm-core/src/models/window_change.rs
+++ b/leftwm-core/src/models/window_change.rs
@@ -91,7 +91,7 @@ impl WindowChange {
         }
         if let Some(states) = self.states {
             changed = true;
-            window.set_states(states);
+            window.states = states;
         }
         changed
     }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -4,8 +4,8 @@ use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::LayoutManager;
 use crate::models::{
-    FocusManager, Mode, ScratchPadName, Screen, TagId, Tags, Window, WindowHandle, WindowState,
-    WindowType, Workspace,
+    FocusManager, Mode, ScratchPadName, Screen, TagId, Tags, Window, WindowHandle, WindowType,
+    Workspace,
 };
 use crate::DisplayAction;
 use leftwm_layouts::Layout;
@@ -82,9 +82,6 @@ impl State {
         // Fullscreen windows
         sorter.sort(Window::is_fullscreen);
 
-        // Maximized windows.
-        sorter.sort(|w| w.r#type == WindowType::Normal && w.is_maximized());
-
         // Dialogs and modals.
         sorter.sort(|w| {
             w.r#type == WindowType::Dialog
@@ -95,6 +92,9 @@ impl State {
 
         // Floating windows.
         sorter.sort(|w| w.r#type == WindowType::Normal && w.floating());
+
+        // Maximized windows.
+        sorter.sort(|w| w.r#type == WindowType::Normal && w.is_maximized());
 
         // Tiled windows.
         sorter.sort(|w| w.r#type == WindowType::Normal);

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -4,8 +4,8 @@ use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::LayoutManager;
 use crate::models::{
-    FocusManager, Mode, ScratchPadName, Screen, TagId, Tags, Window, WindowHandle, WindowType,
-    Workspace,
+    FocusManager, Mode, ScratchPadName, Screen, TagId, Tags, Window, WindowHandle, WindowState,
+    WindowType, Workspace,
 };
 use crate::DisplayAction;
 use leftwm_layouts::Layout;
@@ -226,7 +226,7 @@ impl State {
                     new_tag.iter().for_each(|&tag_id| new_window.tag(&tag_id));
                 }
                 new_window.strut = old_window.strut;
-                new_window.set_states(old_window.states());
+                new_window.states = old_window.states.clone();
                 ordered.push(new_window.clone());
                 self.windows.remove(index);
 

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -70,14 +70,8 @@ impl State {
     pub fn sort_windows(&mut self) {
         let mut sorter = WindowSorter::new(self.windows.iter().collect());
 
-        // Transient windows should be above a fullscreen/maximized parent
-        sorter.sort(|w| {
-            w.transient.is_some_and(|trans| {
-                self.windows
-                    .iter()
-                    .any(|w| w.handle == trans && (w.is_fullscreen() || w.is_maximized()))
-            })
-        });
+        // Windows explicitly marked as on top
+        sorter.sort(|w| w.states.contains(&WindowState::Above));
 
         // Fullscreen windows
         sorter.sort(Window::is_fullscreen);

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -70,8 +70,14 @@ impl State {
     pub fn sort_windows(&mut self) {
         let mut sorter = WindowSorter::new(self.windows.iter().collect());
 
-        // Windows explicitly marked as on top
-        sorter.sort(|w| w.states.contains(&WindowState::Above));
+        // Transient windows should be above a fullscreen/maximized parent
+        sorter.sort(|w| {
+            w.transient.is_some_and(|trans| {
+                self.windows
+                    .iter()
+                    .any(|w| w.handle == trans && (w.is_fullscreen() || w.is_maximized()))
+            })
+        });
 
         // Fullscreen windows
         sorter.sort(Window::is_fullscreen);


### PR DESCRIPTION
# Description

- Refactor to the window sorting to a cleaner solution.
- Refactor `Window.states` to `pub` (set and get methods were there, so why not make it it pub)
- Move from manually getting transient windows whilst sorting windows to adding the `Above` WM state to them.
- Side-effect: We now sort windows with the `Above` WM state on top of everything. Windows set this property on their own.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  - As the window sorting now understands the `Above` WM hint, windows can set themselves to be on top.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - This pr places unmanaged windows above **all** windows instead of all but fullscreen. A visible unmanaged window is yet to be found, so it's not marked as breaking.
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
