### PR TITLE
Add `ToggleAbove` command

### DIFF
--- a/leftwm-core/src/command.rs
+++ b/leftwm-core/src/command.rs
@@ -26,6 +26,7 @@ pub enum Command {
     ToggleFullScreen,
     ToggleMaximized,
     ToggleSticky,
+    ToggleAbove,
     GoToTag {
         tag: TagId,
         swap: bool,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -70,8 +70,8 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
 
         Command::ToggleMaximized => toggle_state(state, WindowState::Maximized),
         Command::ToggleFullScreen => toggle_state(state, WindowState::Fullscreen),
-
         Command::ToggleSticky => toggle_state(state, WindowState::Sticky),
+        Command::ToggleAbove => toggle_state(state, WindowState::Above),
 
         Command::SendWindowToTag { window, tag } => move_to_tag(*window, *tag, manager),
         Command::MoveWindowToNextTag { follow } => move_to_tag_relative(manager, *follow, 1),

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -236,7 +236,8 @@ impl Tag {
                 .iter_mut()
                 .filter(|w| {
                     w.has_tag(&self.id)
-                        && w.transient.unwrap_or_else(|| 0.into()) == handle
+                        && (w.transient == Some(handle)
+                            || w.states().contains(&super::WindowState::Above) && w.floating())
                         && w.is_managed()
                 })
                 .for_each(|w| {

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -179,6 +179,7 @@ fn parse_command(s: &str) -> Result<Command, Box<dyn std::error::Error>> {
         "ToggleFullScreen" => Ok(Command::ToggleFullScreen),
         "ToggleMaximized" => Ok(Command::ToggleMaximized),
         "ToggleSticky" => Ok(Command::ToggleSticky),
+        "ToggleAbove" => Ok(Command::ToggleAbove),
         // General
         "CloseWindow" => Ok(Command::CloseWindow),
         "CloseAllOtherWindows" => Ok(Command::CloseAllOtherWindows),

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -31,6 +31,7 @@ pub enum BaseCommand {
     ToggleFullScreen,
     ToggleMaximized,
     ToggleSticky,
+    ToggleAbove,
     GotoTag,
     ReturnToLastTag,
     FloatingToTile,


### PR DESCRIPTION
# Description

Add a command to control `WindowState::Above`, `ToggleAbove`.

Fixes #1094 

This also makes a slight change to the detection of fullscreen changes: The old code triggered not only on change, but also whenever the window was already in fullscreen.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Add `ToggleAbove` to the command list.

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.