### PR TITLE
change exec_shell to directly executed given command

### DIFF
--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -168,7 +168,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             Ok(child) => {
                 self.children.insert(child);
             }
-            Err(err) => tracing::warn!("Global up script faild: {}", err),
+            Err(err) => tracing::warn!("Global up script failed: {}", err),
         }
         match Nanny::boot_current_theme() {
             Ok(child) => {

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -166,9 +166,7 @@ pub fn register_child_hook(flag: Arc<AtomicBool>) {
 /// Sends command to shell for execution
 /// Assumes STDIN/STDERR/STDOUT unwanted.
 pub fn exec_shell(command: &str, children: &mut Children) -> Option<ChildID> {
-    let child = Command::new("sh")
-        .arg("-c")
-        .arg(command)
+    let child = Command::new(command)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())


### PR DESCRIPTION
# Description

Fixes #958. `ToggleScratchPad` was not working correctly. I changed the way `exec_shell` works to launch directly the command rather then first launch `sh -c`. The PIDs were always off by one, and I think that what was happening was that `sh` consumed one PID and then launched `alacritty` which consumed the next PID.

May be a breaking change for some users scratchpads, so should be tested I suppose.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] Ran `make test` locally with no errors or warnings reported