### PR TITLE
Rework "fixed dialog windows ignoring application-defined sizes (#1166)"

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -443,8 +443,7 @@ fn setup_window(
                 set_relative_floating(window, ws, ws.xyhw);
             }
         }
-        WindowType::Dialog => set_relative_floating(window, ws, ws.xyhw),
-        WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),
+        WindowType::Dialog | WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),
         _ => {}
     }
 }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -440,27 +440,17 @@ fn setup_window(
         WindowType::Normal => {
             window.apply_margin_multiplier(ws.margin_multiplier);
             if window.floating() {
-                match window.requested {
-                    Some(xyhw) => set_relative_floating(window, ws, xyhw),
-                    None => set_relative_floating(window, ws, ws.xyhw),
-                };
+                set_relative_floating(window, ws, ws.xyhw);
             }
         }
         WindowType::Dialog => {
             if window.can_resize() {
                 window.set_floating(true);
-                if let Some(xyhw) = window.requested {
-                    set_relative_floating(window, ws, xyhw);
-                } else {
-                    let new_float_exact = ws.center_halfed();
-                    window.normal = ws.xyhw;
-                    window.set_floating_exact(new_float_exact);
-                };
+                let new_float_exact = ws.center_halfed();
+                window.normal = ws.xyhw;
+                window.set_floating_exact(new_float_exact);
             } else {
-                match window.requested {
-                    Some(xyhw) => set_relative_floating(window, ws, xyhw),
-                    None => set_relative_floating(window, ws, ws.xyhw),
-                };
+                set_relative_floating(window, ws, ws.xyhw);
             }
         }
         WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -338,6 +338,8 @@ fn is_scratchpad(state: &State, window: &Window) -> bool {
         .any(|(_, id)| id.iter().any(|id| window.pid == Some(*id)))
 }
 
+/// Tries to position a window according to the requested sizes.
+/// When no size was requested, defaults to `ws.center_halfed()`
 fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
     window.set_floating(true);
     window.normal = ws.xyhw;
@@ -441,16 +443,7 @@ fn setup_window(
                 set_relative_floating(window, ws, ws.xyhw);
             }
         }
-        WindowType::Dialog => {
-            if window.can_resize() {
-                window.set_floating(true);
-                let new_float_exact = ws.center_halfed();
-                window.normal = ws.xyhw;
-                window.set_floating_exact(new_float_exact);
-            } else {
-                set_relative_floating(window, ws, ws.xyhw);
-            }
-        }
+        WindowType::Dialog => set_relative_floating(window, ws, ws.xyhw),
         WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),
         _ => {}
     }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -345,12 +345,10 @@ fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
         || ws.center_halfed(),
         |mut requested| {
             requested.center_relative(outer, window.border);
-            if ws.xyhw.contains_xyhw(&requested) {
-                requested
-            } else {
+            if !ws.xyhw.contains_xyhw(&requested) {
                 requested.center_relative(ws.xyhw, window.border);
-                requested
             }
+            requested
         },
     );
     window.set_floating_exact(xyhw);


### PR DESCRIPTION
# Description

I wasn't able to do a full review of #1166 before it was merged, but I had taken a look at the code and already noticed that the solution seemed complicated. However I kept it as a unread notification until when I had time (now).

Basically, the `set_relative_floating` function already respects all size requests, it just wasn't called.

This also corrects the mistake made before that (not respecting size hints from resizable dialog windows). However I wasn't able to trace that further than #807 (e2517de95)

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test-full` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.