### PR TITLE
chore: Release leftwm 0.5.0, XDS 0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Upload release artifacts
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  crate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install rust
+        id: rust-install
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install openssl
+        run: |
+          sudo apt update
+          sudo apt install openssl pkg-config libssl-dev
+          cargo clean
+          OPENSSL_LIB_DIR="/usr/lib/x86_64-linux-gnu"
+          OPENSSL_INCLUDE_DIR="/usr/include/openssl"
+
+      - name: Publish macros crate
+        if: github.event_name == 'release'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty -p leftwm-macros
+      - name: Publish display server crate
+        if: github.event_name == 'release'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty -p xlib-display-server
+      - name: Publish core crate
+        if: github.event_name == 'release'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty -p leftwm-core
+      - name: Publish binary crate
+        if: github.event_name == 'release'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty -p leftwm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Change
 
+### Deprecated
+
+### Removed
+
+### Added
+
+### Fixed
+
+## [0.5.0]
+
+### Breaking Change
+
 - The `layouts` and `workspace.layouts` in `config.ron` must be declared as Strings because they are no longer backed by an enum. (ie. use `layouts: ["CenterMain"]` instead of `layouts: [CenterMain]`)
 - The `max_window_width` config was removed without direct replacement. The "always fill entire screen" behavior can now be addressed by creating a custom layout with an appropriate `Reserve` property.
