### PR TITLE
Fix regression introduced in 4621dab

### DIFF
--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -252,7 +252,7 @@ impl Tag {
 
             windows
                 .iter_mut()
-                .filter(|w| w.has_tag(&self.id) && w.floating() && w.is_managed())
+                .filter(|w| w.has_tag(&self.id) && w.floating())
                 .for_each(|w| {
                     w.set_visible(true);
                 });


### PR DESCRIPTION
Maximizing a window would make unmanaged windows invisible. Basically I forgot to remove the `&& w.is_managed()`

Fixes #1162

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
