### PR TITLE
lefthk-worker: change multiple feature checks to one module condition

### DIFF
--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -1,28 +1,25 @@
-#[cfg(feature = "lefthk")]
+#![cfg(feature = "lefthk")]
+
 use lefthk_core::{config::Config, worker::Worker};
-#[cfg(feature = "lefthk")]
 use xdg::BaseDirectories;
 
 fn main() {
-    #[cfg(feature = "lefthk")]
-    {
-        leftwm::utils::log::setup_logging();
+    leftwm::utils::log::setup_logging();
 
-        tracing::info!("lefthk-worker booted!");
+    tracing::info!("lefthk-worker booted!");
 
-        let exit_status = std::panic::catch_unwind(|| {
-            let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
-            let _rt_guard = rt.enter();
-            let config = leftwm::load();
-            let path = BaseDirectories::with_prefix("leftwm-lefthk")
-                .expect("ERROR: could not find base directory");
+    let exit_status = std::panic::catch_unwind(|| {
+        let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
+        let _rt_guard = rt.enter();
+        let config = leftwm::load();
+        let path = BaseDirectories::with_prefix("leftwm-lefthk")
+            .expect("ERROR: could not find base directory");
 
-            rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
-        });
+        rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
+    });
 
-        match exit_status {
-            Ok(()) => tracing::info!("Completed"),
-            Err(err) => tracing::error!("Completed with error: {:?}", err),
-        }
+    match exit_status {
+        Ok(()) => tracing::info!("Completed"),
+        Err(err) => tracing::error!("Completed with error: {:?}", err),
     }
 }


### PR DESCRIPTION
# Description

Simplify lefthk-worker by replacing the three feature checks by one module-wide one. 

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
