### PR TITLE
Fix the 32 bit builds by changing a type cast

### DIFF
--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -94,7 +94,7 @@ impl XWrap {
 
     /// Sets a desktop property.
     pub fn set_desktop_prop(&self, data: &[u32], atom: c_ulong) {
-        let x_data: Vec<c_long> = data.iter().map(|x| i64::from(*x)).collect();
+        let x_data: Vec<c_long> = data.iter().map(|x| *x as c_long).collect();
         self.replace_property_long(self.root, atom, xlib::XA_CARDINAL, &x_data);
     }
 


### PR DESCRIPTION
# Description

`i64::from` was replaced by a direct `as` type cast. to fix the 32bit build error expressed in the issue below.

I don't expect this change to cause any problems as we are casting a smaller type (u32) into a larger one (c_long should be i64-eqivalent).

Compilation was tested on i686-unknown-linux-gnu toolchain.

Fixes #1201 

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
