### PR TITLE
feat(mouse handler): allow user to swap resize and move using ShiftMask

### DIFF
--- a/leftwm-core/src/utils/modmask_lookup.rs
+++ b/leftwm-core/src/utils/modmask_lookup.rs
@@ -8,7 +8,7 @@ bitflags! {
         /// Used as the zero value
         const Zero = 0;
         const Any = 1;
-        const Shift = 1 << 1;
+        const Shift = 1 << 0;
         const Control = 1 << 2;
         /// Mod1
         const Alt = 1 << 3;

--- a/leftwm-core/src/utils/modmask_lookup.rs
+++ b/leftwm-core/src/utils/modmask_lookup.rs
@@ -9,6 +9,8 @@ bitflags! {
         const Zero = 0;
         const Any = 1;
         const Shift = 1 << 0;
+        /// Caps Lock
+        const Lock = 1 << 1;
         const Control = 1 << 2;
         /// Mod1
         const Alt = 1 << 3;
@@ -93,6 +95,7 @@ pub fn into_mod(key: &str) -> ModMask {
         "None" => ModMask::Any,
         "Shift" => ModMask::Shift,
         "Control" => ModMask::Control,
+        "Lock" | "Capslock" => ModMask::Lock,
         "Mod1" | "Alt" => ModMask::Alt,
         // NOTE: we are ignoring the state of Numlock
         // this is left here as a reminder


### PR DESCRIPTION
# Description

Make it so `shift + mousekey + (left) click + drag` resizes windows and `shift + mousekey + (right) click + drag` moves windows. 

Remove static quantities from state struct.

Fixes #1213 

## Type of change

- [X] Development change (no change visible to user)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Updated user documentation:

Holding down `mousekey` while left-clicking is used to move windows, and holding down `mousekey` while right-clicking is used to resize windows. Alternatively, one can hold `mousekey` and Shift while left-clicking to resize windows or `mousekey` and Shift while right-clicking to move windows.

# Checklist:

- [X] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
