### PR TITLE
remove hardcoded default layouts

### DIFF
--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -19,7 +19,7 @@ use leftwm_core::{
     state::State,
     DisplayAction, DisplayServer, Manager, ReturnPipe,
 };
-use leftwm_layouts::layouts::Layouts;
+
 use leftwm_layouts::Layout;
 use regex::Regex;
 use ron::{
@@ -422,7 +422,7 @@ impl leftwm_core::Config for Config {
     }
 
     fn layout_definitions(&self) -> Vec<Layout> {
-        let mut layouts = Layouts::default().layouts;
+        let mut layouts = vec![];
         for custom_layout in &self.layout_definitions {
             layouts.push(custom_layout.clone());
         }


### PR DESCRIPTION
# Description

Remove hard coded default list of layouts

this enables users to define their own layouts using the default names "Monocle" and "MainAndDeck" which are hardcoded into other parts of leftwm.

Fixes #1127

## Type of change

- [X] Development change (no change visible to user)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)

*note* `make test` has failed saying that `X.get(0)` should be replaced by `X.front()` in multiple locations; it failed in the clippy step... perhaps related to #1198
