### PR TITLE
Mirror to Codeberg

### DIFF
--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -9,7 +9,7 @@ jobs:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
     # Only run for the main repo, not for forks
-    if: ${{ github.repository == 'leftwm/leftwm' }}
+    if: ${{ secrets.MIRROR_REPO != null }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,9 +26,9 @@ jobs:
 
       - name: Push to Codeberg
         env:
-          BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref_name }}
+          BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
-        run: git push --force git@codeberg.org:leftwm/leftwm.git HEAD:$BRANCH
+        run: git push --force ${{ secrets.MIRROR_REPO }} HEAD:$BRANCH
 
       - name: Delete key file
         run: rm ~/codeberg_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -13,7 +13,7 @@ jobs:
 #        uses: actions/checkout@v2
 
       - name: ls
-        run: ls -A / ~ /etc/
+        run: ls -A /etc/ssh
 
 #      - name: Load ssh key
 #        env: 

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -8,29 +8,32 @@ jobs:
   mirror:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
-    # Only run if the secret is set
-    env:
+    env: 
       MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
-    if: $MIRROR_REPO != ''
     steps:
       - name: Checkout
+        if: env.MIRROR_REPO != ''
         uses: actions/checkout@v2
         with: 
           fetch-depth: 0
 
       - name: Load ssh key
+        if: env.MIRROR_REPO != ''
         run: |
           umask 066
           echo "${{ secrets.CODEBERG_SSH_KEY }}" > ~/codeberg_key
 
       - name: Add Codeberg to known hosts
+        if: env.MIRROR_REPO != ''
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
 
       - name: Push to Codeberg
+        if: env.MIRROR_REPO != ''
         env:
           BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --force $MIRROR_REPO HEAD:$BRANCH
 
       - name: Delete key file
+        if: env.MIRROR_REPO != ''
         run: rm ~/codeberg_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -8,6 +8,8 @@ jobs:
   mirror:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
+    # Only run for the main repo, not for forks
+    if: ${{ github.repository == 'leftwm/leftwm' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -15,11 +17,9 @@ jobs:
           fetch-depth: 0
 
       - name: Load ssh key
-        env: 
-          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
         run: |
           umask 066
-          echo "$SSH_KEY" > ~/codeberg_key
+          echo "${{ secrets.CODEBERG_SSH_KEY }}" > ~/codeberg_key
 
       - name: Add Codeberg to known hosts
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
@@ -28,7 +28,7 @@ jobs:
         env:
           BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref_name }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
-        run: git push --force git@codeberg.org:Eskaan/leftwm-mirror-testing.git HEAD:$BRANCH
+        run: git push --force git@codeberg.org:leftwm/leftwm.git HEAD:$BRANCH
 
       - name: Delete key file
         run: rm ~/codeberg_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -16,15 +16,12 @@ jobs:
         env: 
           SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
         run: |
-          umask 600
+          umask 066
           echo "$SSH_KEY" > ~/codeberg_key
 
       - name: Add Codeberg to known hosts
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
 
-      - name: ls
-        run: ls -l ~/codeberg_key ~/known_hosts; whoami
-          
       - name: Push repo
         env:
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -9,18 +9,21 @@ jobs:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+#      - name: Checkout
+#        uses: actions/checkout@v2
 
-      - name: Load ssh key
-        env: 
-          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
-        run: echo "$SSH_KEY" > ~/.ssh/codeberg_key
+      - name: ls
+        run: ls -A / ~ /etc/
 
-      - name: Add Codeberg to known hosts
-        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/.ssh/known_hosts
-          
-      - name: Push repo
-        env:
-          GIT_SSH_COMMAND: 'ssh -i ~/.ssh/codeberg_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes'
-        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git
+#      - name: Load ssh key
+#        env: 
+#          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
+#        run: echo "$SSH_KEY" > ~/codeberg_key
+#
+#      - name: Add Codeberg to known hosts
+#        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
+#          
+#      - name: Push repo
+#        env:
+#          GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o  -o StrictHostKeyChecking=yes'
+#        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Load ssh key
         env: 
           SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
-        run: echo "$SSH_KEY" > ~/codeberg_key
+        run: |
+          umask 600
+          echo "$SSH_KEY" > ~/codeberg_key
 
       - name: Add Codeberg to known hosts
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -21,7 +21,7 @@ jobs:
         if: env.MIRROR_REPO != ''
         run: |
           umask 066
-          echo "${{ secrets.CODEBERG_SSH_KEY }}" > ~/codeberg_key
+          echo "${{ secrets.MIRROR_SSH_KEY }}" > ~/mirror_key
 
       - name: Add Codeberg to known hosts
         if: env.MIRROR_REPO != ''
@@ -31,9 +31,9 @@ jobs:
         if: env.MIRROR_REPO != ''
         env:
           BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref }}
