### PR TITLE
Separate leftwm bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,6 @@ dependencies = [
  "anyhow",
  "clap",
  "const_format",
- "dirs-next",
  "futures",
  "git-version",
  "lefthk-core",
@@ -574,7 +573,6 @@ dependencies = [
  "leftwm-macros",
  "liquid",
  "mio",
- "nix",
  "once_cell",
  "regex",
  "ron",
@@ -632,6 +630,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "leftwm-watchdog"
+version = "0.5.1"
+dependencies = [
+ "clap",
+ "dirs-next",
+ "nix",
+ "signal-hook",
+ "tempfile",
+ "thiserror",
+ "xdg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "leftwm",
     "leftwm-core",
     "leftwm-macros",
+    "leftwm-watchdog",
     "display-servers/xlib-display-server",
 ]
 resolver = "2"

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -34,6 +34,7 @@ impl XWrap {
     // `XDefaultScreen`: https://tronche.com/gui/x/xlib/display/display-macros.html#DefaultScreen
     // `XDefaultColormap`: https://tronche.com/gui/x/xlib/display/display-macros.html#DefaultColormap
     // `XAllocNamedColor`: https://tronche.com/gui/x/xlib/color/XAllocNamedColor.html
+    #[must_use]
     pub fn get_color(&self, color: String) -> c_ulong {
         unsafe {
             let screen = (self.xlib.XDefaultScreen)(self.display);
@@ -182,6 +183,7 @@ impl XWrap {
 
     /// Returns the next `Xevent` that matches the mask of the xserver.
     // `XMaskEvent`: https://tronche.com/gui/x/xlib/event-handling/manipulating-event-queue/XMaskEvent.html
+    #[must_use]
     pub fn get_mask_event(&self) -> xlib::XEvent {
         unsafe {
             let mut event: xlib::XEvent = std::mem::zeroed();
@@ -579,6 +581,7 @@ impl XWrap {
     }
 
     /// Returns the `WM_STATE` of a window.
+    #[must_use]
     pub fn get_wm_state(&self, window: xlib::Window) -> Option<c_long> {
         let (prop_return, nitems_return) = self
             .get_property(window, self.atoms.WMState, self.atoms.WMState)

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -11,6 +11,7 @@ use x11_dl::xlib;
 
 impl XWrap {
     /// Sets up a window before we manage it.
+    #[must_use]
     pub fn setup_window(&self, window: xlib::Window) -> Option<DisplayEvent> {
         // Check that the window isn't requesting to be unmanaged
         let attrs = match self.get_window_attrs(window) {

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -4,14 +4,12 @@ use crate::errors::Result;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::iter::{Extend, FromIterator};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{atomic::AtomicBool, Arc};
-use tracing::error;
 use xdg::BaseDirectories;
 
 pub type ChildID = u32;
@@ -20,42 +18,6 @@ pub type ChildID = u32;
 pub struct Nanny {}
 
 impl Nanny {
-    /// As [Desktop Application Autostart Specification](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html) describe,
-    /// some applications placing an application's `.desktop` file in one of the *Autostart Directories*
-    /// could be automatically launched during startup of the user's desktop environment after the user has logged in.
-    ///
-    /// The *Autostart Directories* are `$XDG_CONFIG_DIRS/autostart` and `$XDG_CONFIG_HOME/autostart`.
-    /// `$XDG_CONFIG_DIRS` and `$XDG_CONFIG_HOME` can be found in
-    /// [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
-    ///
-    ///
-    /// There are some principles about autostart file:
-    /// 1. An application `.desktop` file must have the format as defined in the [Desktop Entry Specification](http://standards.freedesktop.org/desktop-entry-spec/)
-    /// 2. If two files have the same filename in `$XDG_CONFIG_DIRS/autostart` and `$XDG_CONFIG_HOME/autostart`,
-    /// e.g. `foo.desktop`, `$XDG_CONFIG_DIRS/autostart/foo.desktop` will be ignored.
-    ///
-    /// `Autostart Entry` will be ignored when:
-    /// 1. the `.desktop` file has the `Hidden` key set to true.
-    /// 2. string identifying the desktop environments not in `OnlyShowIn`
-    /// 3. string identifying the desktop environments in `NotShowIn`
-    ///
-    /// The string identifying the desktop environments means `$XDG_CURRENT_DESKTOP`,
-    /// you can find some from [Registered `OnlyShowIn` Environments](https://specifications.freedesktop.org/menu-spec/latest/apb.html).  
-    /// `LeftWM` use **`LeftWM`** as identification (case-sensitive).
-    #[must_use]
-    pub fn autostart() -> Children {
-        BaseDirectories::new()
-            .map(|xdg_dir| {
-                xdg_dir
-                    .list_config_files_once("autostart")
-                    .iter()
-                    .filter(|path| path.extension() == Some(std::ffi::OsStr::new("desktop")))
-                    .filter_map(|file| boot_desktop_file(file).ok())
-                    .collect::<Children>()
-            })
-            .unwrap_or_default()
-    }
-
     /// Retrieve the path to the config directory. Tries to create it if it does not exist.
     ///
     /// # Errors
@@ -138,161 +100,6 @@ impl Nanny {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-enum EntryBootError {
-    #[error("execute failed: {0}")]
-    Execute(#[from] std::io::Error),
-
-    #[error("invalid desktop (current {current:?})")]
-    NotForThisDesktop { current: String },
-
-    #[error("entry hidden")]
-    Hidden,
-
-    #[error("no exec")]
-    NoExec,
-}
-
-fn boot_desktop_file(path: &Path) -> std::result::Result<Child, EntryBootError> {
-    let entry = DesktopEntry::parse_file(path)?;
-    let env_curr_desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
-
-    if let Some(only_show_in) = entry.only_show_in {
-        if !only_show_in.contains(&env_curr_desktop) {
-            return Err(EntryBootError::NotForThisDesktop {
-                current: env_curr_desktop,
-            });
-        }
-    }
-    if let Some(not_show_in) = entry.not_show_in {
-        if not_show_in.contains(&env_curr_desktop) {
-            return Err(EntryBootError::NotForThisDesktop {
-                current: env_curr_desktop,
-            });
-        }
-    }
-
-    if entry.hidden {
-        return Err(EntryBootError::Hidden);
-    }
-
-    let Some(exec) = entry.exec else {
-        return Err(EntryBootError::NoExec);
-    };
-
-    let exec = remove_field_codes(&exec);
-
-    let wd = entry
-        .path
-        .unwrap_or_else(|| dirs_next::home_dir().unwrap_or_else(|| PathBuf::from(".")));
-
-    Command::new("sh")
-        .current_dir(wd)
-        .arg("-c")
-        .arg(exec)
-        .spawn()
-        .map_err(EntryBootError::Execute)
-}
-
-/// Removes [field codes](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables) from exec string
-///
-/// When encountering % at the end of the string or followed by non-alphabetic and non-% character
-/// the function leaves it unmodified in order to be more resilient.
-/// According to the spec, the input should be unquoted first (but this is not implemented currently).
-fn remove_field_codes(exec: &str) -> String {
-    let mut result = String::with_capacity(exec.len());
-    let mut chars = exec.chars();
-    while let Some(char) = chars.next() {
-        if char == '%' {
-            match chars.next() {
-                Some('%') | None => result.push('%'), // '%%' is '%' but escaped. '%\0' is illegal but leave it untouched.
-                Some(next) if !next.is_ascii_alphabetic() => {
-                    // illegal (not a field code) but leave it untouched
-                    result.push('%');
-                    result.push(next);
-                }
-                _ => (), // this is a field code, remove it by not pushing it
-            }
-        } else {
-            result.push(char); // "normal" character, leave it untouched
-        }
-    }
-    result
-}
-
-/// Refer to [Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html)
-#[derive(Debug, Default)]
-struct DesktopEntry {
-    // TryExec: Option<String>,
-    exec: Option<String>,
-    path: Option<PathBuf>,
-    only_show_in: Option<HashSet<String>>,
-    not_show_in: Option<HashSet<String>>,
-    hidden: bool,
-}
-
-impl DesktopEntry {
-    fn parse_file(path: &Path) -> std::io::Result<Self> {
-        let content = fs::read_to_string(path)?;
-        Ok(Self::parse(content.as_str()))
-    }
-    fn parse(content: &str) -> Self {
-        let mut in_main_section = false;
-        let mut entry: Self = Default::default();
-        for mut line in content.lines() {
-            line = line.trim();
-
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-
-            if line.starts_with('[') {
-                if line == "[Desktop Entry]" {
-                    in_main_section = true;
-                    continue;
-                }
-                in_main_section = false;
-            }
-
-            if !in_main_section {
-                continue;
-            }
-
-            if let Some((key, value)) = Self::split_line(line) {
-                match key {
-                    "Exec" => entry.exec = Some(value.to_string()),
-                    "Path" => entry.path = Some(PathBuf::from(value)),
-                    "OnlyShowIn" => entry.only_show_in = Some(Self::split_to_set(value)),
-                    "NotShowIn" => entry.not_show_in = Some(Self::split_to_set(value)),
-                    "Hidden" => entry.hidden = Self::str_bool(value).unwrap_or_default(),
-                    _ => {}
-                }
-            }
-        }
-        entry
-    }
-
-    fn split_line(line: &str) -> Option<(&str, &str)> {
-        line.find('=')?; // Check we have an equals, if we don't return None
-        line.split_once('=')
-    }
-    fn split_to_set(value: &str) -> HashSet<String> {
-        value
-            .split(';')
-            .filter_map(|s| {
-                let s = s.trim();
-                if s.is_empty() {
-                    return None;
-                }
-                Some(s.to_string())
-            })
-            .collect::<HashSet<String>>()
-    }
-    fn str_bool(value: &str) -> Option<bool> {
-        value.to_lowercase().parse::<bool>().ok()
-    }
-}
-
 /// A struct managing children processes.
 #[derive(Debug, Default)]
 pub struct Children {
@@ -368,98 +175,4 @@ pub fn exec_shell(command: &str, children: &mut Children) -> Option<ChildID> {
     let pid = child.id();
     children.insert(child);
     Some(pid)
-}
-
-#[cfg(test)]
-mod tests {
-
-    use crate::child_process::remove_field_codes;
-
-    use super::DesktopEntry;
-
-    #[test]
-    fn test_parse() {
-        let content = r"
-            [Desktop Action Gallery]
-        Exec=fooview --gallery
-        Name=Browse Gallery
-                [Desktop Entry]
-        #comment
-        Name=Optimus Manager
-        Name[zh_CN]=Optimus \u{7ba1}\u{7406}\u{5668}
-        Comment=A program to handle GPU switching on Optimus laptops
-        Comment[ru]=\u{41f}\u{440}\u{43e}\u{433}\u{440}\u{430}\u{43c}\u{43c}\u{430} \u{434}\u{43b}\u{44f} \u{443}\u{43f}\u{440}\u{430}\u{432}\u{43b}\u{435}\u{43d}\u{438}\u{44f} \u{43f}\u{435}\u{440}\u{435}\u{43a}\u{43b}\u{44e}\u{447}\u{435}\u{43d}\u{438}\u{435}\u{43c} \u{433}\u{440}\u{430}\u{444}\u{438}\u{447}\u{435}\u{441}\u{43a}\u{438}\u{445} \u{43f}\u{440}\u{43e}\u{446}\u{435}\u{441}\u{441}\u{43e}\u{440}\u{43e}\u{432} \u{43d}\u{430} \u{43d}\u{43e}\u{443}\u{442}\u{431}\u{443}\u{43a}\u{430}\u{445} c Optimus
-        Comment[zh_CN]=\u{5904}\u{7406}\u{53cc}\u{663e}\u{5361}\u{7b14}\u{8bb0}\u{672c}\u{7535}\u{8111} GPU \u{5207}\u{6362}\u{7684}\u{7a0b}\u{5e8f}
-        Keywords=nvidia;optimus;settings;switch;GPU;
-        Keywords[ru]=nvidia;optimus;settings;switch;GPU;\u{43d}\u{430}\u{441}\u{442}\u{440}\u{43e}\u{439}\u{43a}\u{438};\u{432}\u{438}\u{434}\u{435}\u{43e}\u{43a}\u{430}\u{440}\u{442}\u{430};
-        Exec=optimus-manager-qt
-        Icon=optimus-manager-qt
-        Terminal=false
-        StartupNotify=false
-        Type=Application
-        Categories=System;Settings;Qt;
-        Actions=Gallery;Create;
-        Hidden=true
-        OnlyShowIn=XFCE;
-
-        [Desktop Action Create]
-        Exec=fooview --create-new
-        Name=Create a new Foo!
-        Icon=fooview-new
-                ";
-
-        let entry = DesktopEntry::parse(content);
-
-        assert_eq!(
-            entry.exec,
-            Some("optimus-manager-qt".to_string()),
-            "exec failed"
-        );
-        assert!(entry.path.is_none(), "expect path none");
-        assert!(entry.hidden, "expect hidden true");
-        assert!(entry.only_show_in.is_some(), "expect only_show_in defined");
-
-        assert!(
-            entry.only_show_in.clone().unwrap().contains("XFCE"),
-            "expect only_show_in contains XFCE"
-        );
-        assert!(
-            !entry.only_show_in.clone().unwrap().contains(""),
-            "expect only show in not contains empty-str"
-        );
-        assert!(entry.not_show_in.is_none(), "expect not_show_in none");
-    }
-
-    #[test]
-    fn test_field_codes_removal() {
-        let sample_exec_with_field_code = "/path/to/app %u";
-        assert_eq!(
-            remove_field_codes(sample_exec_with_field_code),
-            "/path/to/app "
-        );
-
-        let sample_exec_with_multiple_field_codes = "/path/to/app %a %b";
-        assert_eq!(
-            remove_field_codes(sample_exec_with_multiple_field_codes),
-            "/path/to/app  "
-        );
-
-        let sample_exec_with_escaped_percentage_signs = "/path/to/app %%%%";
-        assert_eq!(
-            remove_field_codes(sample_exec_with_escaped_percentage_signs),
-            "/path/to/app %%"
-        );
-
-        let sample_exec_with_field_code_and_escaped_percentage_signs = "/path/to/app %%%%%u";
-        assert_eq!(
-            remove_field_codes(sample_exec_with_field_code_and_escaped_percentage_signs),
-            "/path/to/app %%"
-        );
-
-        let bad_exec1 = "/path/to/app %^";
-        assert_eq!(remove_field_codes(bad_exec1), bad_exec1);
-
-        let bad_exec2 = "/path/to/app %";
-        assert_eq!(remove_field_codes(bad_exec2), bad_exec2);
-    }
 }

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "leftwm"
+version = "0.5.1"
+rust-version = "1.70.0"
+authors = ["Lex Childs <lexchilds@gmail.com>"]
+categories = ["window manager"]
+edition = "2021"
+keywords = ["wm", "window", "manager"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/leftwm/leftwm"
+description = "A window manager for Adventurers"
+
+[dependencies]
+clap = { version = "4.0.0", features = ["cargo"] }
+
+[dev-dependencies]
+tempfile = "3.2.0"
+
+[features]
+lefthk = []
+
+# Sleep on restart
+slow-dm-fix = []
+
+[[bin]]
+

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "leftwm"
+name = "leftwm-watchdog"
 version = "0.5.1"
 rust-version = "1.70.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
@@ -13,6 +13,11 @@ description = "A window manager for Adventurers"
 
 [dependencies]
 clap = { version = "4.0.0", features = ["cargo"] }
+dirs-next = "2.0.0"
+nix = { version = "0.27.1", features = ["fs", "signal"] }
+signal-hook = "0.3.4"
+thiserror = "1.0.30"
+xdg = "2.2.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"
@@ -24,4 +29,5 @@ lefthk = []
 slow-dm-fix = []
 
 [[bin]]
-
+name = "leftwm"
+path = "src/main.rs"

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -23,6 +23,7 @@ xdg = "2.2.0"
 tempfile = "3.2.0"
 
 [features]
+default = ["lefthk"]
 lefthk = []
 
 # Sleep on restart

--- a/leftwm-watchdog/src/main.rs
+++ b/leftwm-watchdog/src/main.rs
@@ -4,7 +4,6 @@
 //! `leftwm-{check, command, state, theme}` as specified, and passes along any extra arguments.
 
 use clap::command;
-use leftwm_core::child_process::{self, Nanny};
 use std::env;
 use std::path::Path;
 use std::process::{exit, Child, Command, ExitStatus};
@@ -12,6 +11,9 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
+
+mod util;
+use util::{self, Nanny};
 
 type Subcommand<'a> = &'a str;
 type SubcommandArgs = Vec<String>;

--- a/leftwm-watchdog/src/utils.rs
+++ b/leftwm-watchdog/src/utils.rs
@@ -1,0 +1,315 @@
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command},
+    sync::{atomic::AtomicBool, Arc},
+};
+
+use xdg::BaseDirectories;
+
+pub const fn get_help_template() -> &'static str {
+    "\
+{name} {version}
+{author-with-newline}{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}
+"
+}
+
+/// As [Desktop Application Autostart Specification](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html) describe,
+/// some applications placing an application's `.desktop` file in one of the *Autostart Directories*
+/// could be automatically launched during startup of the user's desktop environment after the user has logged in.
+///
+/// The *Autostart Directories* are `$XDG_CONFIG_DIRS/autostart` and `$XDG_CONFIG_HOME/autostart`.
+/// `$XDG_CONFIG_DIRS` and `$XDG_CONFIG_HOME` can be found in
+/// [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+///
+///
+/// There are some principles about autostart file:
+/// 1. An application `.desktop` file must have the format as defined in the [Desktop Entry Specification](http://standards.freedesktop.org/desktop-entry-spec/)
+/// 2. If two files have the same filename in `$XDG_CONFIG_DIRS/autostart` and `$XDG_CONFIG_HOME/autostart`,
+/// e.g. `foo.desktop`, `$XDG_CONFIG_DIRS/autostart/foo.desktop` will be ignored.
+///
+/// `Autostart Entry` will be ignored when:
+/// 1. the `.desktop` file has the `Hidden` key set to true.
+/// 2. string identifying the desktop environments not in `OnlyShowIn`
+/// 3. string identifying the desktop environments in `NotShowIn`
+///
+/// The string identifying the desktop environments means `$XDG_CURRENT_DESKTOP`,
+/// you can find some from [Registered `OnlyShowIn` Environments](https://specifications.freedesktop.org/menu-spec/latest/apb.html).  
+/// `LeftWM` use **`LeftWM`** as identification (case-sensitive).
+#[must_use]
+pub fn autostart() -> Vec<Child> {
+    BaseDirectories::new()
+        .map(|xdg_dir| {
+            xdg_dir
+                .list_config_files_once("autostart")
+                .iter()
+                .filter(|path| path.extension() == Some(std::ffi::OsStr::new("desktop")))
+                .filter_map(|file| boot_desktop_file(file).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn remove_finished_children(children: &mut Vec<Child>) {
+    children.retain_mut(|child| child.try_wait().map_or(true, |ret| ret.is_none()));
+}
+
+#[derive(Debug, thiserror::Error)]
+enum EntryBootError {
+    #[error("execute failed: {0}")]
+    Execute(#[from] std::io::Error),
+
+    #[error("invalid desktop (current {current:?})")]
+    NotForThisDesktop { current: String },
+
+    #[error("entry hidden")]
+    Hidden,
+
+    #[error("no exec")]
+    NoExec,
+}
+
+fn boot_desktop_file(path: &Path) -> std::result::Result<Child, EntryBootError> {
+    let entry = DesktopEntry::parse_file(path)?;
+    let env_curr_desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+
+    if let Some(only_show_in) = entry.only_show_in {
+        if !only_show_in.contains(&env_curr_desktop) {
+            return Err(EntryBootError::NotForThisDesktop {
+                current: env_curr_desktop,
+            });
+        }
+    }
+    if let Some(not_show_in) = entry.not_show_in {
+        if not_show_in.contains(&env_curr_desktop) {
+            return Err(EntryBootError::NotForThisDesktop {
+                current: env_curr_desktop,
+            });
+        }
+    }
+
+    if entry.hidden {
+        return Err(EntryBootError::Hidden);
+    }
+
+    let Some(exec) = entry.exec else {
+        return Err(EntryBootError::NoExec);
+    };
+
+    let exec = remove_field_codes(&exec);
+
+    let wd = entry
+        .path
+        .unwrap_or_else(|| dirs_next::home_dir().unwrap_or_else(|| PathBuf::from(".")));
+
+    Command::new("sh")
+        .current_dir(wd)
+        .arg("-c")
+        .arg(exec)
+        .spawn()
+        .map_err(EntryBootError::Execute)
+}
+
+/// Removes [field codes](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables) from exec string
+///
+/// When encountering % at the end of the string or followed by non-alphabetic and non-% character
+/// the function leaves it unmodified in order to be more resilient.
+/// According to the spec, the input should be unquoted first (but this is not implemented currently).
+fn remove_field_codes(exec: &str) -> String {
+    let mut result = String::with_capacity(exec.len());
+    let mut chars = exec.chars();
+    while let Some(char) = chars.next() {
+        if char == '%' {
+            match chars.next() {
+                Some('%') | None => result.push('%'), // '%%' is '%' but escaped. '%\0' is illegal but leave it untouched.
+                Some(next) if !next.is_ascii_alphabetic() => {
+                    // illegal (not a field code) but leave it untouched
+                    result.push('%');
+                    result.push(next);
+                }
+                _ => (), // this is a field code, remove it by not pushing it
+            }
+        } else {
+            result.push(char); // "normal" character, leave it untouched
+        }
+    }
+    result
+}
+
+/// Refer to [Recognized desktop entry keys](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html)
+#[derive(Debug, Default)]
+struct DesktopEntry {
+    // TryExec: Option<String>,
+    exec: Option<String>,
+    path: Option<PathBuf>,
+    only_show_in: Option<HashSet<String>>,
+    not_show_in: Option<HashSet<String>>,
+    hidden: bool,
+}
+
+impl DesktopEntry {
+    fn parse_file(path: &Path) -> std::io::Result<Self> {
+        let content = fs::read_to_string(path)?;
+        Ok(Self::parse(content.as_str()))
+    }
+    fn parse(content: &str) -> Self {
+        let mut in_main_section = false;
+        let mut entry: Self = DesktopEntry::default();
+        for mut line in content.lines() {
+            line = line.trim();
+
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            if line.starts_with('[') {
+                if line == "[Desktop Entry]" {
+                    in_main_section = true;
+                    continue;
+                }
+                in_main_section = false;
+            }
+
+            if !in_main_section {
+                continue;
+            }
+
+            if let Some((key, value)) = Self::split_line(line) {
+                match key {
+                    "Exec" => entry.exec = Some(value.to_string()),
+                    "Path" => entry.path = Some(PathBuf::from(value)),
+                    "OnlyShowIn" => entry.only_show_in = Some(Self::split_to_set(value)),
+                    "NotShowIn" => entry.not_show_in = Some(Self::split_to_set(value)),
+                    "Hidden" => entry.hidden = Self::str_bool(value).unwrap_or_default(),
+                    _ => {}
+                }
+            }
+        }
+        entry
+    }
+
+    fn split_line(line: &str) -> Option<(&str, &str)> {
+        line.find('=')?; // Check we have an equals, if we don't return None
+        line.split_once('=')
+    }
+    fn split_to_set(value: &str) -> HashSet<String> {
+        value
+            .split(';')
+            .filter_map(|s| {
+                let s = s.trim();
+                if s.is_empty() {
+                    return None;
+                }
+                Some(s.to_string())
+            })
+            .collect::<HashSet<String>>()
+    }
+    fn str_bool(value: &str) -> Option<bool> {
+        value.to_lowercase().parse::<bool>().ok()
+    }
+}
+
+/// Register the `SIGCHLD` signal handler. Once the signal is received,
+/// the flag will be set true. User needs to manually clear the flag.
+pub fn register_child_hook(flag: Arc<AtomicBool>) {
+    _ = signal_hook::flag::register(signal_hook::consts::signal::SIGCHLD, flag)
+        .map_err(|err| println!("Cannot register SIGCHLD signal handler: {err:?}"));
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::utils::remove_field_codes;
+
+    use super::DesktopEntry;
+
+    #[test]
+    fn test_parse() {
+        let content = r"
+            [Desktop Action Gallery]
+        Exec=fooview --gallery
+        Name=Browse Gallery
+                [Desktop Entry]
+        #comment
+        Name=Optimus Manager
+        Name[zh_CN]=Optimus \u{7ba1}\u{7406}\u{5668}
+        Comment=A program to handle GPU switching on Optimus laptops
+        Comment[ru]=\u{41f}\u{440}\u{43e}\u{433}\u{440}\u{430}\u{43c}\u{43c}\u{430} \u{434}\u{43b}\u{44f} \u{443}\u{43f}\u{440}\u{430}\u{432}\u{43b}\u{435}\u{43d}\u{438}\u{44f} \u{43f}\u{435}\u{440}\u{435}\u{43a}\u{43b}\u{44e}\u{447}\u{435}\u{43d}\u{438}\u{435}\u{43c} \u{433}\u{440}\u{430}\u{444}\u{438}\u{447}\u{435}\u{441}\u{43a}\u{438}\u{445} \u{43f}\u{440}\u{43e}\u{446}\u{435}\u{441}\u{441}\u{43e}\u{440}\u{43e}\u{432} \u{43d}\u{430} \u{43d}\u{43e}\u{443}\u{442}\u{431}\u{443}\u{43a}\u{430}\u{445} c Optimus
+        Comment[zh_CN]=\u{5904}\u{7406}\u{53cc}\u{663e}\u{5361}\u{7b14}\u{8bb0}\u{672c}\u{7535}\u{8111} GPU \u{5207}\u{6362}\u{7684}\u{7a0b}\u{5e8f}
+        Keywords=nvidia;optimus;settings;switch;GPU;
+        Keywords[ru]=nvidia;optimus;settings;switch;GPU;\u{43d}\u{430}\u{441}\u{442}\u{440}\u{43e}\u{439}\u{43a}\u{438};\u{432}\u{438}\u{434}\u{435}\u{43e}\u{43a}\u{430}\u{440}\u{442}\u{430};
+        Exec=optimus-manager-qt
+        Icon=optimus-manager-qt
+        Terminal=false
+        StartupNotify=false
+        Type=Application
+        Categories=System;Settings;Qt;
+        Actions=Gallery;Create;
+        Hidden=true
+        OnlyShowIn=XFCE;
+
+        [Desktop Action Create]
+        Exec=fooview --create-new
+        Name=Create a new Foo!
+        Icon=fooview-new
+                ";
+
+        let entry = DesktopEntry::parse(content);
+
+        assert_eq!(
+            entry.exec,
+            Some("optimus-manager-qt".to_string()),
+            "exec failed"
+        );
+        assert!(entry.path.is_none(), "expect path none");
+        assert!(entry.hidden, "expect hidden true");
+        assert!(entry.only_show_in.is_some(), "expect only_show_in defined");
+
+        assert!(
+            entry.only_show_in.clone().unwrap().contains("XFCE"),
+            "expect only_show_in contains XFCE"
+        );
+        assert!(
+            !entry.only_show_in.clone().unwrap().contains(""),
+            "expect only show in not contains empty-str"
+        );
+        assert!(entry.not_show_in.is_none(), "expect not_show_in none");
+    }
+
+    #[test]
+    fn test_field_codes_removal() {
+        let sample_exec_with_field_code = "/path/to/app %u";
+        assert_eq!(
+            remove_field_codes(sample_exec_with_field_code),
+            "/path/to/app "
+        );
+
+        let sample_exec_with_multiple_field_codes = "/path/to/app %a %b";
+        assert_eq!(
+            remove_field_codes(sample_exec_with_multiple_field_codes),
+            "/path/to/app  "
+        );
+
+        let sample_exec_with_escaped_percentage_signs = "/path/to/app %%%%";
+        assert_eq!(
+            remove_field_codes(sample_exec_with_escaped_percentage_signs),
+            "/path/to/app %%"
+        );
+
+        let sample_exec_with_field_code_and_escaped_percentage_signs = "/path/to/app %%%%%u";
+        assert_eq!(
+            remove_field_codes(sample_exec_with_field_code_and_escaped_percentage_signs),
+            "/path/to/app %%"
+        );
+
+        let bad_exec1 = "/path/to/app %^";
+        assert_eq!(remove_field_codes(bad_exec1), bad_exec1);
+
+        let bad_exec2 = "/path/to/app %";
+        assert_eq!(remove_field_codes(bad_exec2), bad_exec2);
+    }
+}

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = "1.0.48"
 clap = { version = "4.0.0", features = ["cargo"] }
 const_format = "0.2.26"
 once_cell = "1.13.0"
-dirs-next = "2.0.0"
 futures = "0.3.21"
 git-version = "0.3.5"
 lefthk-core = { version = '0.2', optional = true }
@@ -25,7 +24,6 @@ leftwm-macros = {path = "../leftwm-macros", version = '0.5.0'}
 leftwm-layouts = "0.8.4"
 liquid = "0.26.0"
 mio = "0.8.0"
-nix = {version = "0.27.1", features = ["fs", "signal"]}
 regex = "1"
 ron = "0.8.0"
 serde = { version = "1.0.104", features = ["derive", "rc"] }

--- a/leftwm/src/utils.rs
+++ b/leftwm/src/utils.rs
@@ -1,5 +1,6 @@
 pub mod log;
 
+#[must_use]
 pub const fn get_help_template() -> &'static str {
     "\
 {name} {version}


### PR DESCRIPTION
# Description

Separate the leftwm(bin) target out of the leftwm crate into the leftwm-watchdog crate to improve compile times.

I changed the binary target's name to `leftwm` to avoid problems (this is now a development change, the target directory's executable are the same as before).

Fixes #1190 

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
