### PR TITLE
fixed dialog windows ignoring application-defined sizes

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -440,17 +440,27 @@ fn setup_window(
         WindowType::Normal => {
             window.apply_margin_multiplier(ws.margin_multiplier);
             if window.floating() {
-                set_relative_floating(window, ws, ws.xyhw);
+                match window.requested {
+                    Some(xyhw) => set_relative_floating(window, ws, xyhw),
+                    None => set_relative_floating(window, ws, ws.xyhw),
+                };
             }
         }
         WindowType::Dialog => {
             if window.can_resize() {
                 window.set_floating(true);
-                let new_float_exact = ws.center_halfed();
-                window.normal = ws.xyhw;
-                window.set_floating_exact(new_float_exact);
+                if let Some(xyhw) = window.requested {
+                    set_relative_floating(window, ws, xyhw);
+                } else {
+                    let new_float_exact = ws.center_halfed();
+                    window.normal = ws.xyhw;
+                    window.set_floating_exact(new_float_exact);
+                };
             } else {
-                set_relative_floating(window, ws, ws.xyhw);
+                match window.requested {
+                    Some(xyhw) => set_relative_floating(window, ws, xyhw),
+                    None => set_relative_floating(window, ws, ws.xyhw),
+                };
             }
         }
         WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),


### PR DESCRIPTION
# Description

Fixed an issue where leftwm would ignore the requested size of dialog-type windows when they are spawned, particularly when they are spawned without a parent. The previous behavior (which appears to be filling in the space left by the xyhw avoided) is still default when there is no desired size given. Additionally, this change has been carried over to splash screen windows and floating normal windows, just in case this issue applies to other windows with those types.

Fixes #1118 

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

N/A

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [x] Wiki pages have been updated accordingly (to perform **after** merge)
