### PR TITLE
Fix newly spawned floating windows ignoring ws margins

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -347,8 +347,8 @@ fn set_relative_floating(window: &mut Window, ws: &Workspace, outer: Xyhw) {
         || ws.center_halfed(),
         |mut requested| {
             requested.center_relative(outer, window.border);
-            if !ws.xyhw.contains_xyhw(&requested) {
-                requested.center_relative(ws.xyhw, window.border);
+            if !ws.xyhw_avoided.contains_xyhw(&requested) {
+                requested.center_relative(ws.xyhw_avoided, window.border);
             }
             requested
         },
@@ -440,10 +440,12 @@ fn setup_window(
         WindowType::Normal => {
             window.apply_margin_multiplier(ws.margin_multiplier);
             if window.floating() {
-                set_relative_floating(window, ws, ws.xyhw);
+                set_relative_floating(window, ws, ws.xyhw_avoided);
             }
         }
-        WindowType::Dialog | WindowType::Splash => set_relative_floating(window, ws, ws.xyhw),
+        WindowType::Dialog | WindowType::Splash => {
+            set_relative_floating(window, ws, ws.xyhw_avoided);
+        }
         _ => {}
     }
 }

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -16,7 +16,7 @@ pub struct Workspace {
     #[serde(skip)]
     pub avoid: Vec<Xyhw>,
     pub xyhw: Xyhw,
-    xyhw_avoided: Xyhw,
+    pub xyhw_avoided: Xyhw,
     /// ID of workspace. Starts with 1.
     pub id: WorkspaceId,
 }


### PR DESCRIPTION
# Description

I encountered a bug after configuring a window hook for [PrismLauncher](https://github.com/PrismLauncher/PrismLauncher/) windows to be floating.
The "edit" window (normal type) does not request a height, The fallback was to use the workspace xywh, which caused it to clip into my bar up top.

This pr switches the full ws xywh to the xywh_avoided which considers margins.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