+- LeftWM now depends on `lefthk` ^0.2.0, which has been refactored (thanks to @blackdragon2447 in #1154)
 
 ### Deprecated
 
@@ -25,13 +38,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented the new [leftwm-layouts](https://github.com/leftwm/leftwm-layouts) library (via #1000 by @hertg)
 - Added `IncreaseMainSize` / `DecreaseMainSize` as a replacement for the deprecated `IncreaseMainWidth` / `DecreaseMainWidth` (closes #545 via #1000 by @hertg)
 - Added `ToggleMaximized` command (closes #973 via #1121 by @bksalman)
+- Added `ToggleAbove` command (closes #1094 via #1160 by @Eskaan)
 - Add support for multiple main windows on all layouts that have a main column, new commands are `IncreaseMainCount` and `DecreaseMainCount` (closes #516 via #1000 by @hertg)
 - use `unwrap_newtypes` extension in ron deserializer (via #1000 by @hertg)
+- Improved error and documentation for external commands using leftwm-command (thanks to @Silicasandwhich in #1098, resolves #1096)
+- General improvements to leftwm-log, including a nicer matching solution and feature-gates functions (thanks to @Eskaan in #1109)
+- `leftwm-command -l` has been parameterized using the `leftwm-macros` library (thanks to @Mautamu in #1115; closes #1095)
+- Added `disable_cursor_reposition_on_resize` option to config (thanks to @BKSalman in #1123)
+- Fullscreen ordering/resizing changes and other optimizations (from @Eskaan and @bksalman in #1136, #1164, #1158, #1159)
+- Commented example configuration (by @VuiMuich in #1133)
 - The currently supported MSRV is 1.70.0
 
 ### Fixed
 
 - Changing main width now works on all layouts that have a main column (fixes #96 via #1000 by @hertg)
+- Fixed a bug where windows would sometimes spawn on the last tag (fixes #1065 via #1093 by @Silicasandwhich)
+- `basic_lemonbar` theme now works if the user has only one workspace, the clock is independent of leftwm-state, the tags are now clickable and have better naming (thanks to @simtd in #1101)
+- Ron option checking by `leftwm-check` has been corrected when `#![enable(implicit_some)]` is not present (thanks to @samuelabreu in #1110)
+- `output` field has been returned to `leftwm-state` (thanks to @Eskaan in #1116, resolves #1111)
+- Maximized windows no longer hide dock and desktop (thank to @BkSalman in #1126)
+- Readme typos and changelog rename in #1113 thank to @Chudson16 and #1091 thanks to @Eskaan; various code formatting changes (thanks to Eskaan in #1117, #1120)
+- Dialog windows now obey application-defined sizes (thanks to @Silicasandwhich in #1166; closes #1118)
+- Nixos flake rewritten to use flake-parts (#1122 by @vesdev)
+- Moved windows no longer switch to the first tag (closes #1054 via #1161 by @Eskaan)
+- Clippy fixes and updates which results in MSRV=1.70.0 (by @VuiMuich, @cyril-marpaud, and @Mautamu in #1137, #1130, #1151)
 
 ## [0.4.2]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "dirs-next",
  "futures",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm-macros"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1581,7 +1581,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xlib-display-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "leftwm-core",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
         <img src="https://github.com/leftwm/leftwm/workflows/CI/badge.svg" alt="build status" />
     </a>
     <a href="https://github.com/leftwm/leftwm/wiki">
-        <img src="https://img.shields.io/badge/wiki-0.4.2-green.svg" alt="wiki" />
+        <img src="https://img.shields.io/badge/wiki-0.5.0-green.svg" alt="wiki" />
     </a>
     <a href="https://docs.rs/leftwm/">
         <img src="https://docs.rs/leftwm/badge.svg" alt="Documentation" />
@@ -66,7 +66,7 @@ LeftWM follows the following mantra:
 > LeftWM is not a compositor.  
 > LeftWM is not a lock screen.  
 > LeftWM is not a bar. But, there are lots of good bars out there. With themes, picking one is as
-  simple as setting a symlink.
+> simple as setting a symlink.
 
 Because you probably want more than just a black screen, LeftWM is built around the concept of
 themes. With themes, you can choose between different bars, compositors, backgrounds, colors, docks,
@@ -102,25 +102,25 @@ While LeftWM has very few dependencies, this isn't always the case for themes.
 Themes typically require the following to be installed. However, this is up to the
 author of the theme and could be different.
 
-List of LeftWM dependencies:  
+List of LeftWM dependencies:
 
-- xorg (runtime, build): specifically libx11, xrandr, xorg-server, libxinerama  
+- xorg (runtime, build): specifically libx11, xrandr, xorg-server, libxinerama
 - sh (runtime): any posix-compliant shell for starting up and down files
 - rust (build): >= 1.70.0
 - bash (optional): Most of the themes available use bash, though the scripts maybe converted to any posix-compliant shell
 
 List of common dependencies for themes:
 
-| Dependency<br>(git) | Ubuntu 20.4.1<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 33<br> _sudo dnf install {}_ | PKGS |
-|--------------------------|-----------|-------------------|-----------|--------------------------|
-| [feh][feh-git]           | feh       | feh               | feh       | [feh][feh-pkg]           |
-| [compton][compton-git]   | compton   | picom             | compton   | [compton][compton-pkg]   |
-| [picom][picom-git]       | manual ** | picom             | picom     | [picom][picom-pkg]       |
-| [polybar][polybar-git]   | manual ** | polybar           | polybar   | [polybar][polybar-pkg]   |
-| [xmobar][xmobar-git]     | xmobar    | xmobar            | xmobar    | [xmobar][xmobar-pkg]     |
-| [lemonbar][lemonbar-git] | lemonbar  | paru -S lemonbar* | manual ** | [lemonbar][lemonbar-pkg] |
-| [conky][conky-git]       | conky     | conky             | conky     | [conky][conky-pkg]       |
-| [dmenu][dmenu-git]       | dmenu     | dmenu             | dmenu     | [dmenu][dmenu-pkg]       |
+| Dependency<br>(git)      | Ubuntu 20.4.1<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 33<br> _sudo dnf install {}_ | PKGS                     |
+| ------------------------ | --------------------------------------- | ---------------------------- | ----------------------------------- | ------------------------ |
+| [feh][feh-git]           | feh                                     | feh                          | feh                                 | [feh][feh-pkg]           |
+| [compton][compton-git]   | compton                                 | picom                        | compton                             | [compton][compton-pkg]   |
+| [picom][picom-git]       | manual \*\*                             | picom                        | picom                               | [picom][picom-pkg]       |
+| [polybar][polybar-git]   | manual \*\*                             | polybar                      | polybar                             | [polybar][polybar-pkg]   |
+| [xmobar][xmobar-git]     | xmobar                                  | xmobar                       | xmobar                              | [xmobar][xmobar-pkg]     |
+| [lemonbar][lemonbar-git] | lemonbar                                | paru -S lemonbar\*           | manual \*\*                         | [lemonbar][lemonbar-pkg] |
+| [conky][conky-git]       | conky                                   | conky                        | conky                               | [conky][conky-pkg]       |
+| [dmenu][dmenu-git]       | dmenu                                   | dmenu                        | dmenu                               | [dmenu][dmenu-pkg]       |
 
 [feh-git]: https://github.com/derf/feh
 [feh-pkg]: https://pkgs.org/search/?q=feh&on=provides
@@ -149,7 +149,7 @@ List of common dependencies for themes:
 ## Gentoo ([GURU])
 
 ```sh
-sudo layman -a guru && sudo emerge --sync 
+sudo layman -a guru && sudo emerge --sync
 sudo emerge --ask --verbose x11-wm/leftwm
 ```
 
@@ -198,6 +198,7 @@ to be able to login to LeftWM from a display manager (GDM, SSDM, LightDM, etc.):
 ```sh
 sudo cp PATH_TO_LEFTWM/leftwm.desktop /usr/share/xsessions
 ```
+
 Also see [the build options](#optional-build-features) for more feature options, especially if you don't use `systemd` or want to use your own hotkey daemon like `sxhkd`.
 
 ## OpenBSD ([OpenBSD])
@@ -259,13 +260,13 @@ exec dbus-launch ~/.cargo/bin/leftwm >> ~/.cache/leftwm.log 2>&1
    sudo cp leftwm.desktop /usr/share/xsessions/
    ```
 
-You should now see LeftWM in your list of available window managers.  At this point, expect only a
-simple black screen on login.  For a more customized look, install a theme.
+You should now see LeftWM in your list of available window managers. At this point, expect only a
+simple black screen on login. For a more customized look, install a theme.
 
 ## Optional Development Installation
 
 If your goal is to continuously build leftwm and keep up to date with the latest releases, you may
-prefer to symlink the leftwm executables instead of copying them.  If you choose to install this
+prefer to symlink the leftwm executables instead of copying them. If you choose to install this
 way, make sure you do not move the build directory as it will break your installation.
 
 Note that if you want to build leftwm with another build profile, you will have to change the
@@ -286,6 +287,7 @@ Currently available are `dev`, `release` and `optimized`.
    # With systemd logging (view with 'journalctl -f -t leftwm-worker')
    cargo build --profile optimized
    ```
+
    For more options see [build options below](#optional-build-features).
 
 4. Create the symlinks
@@ -305,12 +307,12 @@ Currently available are `dev`, `release` and `optimized`.
    sudo cp leftwm.desktop /usr/share/xsessions/
    ```
 
-You should now see LeftWM in your list of available window managers.  At this point, expect only a
-simple black screen on login.  For a more customized look, install a theme.
+You should now see LeftWM in your list of available window managers. At this point, expect only a
+simple black screen on login. For a more customized look, install a theme.
 
 ### Rebuilding the development installation
 
-1. Now if you want to get the newest version of leftwm run this command from your build directory:  
+1. Now if you want to get the newest version of leftwm run this command from your build directory:
 
    ```bash
    git pull origin main
@@ -328,21 +330,22 @@ simple black screen on login.  For a more customized look, install a theme.
    ```bash
    Mod + Shift + R
    ```
-  
+
 ### Optional Build Features
 
 Since `LeftWM` is targeting to be more and more modular, there are a few features that can be selected at compile time:
 
 Use `cargo` with the added flags `--no-default-features --features=` and then commaseparated a selection from the following features:
 
-| feature | info | default |
-| - | - | - |
-| lefthk | built-in hotkey daemon, if you build with out make sure you bring your own (e.g. `sxhkd`) to manage any keybinds, be sure you install the `lefthk-worker` binary if you build with this option | ✔ |
-| journald-log | logging to `journald`, depends on `systemd` | ✔ |
-| sys-log | use standard system logging | ✘ |
-| file-log | log to `/tmp/leftwm/<log-file-by-datetime-of-launch>` | ✘ |
+| feature      | info                                                                                                                                                                                           | default |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| lefthk       | built-in hotkey daemon, if you build with out make sure you bring your own (e.g. `sxhkd`) to manage any keybinds, be sure you install the `lefthk-worker` binary if you build with this option | ✔      |
+| journald-log | logging to `journald`, depends on `systemd`                                                                                                                                                    | ✔      |
+| sys-log      | use standard system logging                                                                                                                                                                    | ✘       |
+| file-log     | log to `/tmp/leftwm/<log-file-by-datetime-of-launch>`                                                                                                                                          | ✘       |
 
 Example:
+
 ```bash
 # With `lefthk` and logging to `sys-log`
 cargo build --profile optimized --no-default-features --features=lefthk,sys-log
@@ -351,10 +354,10 @@ cargo build --profile optimized --no-default-features --features=lefthk,sys-log
 cargo build --profile optimized --no-default-features --features=file-log
 ```
 
-
 There are also multiple levels of optimization. These are specified by the cargo profiles, available are `dev`, `release` and `optimized`. The dev and release profiles are default profiles used by cargo, whereas the optimized profile is recomended for production builds.
 
 Example:
+
 ```bash
 # With the dev profile
 cargo build --profile dev
@@ -367,17 +370,17 @@ cargo build --profile release
 
 For conveniece we also have a Makefile with the following rules:
 
-| make ... | info |
-| - | - |
-| all | implies `build` and `test` |
-| test | runs same tests as CI on github |
-| test-full | same as `test` but additionally with pedantic clippy lints |
-| test-full-nix | same as `test-full` but additionally compiles the nix package, resulting in a full representation of ci checks | 
-| build | builds with cargo profile `optimized` by default; read build output on how to change the profile. |
-| clean | clean all buildfiles |
-| install | install by copying binaries to `/usr/bin`, also places `leftwm.desktop` file to `/usr/share/xsession` and cleans build files |
-| install-linked | installs by symlinking, copies `leftwm.desktop`, no clean |
-| uninstall | removes `leftwm-*` files from `/usr/bin` and `leftwm.desktop` file |
+| make ...       | info                                                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| all            | implies `build` and `test`                                                                                                   |
+| test           | runs same tests as CI on github                                                                                              |
+| test-full      | same as `test` but additionally with pedantic clippy lints                                                                   |
+| test-full-nix  | same as `test-full` but additionally compiles the nix package, resulting in a full representation of ci checks               |
+| build          | builds with cargo profile `optimized` by default; read build output on how to change the profile.                            |
+| clean          | clean all buildfiles                                                                                                         |
+| install        | install by copying binaries to `/usr/bin`, also places `leftwm.desktop` file to `/usr/share/xsession` and cleans build files |
+| install-linked | installs by symlinking, copies `leftwm.desktop`, no clean                                                                    |
+| uninstall      | removes `leftwm-*` files from `/usr/bin` and `leftwm.desktop` file                                                           |
 
 Note that for `build`, `install` and `install-linked`, you can specify the build profile to use by adding the `profile=<profile-name>` argument. Currently available are `dev`, `release` and `release-optimized`.
 
@@ -390,13 +393,14 @@ Make sure this is at the end of your `.xinitrc` file:
 exec dbus-launch leftwm
 ```
 
-On some distros like Archlinux, the environment variables are being setup by sourcing `/etc/X11/xinit/xinitrc.d`, as described in [the Arch docs](https://wiki.archlinux.org/title/Xinit#xinitrc), please make sure you copy the default xinitrc like this: 
+On some distros like Archlinux, the environment variables are being setup by sourcing `/etc/X11/xinit/xinitrc.d`, as described in [the Arch docs](https://wiki.archlinux.org/title/Xinit#xinitrc), please make sure you copy the default xinitrc like this:
 
 ```bash
 cp /etc/X11/xinit/xinitrc ~/.xinitrc
 ```
 
 **Note:** In this case it is not necessary to start leftwm through `dbus-launch` and might even result in some cases in services like `gnome-keyring` to fail. In such an occasion just use:
+
 ```bash
 # .xinitrc
 exec leftwm
@@ -432,6 +436,7 @@ For more information about themes check out our [theme guide][theme-guide] or th
 [wiki]: https://github.com/leftwm/leftwm/wiki/Themes
 
 ---
+
 **Note:** leftwm uses RON now as its default config language. Please consider migrating your toml configs.
 
 ---
@@ -441,6 +446,7 @@ For more information about themes check out our [theme guide][theme-guide] or th
 You can configure key bindings, default mod key and many other options:
 
 ## With [LeftWM-Config](https://github.com/leftwm/leftwm-config)
+
 ```bash
 leftwm-config -n # Generate new config
 leftwm-config    # Open configuration file in $EDITOR
@@ -452,33 +458,36 @@ leftwm-config -t # Edit configuration via TUI (Beta)
 ```bash
 ~/.config/leftwm/config.ron
 ```
+
 ---
+
 **Note:** The configuration file is automatically generated when leftwm or leftwm-check is run for the first time.
 
 ---
+
 **Note:** leftwm uses RON now as its default config language. Please consider migrating your toml configs.
 
 ---
 
 ## Default keys
 
-| Keybinding          | Description                                                            |
-|---------------------|------------------------------------------------------------------------|
-| Mod + (1-9)         | Switch to a desktop/tag                                                |
-| Mod + Shift + (1-9) | Move the focused window to desktop/tag                                 |
-| Mod + W             | Switch the desktops for each screen. Desktops [1][2] changes to [2][1] |
-| Mod + Shift + W     | Move window to the other desktop                                       |
-| Mod + (⬆️⬇️)          | Focus on the different windows in the current workspace                |
-| Mod + Shift + (⬆️⬇️)  | Move the different windows in the current workspace                    |
-| Mod + Enter         | Move selected window to the top of the stack in the current workspace  |
-| Mod + Ctrl + (⬆️⬇️)   | Switch between different layouts                                       |
-| Mod + Shift + (⬅➡)  | Switch between different workspaces                                    |
-| Mod + Shift + Enter | Open a terminal                                                        |
-| Mod + Ctrl + L      | Lock the screen                                                        |
-| Mod + Shift + X     | Exit LeftWM                                                            |
-| Mod + Shift + Q     | Close the current window                                               |
-| Mod + Shift + R     | Reload LeftWM and its config                                           |
-| Mod + p             | Use dmenu to start application                                         |
+| Keybinding           | Description                                                            |
+| -------------------- | ---------------------------------------------------------------------- |
+| Mod + (1-9)          | Switch to a desktop/tag                                                |
+| Mod + Shift + (1-9)  | Move the focused window to desktop/tag                                 |
+| Mod + W              | Switch the desktops for each screen. Desktops [1][2] changes to [2][1] |
+| Mod + Shift + W      | Move window to the other desktop                                       |
+| Mod + (⬆️⬇️)         | Focus on the different windows in the current workspace                |
+| Mod + Shift + (⬆️⬇️) | Move the different windows in the current workspace                    |
+| Mod + Enter          | Move selected window to the top of the stack in the current workspace  |
+| Mod + Ctrl + (⬆️⬇️)  | Switch between different layouts                                       |
+| Mod + Shift + (⬅➡) | Switch between different workspaces                                    |
+| Mod + Shift + Enter  | Open a terminal                                                        |
+| Mod + Ctrl + L       | Lock the screen                                                        |
+| Mod + Shift + X      | Exit LeftWM                                                            |
+| Mod + Shift + Q      | Close the current window                                               |
+| Mod + Shift + R      | Reload LeftWM and its config                                           |
+| Mod + p              | Use dmenu to start application                                         |
 
 **Note:** Although we encourage you to use [Alacritty](https://github.com/alacritty/alacritty),
 LeftWM will set your default terminal to the first terminal it finds in this list (in the order
@@ -506,7 +515,7 @@ presented):
 You can optionally switch between tiling or floating mode for any window.
 
 | Keybinding              | Description                             |
-|-------------------------|-----------------------------------------|
+| ----------------------- | --------------------------------------- |
 | Mod + MouseDrag         | Switch a tiled window to floating mode  |
 | Mod + RightMouseDrag    | Resize a window                         |
 | Drag window onto a tile | Switch a floating window to tiling mode |
@@ -537,6 +546,7 @@ workspaces: [
 ```
 
 ---
+
 **NOTE**
 You do not have to define an ID for each workspace, but if you assign an ID to one workspace all subsequently defined workspaces without an ID will be assigned an ID incrementing from the largest ID currently assigned to any workspace. In the above example if the second workspace was not defined with ID = 0 it would be assigned ID = 2. Keep this in mind when creating or customizing themes.
 
@@ -592,12 +602,12 @@ The default layouts are [all of the kinds](leftwm-core/src/layouts/mod.rs#L21) d
 
 ## Troubleshooting
 
-| Issue | Description | Solution |
-|-|-|:-:|
-| LeftWM not listed by login manager | You likely need to add the xsessions file to the right folder. | See [installation](#installation-with-package-manager) |
-| No config.toml file exists | LeftWM does not always ship with a `config.toml`. You will need to execute LeftWM at least once for one to be generated. | Try the following: ``` leftwm-worker ``` |
-| Config.toml is not being parsed | LeftWM ships with a binary called leftwm-check. It might not be installed by the AUR. | Try the following: ``` leftwm-check ``` |
-| Keybinding doesn't work | It's likely you need to specify a value or have a typo. | See Wiki |
+| Issue                              | Description                                                                                                              |                        Solution                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------: |
+| LeftWM not listed by login manager | You likely need to add the xsessions file to the right folder.                                                           | See [installation](#installation-with-package-manager) |
+| No config.toml file exists         | LeftWM does not always ship with a `config.toml`. You will need to execute LeftWM at least once for one to be generated. |           Try the following: `leftwm-worker`           |
+| Config.toml is not being parsed    | LeftWM ships with a binary called leftwm-check. It might not be installed by the AUR.                                    |           Try the following: `leftwm-check`            |
+| Keybinding doesn't work            | It's likely you need to specify a value or have a typo.                                                                  |                        See Wiki                        |
 
 ## Support
 

--- a/display-servers/xlib-display-server/Cargo.toml
+++ b/display-servers/xlib-display-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlib-display-server"
-version = "0.1.1"
+version = "0.1.2"
 description = "A display server library for LeftWM" 
 license = "MIT"
 edition = "2021"
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leftwm-core = { path = "../../leftwm-core", version = '0.4.2' }
+leftwm-core = { path = "../../leftwm-core", version = '0.5.0' }
 x11-dl = "2.18.4"
 futures = "0.3.21"
 tracing = "0.1.36"

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-core"
-version = "0.4.2"
+version = "0.5.0"
 rust-version = "1.70.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["window manager"]

--- a/leftwm-macros/Cargo.toml
+++ b/leftwm-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-macros"
-version = "0.4.2"
+version = "0.5.0"
 rust-version = "1.70.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["window manager"]

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -20,8 +20,8 @@ dirs-next = "2.0.0"
 futures = "0.3.21"
 git-version = "0.3.5"
 lefthk-core = { version = '0.2', optional = true }
-leftwm-core = { path = "../leftwm-core", version = '0.4.2' }
-leftwm-macros = {path = "../leftwm-macros", version = '0.4.2'}
+leftwm-core = { path = "../leftwm-core", version = '0.5.0' }
+leftwm-macros = {path = "../leftwm-macros", version = '0.5.0'}
 leftwm-layouts = "0.8.4"
 liquid = "0.26.0"
 mio = "0.8.0"
@@ -58,7 +58,7 @@ tracing-appender = {version = "0.2.2", optional = true}
 syslog-tracing = {version = "0.2.0", optional = true}
 
 # display_servers
-xlib-display-server = { path = "../display-servers/xlib-display-server", version = "0.1.1" }
+xlib-display-server = { path = "../display-servers/xlib-display-server", version = "0.1.2" }
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
# Description

This releases leftwm 0.5.0. Hoping to get #1168 included prior to this, so marking as draft for now.

**Note: Creating a GitHub Release/Tag will trigger crates.io to be updated, steps:**
1. [Draft a new release](https://github.com/leftwm/leftwm/releases/new)
2. Tag = (new tag), v0.5.0
3. Target = (this commit)
4. Release Title = v0.5.0
5. Set as a pre-release  = False
6. Set as the latest release  = True
7. Create a discussion for this release  = True
8. Ensure release goes smoothly, will be listed in the "Actions" tab

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation only update (no change to the factual codebase)

## Updated user documentation:
 - [X] README
 - [X] CHANGELOG

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [X] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly **(N/A)**
- [ ] Wiki pages have been updated accordingly (to perform **after** merge) **(N/A)**