-          GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
+          GIT_SSH_COMMAND: 'ssh -i ~/mirror_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --force $MIRROR_REPO HEAD:$BRANCH
 
       - name: Delete key file
         if: env.MIRROR_REPO != ''
-        run: rm ~/codeberg_key
+        run: rm ~/mirror_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with: 
-          fetch-depth: 0
+        run: |
+          git clone --bare
 
       - name: Load ssh key
         env: 
@@ -29,3 +28,6 @@ jobs:
           BRANCH: ${{ github.event_name == 'pull_request' && format('pull/{0}', github.event.number) || github.ref_name }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --force git@codeberg.org:Eskaan/leftwm-mirror-testing.git HEAD:$BRANCH
+
+      - name: Delete key file
+        run: rm ~/codeberg_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -8,8 +8,10 @@ jobs:
   mirror:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
-    # Only run for the main repo, not for forks
-    if: ${{ secrets.MIRROR_REPO != null }}
+    # Only run if the secret is set
+    env:
+      MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
+    if: env.MIRROR_REPO != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -28,7 +30,7 @@ jobs:
         env:
           BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
-        run: git push --force ${{ secrets.MIRROR_REPO }} HEAD:$BRANCH
+        run: git push --force $MIRROR_REPO HEAD:$BRANCH
 
       - name: Delete key file
         run: rm ~/codeberg_key

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -24,6 +24,6 @@ jobs:
 
       - name: Push to Codeberg
         env:
-          BRANCH: ${{ github.event_name == 'pull_request' && format("pull/{0}", github.event.number) || github.ref_name }}
+          BRANCH: ${{ github.event_name == 'pull_request' && format('pull/{0}', github.event.number) || github.ref_name }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --force git@codeberg.org:Eskaan/leftwm-mirror-testing.git HEAD:$BRANCH

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
 
       - name: Load ssh key
         env: 

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -1,0 +1,26 @@
+name: Mirror to Codeberg
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  mirror:
+    name: Mirror to Codeberg
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Load ssh key
+        env: 
+          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
+        run: echo "$SSH_KEY" > ~/.ssh/codeberg_key
+
+      - name: Add Codeberg to known hosts
+        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/.ssh/known_hosts
+          
+      - name: Push repo
+        env:
+          GIT_SSH_COMMAND: 'ssh -i ~/.ssh/codeberg_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes'
+        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Load ssh key
         env: 
           SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
-        run: echo "$SSH_KEY" > /etc/ssh/codeberg_key
+        run: echo "$SSH_KEY" > ~/codeberg_key
 
       - name: Add Codeberg to known hosts
-        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > /etc/ssh/known_hosts
+        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
           
       - name: Push repo
         env:
-          GIT_SSH_COMMAND: 'ssh -i /etc/ssh/codeberg_key -o IdentitiesOnly=yes -o  -o StrictHostKeyChecking=yes'
+          GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        run: |
-          git clone --bare
+        uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
 
       - name: Load ssh key
         env: 

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -9,21 +9,18 @@ jobs:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
     steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: ls
-        run: ls -A /etc/ssh
+      - name: Load ssh key
+        env: 
+          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
+        run: echo "$SSH_KEY" > /etc/ssh/codeberg_key
 
-#      - name: Load ssh key
-#        env: 
-#          SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
-#        run: echo "$SSH_KEY" > ~/codeberg_key
-#
-#      - name: Add Codeberg to known hosts
-#        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
-#          
-#      - name: Push repo
-#        env:
-#          GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o  -o StrictHostKeyChecking=yes'
-#        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git
+      - name: Add Codeberg to known hosts
+        run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > /etc/ssh/known_hosts
+          
+      - name: Push repo
+        env:
+          GIT_SSH_COMMAND: 'ssh -i /etc/ssh/codeberg_key -o IdentitiesOnly=yes -o  -o StrictHostKeyChecking=yes'
+        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        run: git clone --mirror
 
       - name: Load ssh key
         env: 
@@ -22,7 +22,8 @@ jobs:
       - name: Add Codeberg to known hosts
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
 
-      - name: Push repo
+      - name: Push to Codeberg
         env:
+          BRANCH: ${{ github.event_name == 'pull_request' && format("pull/{0}", github.event.number) || github.ref_name }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
-        run: git push --mirror git@codeberg.org:Eskaan/leftwm-mirror-testing.git
+        run: git push --force git@codeberg.org:Eskaan/leftwm-mirror-testing.git HEAD:$BRANCH

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -9,7 +9,7 @@ jobs:
     name: Mirror to Codeberg
     runs-on: ubuntu-latest
     env: 
-      MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
+      MIRROR_REPO: ${{ secrets.CODEBERG_MIRROR_LEFTWM }}
     steps:
       - name: Checkout
         if: env.MIRROR_REPO != ''
@@ -21,7 +21,7 @@ jobs:
         if: env.MIRROR_REPO != ''
         run: |
           umask 066
-          echo "${{ secrets.MIRROR_SSH_KEY }}" > ~/mirror_key
+          echo "${{ secrets.CODEBERG_MIRROR_LEFTWM_SSH_KEY }}" > ~/mirror_key
 
       - name: Add Codeberg to known hosts
         if: env.MIRROR_REPO != ''

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -11,7 +11,7 @@ jobs:
     # Only run if the secret is set
     env:
       MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
-    if: env.MIRROR_REPO != ''
+    if: ${{ env.MIRROR_REPO != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -11,7 +11,7 @@ jobs:
     # Only run if the secret is set
     env:
       MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
-    if: ${{ env.MIRROR_REPO != '' }}
+    if: $MIRROR_REPO != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Add Codeberg to known hosts
         run: echo "codeberg.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIVIC02vnjFyL+I4RHfvIGNtOgJMe769VTF1VR4EB3ZB" > ~/known_hosts
+
+      - name: ls
+        run: ls -l ~/codeberg_key ~/known_hosts; whoami
           
       - name: Push repo
         env:

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Push to Codeberg
         env:
-          BRANCH: ${{ github.event_name == 'pull_request' && format('pull/{0}', github.event.number) || github.ref_name }}
+          BRANCH: ${{ github.event_name == 'pull_request' && format('refs/heads/pull/{0}', github.event.number) || github.ref_name }}
           GIT_SSH_COMMAND: 'ssh -i ~/codeberg_key -o IdentitiesOnly=yes -o GlobalKnownHostsFile=~/known_hosts -o StrictHostKeyChecking=yes'
         run: git push --force git@codeberg.org:Eskaan/leftwm-mirror-testing.git HEAD:$BRANCH
 

--- a/.github/workflows/codeberg-mirror.yml
+++ b/.github/workflows/codeberg-mirror.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        run: git clone --mirror
+        uses: actions/checkout@v2
 
       - name: Load ssh key
         env: 


### PR DESCRIPTION
# Description

I took some time this afternoon and created a GitHub workflow to mirror the leftwm repo over to Codeberg.
- Mirror all branches on every push
- Mirror all prs under the `pulls/` branches (because we loose history when squashing)
- Only runs when `secrets.MIRROR_REPO` is set (accounting for forks)

Fixes #1053 

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Tested on my own repository(s)
- [x] [Maintainer] Setup secrets:
  - Create ssh keys: `ssh-keygen -f ssh_key -N ''` (creates ssh_key and shk_key.pub files)
  - `MIRROR_REPO` secret: `git@codeberg.org:leftwm/leftwm.git`
  - `MIRROR_SSH_KEY` secret: content of generated ssh_key file
  - Over on the mirror: add content of ssh_key.pub file as "Deploy Key" in repo settings
- [x] [Maintainer] Push all old prs/tags/branches onto the mirror using
  ```bash
  git fetch upstream "refs/*:refs/remote/upstream/*"
  git push mirror "refs/remote/upstream/{heads,tags}/*"
  git push mirror "refs/remote/upstream/pull/*/head:refs/heads/pull/*"
  ```

# TODO
- [ ] Mirror prs or not?