### PR TITLE
Rework fullscreen order restoring

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -238,34 +238,6 @@ fn toggle_state(state: &mut State, window_state: WindowState) -> Option<bool> {
     let window = state.focus_manager.window(&state.windows)?;
     let handle = window.handle;
     let toggle_to = !window.states.contains(&window_state);
-    let tag_id = state.focus_manager.tag(0)?;
-
-    if window_state == WindowState::Fullscreen || window_state == WindowState::Maximized {
-        // Going to fullscreen or maximized, so we save the window order
-        // or else, we restore it!
-        if toggle_to {
-            let handles = state
-                .windows
-                .iter()
-                .filter(|window| window.tag == Some(tag_id) && window.is_managed())
-                .map(|w| w.handle)
-                .collect();
-
-            state.window_history.insert(tag_id, handles);
-        } else if let Some(window_order) = state.window_history.get(&tag_id) {
-            for window_handle in window_order {
-                if let Some(pos) = state
-                    .windows
-                    .iter()
-                    .position(|w| w.handle == *window_handle)
-                {
-                    let window = state.windows.remove(pos);
-                    state.windows.push(window);
-                }
-            }
-        }
-    }
-
     let act = DisplayAction::SetState(handle, toggle_to, window_state);
     state.actions.push_back(act);
     state.handle_window_focus(&handle);
@@ -905,37 +877,6 @@ mod tests {
     use super::*;
     use crate::models::Tags;
 
-    fn split_window_vec(windows: Vec<Window>, first_tag_id: usize) -> (Vec<Window>, Vec<Window>) {
-        let mut windows_first_tag = vec![];
-        let mut windows_second_tag = vec![];
-
-        for w in windows {
-            if w.tag == Some(first_tag_id) {
-                windows_first_tag.push(w);
-            } else {
-                windows_second_tag.push(w);
-            }
-        }
-
-        (windows_first_tag, windows_second_tag)
-    }
-
-    fn get_current_handles(
-        manager: &mut Manager<
-            crate::config::tests::TestConfig,
-            crate::display_servers::MockDisplayServer,
-        >,
-        tag_id: Option<TagId>,
-    ) -> Vec<WindowHandle> {
-        manager
-            .state
-            .windows
-            .iter()
-            .filter(|window| window.tag == tag_id && window.is_managed())
-            .map(|w| w.handle)
-            .collect::<Vec<_>>()
-    }
-
     fn mock_update(
         manager: &mut Manager<
             crate::config::tests::TestConfig,
@@ -967,8 +908,6 @@ mod tests {
     #[test]
     fn toggle_fullscreen() {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
-        let tag_id = manager.state.tags.get(1).unwrap().id;
-
         manager.screen_create_handler(Screen::default());
 
         for i in 1..=3 {
@@ -978,8 +917,6 @@ mod tests {
                 -1,
             );
         }
-
-        let expected = get_current_handles(&mut manager, Some(tag_id));
 
         assert!(!manager
             .state
@@ -995,138 +932,11 @@ mod tests {
             .windows
             .iter()
             .any(|w| w.states.contains(&WindowState::Fullscreen)));
-
-        // Mess with the window positions
-        manager.state.windows.reverse();
-
-        let actual = get_current_handles(&mut manager, Some(tag_id));
-
-        assert_ne!(expected, actual);
-
-        manager.command_handler(&Command::ToggleFullScreen);
-        mock_update(&mut manager);
-
-        let actual = get_current_handles(&mut manager, Some(tag_id));
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn toggle_fullscreen_with_multiple_tags() {
-        let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-
-        let first_tag = manager.state.tags.get(1).unwrap().id;
-        let second_tag = manager.state.tags.get(2).unwrap().id;
-
-        manager.screen_create_handler(Screen::default());
-
-        for i in 1..=3 {
-            manager.window_created_handler(
-                Window::new(WindowHandle::MockHandle(i), None, None),
-                -1,
-                -1,
-            );
-        }
-
-        let expected_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
-
-        assert!(!manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Fullscreen)));
-
-        manager.command_handler(&Command::ToggleFullScreen);
-        mock_update(&mut manager);
-
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Fullscreen)));
-
-        // Mess with the window positions
-        manager.state.windows.reverse();
-
-        assert!(manager.command_handler(&Command::GoToTag {
-            tag: 2,
-            swap: false
-        }));
-
-        for i in 4..=6 {
-            manager.window_created_handler(
-                Window::new(WindowHandle::MockHandle(i), None, None),
-                -1,
-                -1,
-            );
-        }
-
-        let expected_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
-
-        assert_eq!(
-            manager
-                .state
-                .windows
-                .iter()
-                .find(|w| w.states.contains(&WindowState::Fullscreen))
-                .iter()
-                .count(),
-            1
-        );
-
-        manager.command_handler(&Command::ToggleFullScreen);
-        mock_update(&mut manager);
-
-        assert_eq!(
-            manager
-                .state
-                .windows
-                .iter()
-                .filter(|w| w.states.contains(&WindowState::Fullscreen))
-                .count(),
-            2
-        );
-
-        // Mess with the windows positions of the second tag
-        let (mut windows_first_tag, mut windows_second_tag) =
-            split_window_vec(manager.state.windows, first_tag);
-        windows_second_tag.reverse();
-        windows_first_tag.append(&mut windows_second_tag);
-        manager.state.windows = windows_first_tag;
-
-        manager.command_handler(&Command::GoToTag {
-            tag: 1,
-            swap: false,
-        });
-
-        manager.command_handler(&Command::ToggleFullScreen);
-        mock_update(&mut manager);
-
-        manager.command_handler(&Command::GoToTag {
-            tag: 2,
-            swap: false,
-        });
-
-        manager.command_handler(&Command::ToggleFullScreen);
-        mock_update(&mut manager);
-
-        let actual_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
-        let actual_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
-
-        assert_eq!(
-            expected_first_tag_window_order,
-            actual_first_tag_window_order
-        );
-        assert_eq!(
-            expected_second_tag_window_order,
-            actual_second_tag_window_order
-        );
     }
 
     #[test]
     fn toggle_maximized() {
         let mut manager = Manager::new_test(vec!["1".to_string()]);
-        let tag_id = manager.state.tags.get(1).unwrap().id;
-
         manager.screen_create_handler(Screen::default());
 
         for i in 1..=3 {
@@ -1136,8 +946,6 @@ mod tests {
                 -1,
             );
         }
-
-        let expected = get_current_handles(&mut manager, Some(tag_id));
 
         assert!(!manager
             .state
@@ -1153,31 +961,14 @@ mod tests {
             .windows
             .iter()
             .any(|w| w.states.contains(&WindowState::Maximized)));
-
-        // Mess with the window positions
-        manager.state.windows.reverse();
-
-        let actual = get_current_handles(&mut manager, Some(tag_id));
-
-        assert_ne!(expected, actual);
-
-        manager.command_handler(&Command::ToggleMaximized);
-        mock_update(&mut manager);
-
-        let actual = get_current_handles(&mut manager, Some(tag_id));
-        assert_eq!(expected, actual);
     }
 
     #[test]
-    fn toggle_maximized_with_multiple_tags() {
-        let mut manager = Manager::new_test(vec!["1".to_string(), "2".to_string()]);
-
-        let first_tag = manager.state.tags.get(1).unwrap().id;
-        let second_tag = manager.state.tags.get(2).unwrap().id;
-
+    fn fullscreen_window_sorting() {
+        let mut manager = Manager::new_test(vec!["1".to_string()]);
         manager.screen_create_handler(Screen::default());
 
-        for i in 1..=3 {
+        for i in 1..=4 {
             manager.window_created_handler(
                 Window::new(WindowHandle::MockHandle(i), None, None),
                 -1,
@@ -1185,99 +976,27 @@ mod tests {
             );
         }
 
-        let expected_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
-
-        assert!(!manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Maximized)));
-
+        manager.state.focus_window(&WindowHandle::MockHandle(2));
         manager.command_handler(&Command::ToggleMaximized);
+
+        manager.state.focus_window(&WindowHandle::MockHandle(3));
+        manager.command_handler(&Command::ToggleFullScreen);
+
         mock_update(&mut manager);
+        manager.state.sort_windows();
 
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Maximized)));
+        // Fullscreen(3) > maximized(2) > normal(1) + normal(4)
+        let expected_order = vec![
+            WindowHandle::MockHandle(3),
+            WindowHandle::MockHandle(2),
+            WindowHandle::MockHandle(1),
+            WindowHandle::MockHandle(4),
+        ];
 
-        // Mess with the window positions
-        manager.state.windows.reverse();
-
-        assert!(manager.command_handler(&Command::GoToTag {
-            tag: 2,
-            swap: false
-        }));
-
-        for i in 4..=6 {
-            manager.window_created_handler(
-                Window::new(WindowHandle::MockHandle(i), None, None),
-                -1,
-                -1,
-            );
+        match manager.state.actions.get(0).unwrap() {
+            DisplayAction::SetWindowOrder(order) => assert_eq!(order, &expected_order),
+            _ => unreachable!("No other update should be left"),
         }
-
-        let expected_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
-
-        assert_eq!(
-            manager
-                .state
-                .windows
-                .iter()
-                .find(|w| w.states.contains(&WindowState::Maximized))
-                .iter()
-                .count(),
-            1
-        );
-
-        manager.command_handler(&Command::ToggleMaximized);
-        mock_update(&mut manager);
-
-        assert_eq!(
-            manager
-                .state
-                .windows
-                .iter()
-                .filter(|w| w.states.contains(&WindowState::Maximized))
-                .count(),
-            2
-        );
-
-        // Mess with the windows positions of the second tag
-        let (mut windows_first_tag, mut windows_second_tag) =
-            split_window_vec(manager.state.windows, first_tag);
-        windows_second_tag.reverse();
-        windows_first_tag.append(&mut windows_second_tag);
-        manager.state.windows = windows_first_tag;
-
-        manager.command_handler(&Command::GoToTag {
-            tag: 1,
-            swap: false,
-        });
-
-        manager.command_handler(&Command::ToggleMaximized);
-        mock_update(&mut manager);
-
-        manager.command_handler(&Command::GoToTag {
-            tag: 2,
-            swap: false,
-        });
-
-        manager.command_handler(&Command::ToggleMaximized);
-        mock_update(&mut manager);
-
-        let actual_first_tag_window_order = get_current_handles(&mut manager, Some(first_tag));
-        let actual_second_tag_window_order = get_current_handles(&mut manager, Some(second_tag));
-
-        assert_eq!(
-            expected_first_tag_window_order,
-            actual_first_tag_window_order
-        );
-        assert_eq!(
-            expected_second_tag_window_order,
-            actual_second_tag_window_order
-        );
     }
 
     #[test]

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -4,8 +4,7 @@ use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::LayoutManager;
 use crate::models::{
-    FocusManager, Mode, ScratchPadName, Screen, TagId, Tags, Window, WindowHandle, WindowType,
-    Workspace,
+    FocusManager, Mode, ScratchPadName, Screen, Tags, Window, WindowHandle, WindowType, Workspace,
 };
 use crate::DisplayAction;
 use leftwm_layouts::Layout;
@@ -16,7 +15,6 @@ use std::collections::{HashMap, VecDeque};
 pub struct State {
     pub screens: Vec<Screen>,
     pub windows: Vec<Window>,
-    pub window_history: HashMap<TagId, Vec<WindowHandle>>,
     pub workspaces: Vec<Workspace>,
     pub focus_manager: FocusManager,
     pub layout_manager: LayoutManager,
@@ -44,7 +42,6 @@ impl State {
         tags.add_new_hidden("NSP");
 
         Self {
-            window_history: HashMap::new(),
             focus_manager: FocusManager::new(config),
             layout_manager: LayoutManager::new(config),
             scratchpads: config.create_list_of_scratchpads(),
@@ -104,9 +101,7 @@ impl State {
 
         // Finish and put all unsorted at the end.
         let windows = sorter.finish();
-
         let handles = windows.iter().map(|w| w.handle).collect();
-        self.windows = windows.into_iter().cloned().collect();
 
         let act = DisplayAction::SetWindowOrder(handles);
         self.actions.push_back(act);


### PR DESCRIPTION
- [x] **Blocked** - waiting for #1156. This is currently based ontop of `Eskaan:refactor-window-sorting`, as it has conflicts with this branch. Will be rebased as soon as it gets merged. Only additional commit is 489155e292d80004949ef96ff63238ebcdaadabf.

# Description

Massively simplify #1052 by removing [line 124](https://github.com/leftwm/leftwm/blob/7628b688be4aafb155b1efdd09125de891e212a7/leftwm-core/src/state.rs#L124) from state.rs

Also a non-noticeable performance improvement by not having to do all the moves to restore the order.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.