### PR TITLE
update layouts in man page

### DIFF
--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -264,9 +264,9 @@ layout_definitions = [(
     rotate: North,
     main: (count: 1, size: 0.8, flip: None, rotate: North, split: None),
     stack: (flip: None, rotate: North, split: Horizontal),
-    second_stack: None)
+    second_stack: None,
   ),
-]
+)]
 \f[R]
 .fi
 .PP

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -260,11 +260,11 @@ layout_definitions = [(
   rotate: North,
   reserve: ReserveAndCenter,
   columns: (
-  flip: None,
-  rotate: North,
-  main: (count: 1, size: 0.8, flip: None, rotate: North, split: None),
-  stack: (flip: None, rotate: North, split: Horizontal),
-  second_stack: None)
+    flip: None,
+    rotate: North,
+    main: (count: 1, size: 0.8, flip: None, rotate: North, split: None),
+    stack: (flip: None, rotate: North, split: Horizontal),
+    second_stack: None)
   ),
 ]
 \f[R]
@@ -312,8 +312,8 @@ Again the example for an ultra-wide screen, splitting workspaces by substracting
 .nf
 \f[C]
 workspaces: [
-    { output: "HDMI-1", y: 0, x: 0, height: 1440, width: -1720 },
-    { output: "HDMI-1", y: 0, x: 1720, height: 1440, width: -1720 },
+    ( output: "HDMI-1", y: 0, x: 0, height: 1440, width: -1720 ),
+    ( output: "HDMI-1", y: 0, x: 1720, height: 1440, width: -1720 ),
 ]
 \f[R]
 .fi

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -217,36 +217,70 @@ New windows will be created in the workspace:
 .IP "-"
 .B  Containing the cursor
 when unset (\f[C]None\f[R]), \f[C]Some(true)\f[R], or when the cursor is in \f[C]Sloppy\f[R] mode
-.IP "-" 
+.IP "-"
 .B Which is focused
 when set to \f[C]Some(false)\f[R]
 .PP
 Default: \f[C]create_follows_cursor = None\f[R]
 .SS Layouts
 .PP
-Leftwm supports variety of layouts, which define the way that windows are tiled in the workspace
+Leftwm supports a variety of user definable layouts. Layouts define the way that windows are tiled in the workspace.
 .PP
-Default layouts:
+The layouts considered by leftwm can be customized in the
+.B config.ron
+file by editing the
+.B layouts
+and the
+.B layout_definitions
+entries.
+.PP
+The layouts in the
+.B layouts
+list are those accessible when switching layouts. For an example with a single layout:
+.PP
 .IP
 .nf
 \f[C]
-layouts: [
-    MainAndDeck,
-    MainAndVertStack,
-    MainAndHorizontalStack,
-    GridHorizontal,
-    EvenHorizontal,
-    EvenVertical,
-    Fibonacci,
-    CenterMain,
-    CenterMainBalanced,
-    CenterMainFluid,
-    Monocle,
-    RightWiderLeftStack,
-    LeftWiderRightStack,
+layouts = [ "MyMainAndVertStack" ]
+\f[R]
+.fi
+.PP
+Each list in the
+.B layouts
+list must have a corresponding definition in the
+.B layout_definitions
+entry. For example:
+.PP
+.IP
+.nf
+\f[C]
+layout_definitions = [(
+  name: "MyMainAndVertStack",
+  flip: None,
+  rotate: North,
+  reserve: ReserveAndCenter,
+  columns: (
+  flip: None,
+  rotate: North,
+  main: (count: 1, size: 0.8, flip: None, rotate: North, split: None),
+  stack: (flip: None, rotate: North, split: Horizontal),
+  second_stack: None)
+  ),
 ]
 \f[R]
 .fi
+.PP
+The size of the
+.B main
+area can be controlled with the
+.B IncreaseMainSize
+and
+.B DecreaseMainSize
+commands.
+
+.PP
+There are various possiblities for the other parameters, and the user is referred to the default configuration file to see a large selection of examples.
+
 
 .SS Workspaces
 .PP


### PR DESCRIPTION
# Description

Fixes #1129

Adds explanation of `layouts` and `layout_definitions` entries in `config.ron` in the manpage

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [X] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
