### PR TITLE
feat: add AUR publishing capabilities

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,50 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish --allow-dirty -p leftwm
+    publish_aur_package:
+      name: Publish AUR package
+
+      runs-on: ubuntu-latest
+
+      strategy:
+        fail-fast: true
+        matrix:
+          target:
+            - x86_64-unknown-linux-gnu
+
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Download checksums
+          uses: actions/download-artifact@v2.0.9
+          with:
+            name: checksums
+            path: ./checksums
+
+        - name: Generate PKGBUILD
+          env:
+            TARGET: ${{ matrix.target }}
+            RELEASE_TAG: ${{ needs.create_release.outputs.release_tag }}
+          run: ./ci/github-actions/generate-pkgbuild.py3
+
+        - name: Publish leftwm, leftwm-nonsystemd to the AUR
+          uses: KSXGitHub/github-actions-deploy-aur@v2.2.3
+          with:
+            pkgname: leftwm
+            pkgbuild: ./leftwm/release/PKGBUILD
+            commit_username: ${{ secrets.AUR_USERNAME }}
+            commit_email: ${{ secrets.AUR_EMAIL }}
+            ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+            commit_message: ${{ github.ref }}
+            updpkgsums: true
+
+        - name: Publish leftwm-git, leftwm-nonsystemd-git to the AUR
+          uses: KSXGitHub/github-actions-deploy-aur@v2.2.3
+          with:
+            pkgname: leftwm-git
+            pkgbuild: ./leftwm/release/git-PKGBUILD
+            commit_username: ${{ secrets.AUR_USERNAME }}
+            commit_email: ${{ secrets.AUR_EMAIL }}
+            ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+            commit_message: ${{ github.ref }}
+            updpkgsums: true

--- a/leftwm/release/PKGBUILD
+++ b/leftwm/release/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Lex Childs <lexchilds@gmail.com>
+# Contributor: éclairevoyant
+
+pkgbase=leftwm
+pkgname=(leftwm leftwm-nonsystemd)
+pkgver=0.5.1
+pkgrel=2
+pkgdesc="A tiling window manager for the adventurer"
+arch=('i686' 'x86_64')
+url="https://github.com/leftwm/leftwm"
+license=('MIT')
+depends=(gcc-libs)
+makedepends=('cargo' 'git')
+optdepends=('bash: themes'
+            'dmenu: default launcher'
+            'eww: flexible status bar'
+            'feh: used to set background images'
+            'lemonbar: light weight bar'
+            'polybar: light weight bar')
+source=("${pkgbase}-${pkgver}.tar.gz::${url}/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('3c8ab0fdbfe205b33ad7ae108d3a604bdd22663458bf803e0a3a4a924aad963a')
+install='readme.install'
+
+prepare() {
+	cd $pkgbase-$pkgver
+	cargo fetch --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+	cd $pkgbase-$pkgver
+
+	export CARGO_TARGET_DIR=target_non_systemd
+	cargo build --frozen --release --no-default-features --features=lefthk,sys-log
+
+	export CARGO_TARGET_DIR=target_systemd
+	cargo build --frozen --release
+}
+
+_package() {
+	install -Dm755 leftwm{,-worker,-state,-check,-command} lefthk-worker -t "$pkgdir"/usr/bin/
+
+	cd ../../
+	install -Dm644 leftwm/doc/leftwm.1 -t "$pkgdir"/usr/share/man/man1/
+	install -d "$pkgdir"/usr/share/leftwm
+	cp -R themes "$pkgdir"/usr/share/leftwm
+	install -Dm644 leftwm.desktop -t "$pkgdir"/usr/share/xsessions/
+	install -Dm644 LICENSE.md "$pkgdir"/usr/share/licenses/leftwm/LICENSE
+}
+
+package_leftwm-nonsystemd() {
+	pkgdesc+=" (non-systemd init)"
+	cd $pkgbase-$pkgver/target_non_systemd/release
+	_package
+}
+
+package_leftwm() {
+	pkgdesc+=" (systemd init)"
+	depends+=(systemd)
+	cd $pkgbase-$pkgver/target_systemd/release
+	_package
+}

--- a/leftwm/release/git-PKGBUILD
+++ b/leftwm/release/git-PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Lex Childs <lexchilds@gmail.com>
+# Maintainer: hertg <aur@her.tg>
+# Contributor: éclairevoyant
+# Contributor: mautam <mautam@usa.com>
+
+pkgbase=leftwm-git
+pkgname=(leftwm-nonsystemd-git leftwm-git)
+pkgver=0.5.1.r0.g2ae93293
+pkgrel=1
+pkgdesc="A tiling window manager for the adventurer"
+arch=('i686' 'x86_64')
+url="https://github.com/leftwm/leftwm"
+license=('MIT')
+depends=(gcc-libs)
+makedepends=('cargo' 'git')
+optdepends=('bash: themes'
+            'dmenu: default launcher'
+            'eww: flexible status bar'
+            'feh: used to set background images'
+            'lemonbar: light weight bar'
+            'polybar: light weight bar')
+provides=('leftwm')
+conflicts=('leftwm')
+source=("$pkgbase::git+https://github.com/leftwm/leftwm.git")
+md5sums=('SKIP')
+install='readme.install'
+
+prepare() {
+	cd $pkgbase
+	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+pkgver() {
+	cd $pkgbase
+	git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+	cd $pkgbase
+
+	export CARGO_TARGET_DIR=target_non_systemd
+	cargo build --frozen --release --no-default-features --features=lefthk,sys-log
+
+	export CARGO_TARGET_DIR=target_systemd
+	cargo build --frozen --release
+}
+
+_package() {
+	install -Dm755 leftwm{,-worker,-state,-check,-command} lefthk-worker -t "$pkgdir"/usr/bin/
+
+	cd ../../
+	install -Dm644 leftwm/doc/leftwm.1 -t "$pkgdir"/usr/share/man/man1/
+	install -d "$pkgdir"/usr/share/leftwm
+	cp -R themes "$pkgdir"/usr/share/leftwm
+	install -Dm644 leftwm.desktop -t "$pkgdir"/usr/share/xsessions/
+}
+
+package_leftwm-nonsystemd-git() {
+	pkgdesc+=" (non-systemd init)"
+	cd $pkgbase/target_non_systemd/release
+	_package
+}
+
+package_leftwm-git() {
+	pkgdesc+=" (systemd init)"
+	depends+=(systemd)
+	cd $pkgbase/target_systemd/release
+	_package
+}


### PR DESCRIPTION
# Description

Adds the capability to publish crate updates to the AUR. Although I am reasonably confident in this build, I'm not certain it's finished. Additionally, we will need to add the secrets to GitHub to finalize this change.

## Type of change

- [X] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [X] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary. [N/A]
