### PR TITLE
Spawn new floating windows above old ones

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -605,7 +605,9 @@ fn tile_to_floating(state: &mut State) -> Option<bool> {
     window.set_floating_offsets(Some(floating));
     window.start_loc = Some(floating);
     window.set_floating(true);
-    state.sort_windows();
+
+    let handle = window.handle;
+    state.move_to_top(&handle);
 
     Some(true)
 }

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -588,11 +588,7 @@ fn tile_to_floating(state: &mut State) -> Option<bool> {
     let width = state.default_width;
     let height = state.default_height;
     let window = state.focus_manager.window_mut(&mut state.windows)?;
-    if window.must_float() {
-        return None;
-    }
-    // Not ideal as is_floating and must_float are connected so have to check
-    // them separately
+
     if window.floating() {
         return None;
     }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -297,10 +297,11 @@ fn insert_window(state: &mut State, window: &mut Window, layout: &str) {
         }
     }
 
-    // If a window is a dialog, splash, or scractchpad we want it to be at the top.
+    // If a window is a dialog, splash, utility, floating or scractchpad we want it to be at the top.
     if window.r#type == WindowType::Dialog
         || window.r#type == WindowType::Splash
         || window.r#type == WindowType::Utility
+        || window.floating()
         || is_scratchpad(state, window)
     {
         state.windows.insert(0, window.clone());


### PR DESCRIPTION
# Description

Fixes what presumably is a regression I caused in #1158 where newly spawned and previously tiled floating windows aren't put up front but behind already existing ones. 

> [!NOTE]  
> I assume ignoring the `inset_behavior` config be intended behavior here.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
