### PR TITLE
Refactor theme config loading

### DIFF
--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -35,7 +35,8 @@ impl DisplayServer for XlibDisplayServer {
     fn new(config: &impl Config) -> Self {
         let mut wrap = XWrap::new();
 
-        wrap.init(config); // setup events masks
+        wrap.load_config(config);
+        wrap.init(); // setup events masks
 
         let root = wrap.get_default_root();
         let instance = Self {
@@ -54,10 +55,11 @@ impl DisplayServer for XlibDisplayServer {
     fn load_config(
         &mut self,
         config: &impl Config,
-        focused: Option<&Option<WindowHandle>>,
+        focused: Option<WindowHandle>,
         windows: &[Window],
     ) {
-        self.xw.load_config(config, focused, windows);
+        self.xw.load_config(config);
+        self.xw.update_colors(focused, windows);
     }
 
     fn update_windows(&self, windows: Vec<&Window>) {

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -52,7 +52,7 @@ impl DisplayServer for XlibDisplayServer {
         }
     }
 
-    fn load_config(
+    fn reload_config(
         &mut self,
         config: &impl Config,
         focused: Option<WindowHandle>,

--- a/leftwm-core/src/display_servers.rs
+++ b/leftwm-core/src/display_servers.rs
@@ -19,7 +19,7 @@ pub trait DisplayServer {
 
     fn get_next_events(&mut self) -> Vec<DisplayEvent>;
 
-    fn load_config(
+    fn reload_config(
         &mut self,
         config: &impl Config,
         focused: Option<WindowHandle>,

--- a/leftwm-core/src/display_servers.rs
+++ b/leftwm-core/src/display_servers.rs
@@ -21,11 +21,10 @@ pub trait DisplayServer {
 
     fn load_config(
         &mut self,
-        _config: &impl Config,
-        _focused: Option<&Option<WindowHandle>>,
-        _windows: &[Window],
-    ) {
-    }
+        config: &impl Config,
+        focused: Option<WindowHandle>,
+        windows: &[Window],
+    );
 
     fn update_windows(&self, _windows: Vec<&Window>) {}
 

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -29,4 +29,13 @@ impl DisplayServer for MockDisplayServer {
     fn generate_verify_focus_event(&self) -> Option<DisplayEvent> {
         unimplemented!()
     }
+
+    fn load_config(
+        &mut self,
+        _config: &impl Config,
+        _focused: Option<crate::models::WindowHandle>,
+        _windows: &[crate::Window],
+    ) {
+        unimplemented!()
+    }
 }

--- a/leftwm-core/src/display_servers/mock_display_server.rs
+++ b/leftwm-core/src/display_servers/mock_display_server.rs
@@ -30,7 +30,7 @@ impl DisplayServer for MockDisplayServer {
         unimplemented!()
     }
 
-    fn load_config(
+    fn reload_config(
         &mut self,
         _config: &impl Config,
         _focused: Option<crate::models::WindowHandle>,

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -52,7 +52,6 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
     command: &Command,
 ) -> Option<bool> {
     let state = &mut manager.state;
-    let config = &manager.config;
     match command {
         Command::ToggleScratchPad(name) => scratchpad_handler::toggle_scratchpad(manager, name),
         Command::AttachScratchPad { window, scratchpad } => {
@@ -96,12 +95,9 @@ fn process_internal<C: Config, SERVER: DisplayServer>(
         Command::SetLayout(layout) => set_layout(layout.as_str(), state),
 
         Command::FloatingToTile => floating_to_tile(state),
-        Command::TileToFloating => {
-            tile_to_floating(state, config.default_width(), config.default_height())
-        }
-        Command::ToggleFloating => {
-            toggle_floating(state, config.default_width(), config.default_height())
-        }
+        Command::TileToFloating => tile_to_floating(state),
+        Command::ToggleFloating => toggle_floating(state),
+
         Command::FocusNextTag { behavior } => match *behavior {
             FocusDeltaBehavior::Default => focus_tag_change(state, 1),
             FocusDeltaBehavior::IgnoreEmpty => focus_next_used_tag(state),
@@ -588,7 +584,9 @@ fn floating_to_tile(state: &mut State) -> Option<bool> {
     Some(true)
 }
 
-fn tile_to_floating(state: &mut State, width: i32, height: i32) -> Option<bool> {
+fn tile_to_floating(state: &mut State) -> Option<bool> {
+    let width = state.default_width;
+    let height = state.default_height;
     let window = state.focus_manager.window_mut(&mut state.windows)?;
 
     if window.floating() {
@@ -614,12 +612,12 @@ fn tile_to_floating(state: &mut State, width: i32, height: i32) -> Option<bool> 
     Some(true)
 }
 
-fn toggle_floating(state: &mut State, width: i32, height: i32) -> Option<bool> {
+fn toggle_floating(state: &mut State) -> Option<bool> {
     let window = state.focus_manager.window(&state.windows)?;
     if window.floating() {
         floating_to_tile(state)
     } else {
-        tile_to_floating(state, width, height)
+        tile_to_floating(state)
     }
 }
 

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -49,11 +49,16 @@ impl<C, SERVER> Manager<C, SERVER> {
 
 impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
     /// Reload the configuration of the running [`Manager`].
-    pub fn reload_config(&mut self) -> bool {
-        let focused = self.state.focus_manager.window_history.front();
+    pub fn load_theme_config(&mut self) -> bool {
+        let focused = self
+            .state
+            .focus_manager
+            .window_history
+            .front()
+            .and_then(|o| *o);
         self.display_server
             .load_config(&self.config, focused, &self.state.windows);
-        self.state.load_config(&self.config);
+        self.state.load_theme_config(&self.config);
         true
     }
 }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -57,7 +57,7 @@ impl<C: Config, SERVER: DisplayServer> Manager<C, SERVER> {
             .front()
             .and_then(|o| *o);
         self.display_server
-            .load_config(&self.config, focused, &self.state.windows);
+            .reload_config(&self.config, focused, &self.state.windows);
         self.state.load_theme_config(&self.config);
         true
     }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -26,6 +26,8 @@ pub struct State {
     pub actions: VecDeque<DisplayAction>,
     pub tags: Tags, // List of all known tags.
     pub mousekey: Vec<String>,
+    pub default_width: i32,
+    pub default_height: i32,
     pub disable_tile_drag: bool,
     pub reposition_cursor_on_resize: bool,
     pub insert_behavior: InsertBehavior,
@@ -53,6 +55,8 @@ impl State {
             actions: Default::default(),
             tags,
             mousekey: config.mousekey(),
+            default_width: config.default_width(),
+            default_height: config.default_height(),
             disable_tile_drag: config.disable_tile_drag(),
             reposition_cursor_on_resize: config.reposition_cursor_on_resize(),
             insert_behavior: config.insert_behavior(),

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -170,8 +170,7 @@ impl State {
             });
     }
 
-    pub(crate) fn load_config(&mut self, config: &impl Config) {
-        self.mousekey = config.mousekey();
+    pub(crate) fn load_theme_config(&mut self, config: &impl Config) {
         for win in &mut self.windows {
             config.load_window(win);
         }

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -178,6 +178,8 @@ impl State {
         for ws in &mut self.workspaces {
             ws.load_config(config);
         }
+        self.default_height = config.default_height();
+        self.default_width = config.default_width();
     }
 
     /// Apply saved state to a running manager.

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use clap::{arg, command};
-use leftwm::{Config, ThemeSetting};
+use leftwm::{Config, ThemeConfig};
 use ron::{
     extensions::Extensions,
     ser::{to_string_pretty, PrettyConfig},
@@ -338,7 +338,7 @@ fn check_theme_toml(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
             println!("Found: {}", filepath.display());
         }
 
-        match toml::from_str::<ThemeSetting>(&contents) {
+        match toml::from_str::<ThemeConfig>(&contents) {
             Ok(_) => {
                 if verbose {
                     println!("The theme file looks OK.");
@@ -368,7 +368,7 @@ fn check_theme_ron(filepath: PathBuf, verbose: bool) -> Result<PathBuf> {
 
         let ron = Options::default()
             .with_default_extension(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES);
-        match ron.from_str::<ThemeSetting>(&contents) {
+        match ron.from_str::<ThemeConfig>(&contents) {
             Ok(_) => {
                 if verbose {
                     println!("The theme file looks OK.");

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -460,12 +460,12 @@ impl leftwm_core::Config for Config {
                         tracing::warn!("Path submitted does not exist.");
                         write_to_pipe(&mut return_pipe, "ERROR: Path submitted does not exist");
                     }
-                    manager.reload_config()
+                    manager.load_theme_config()
                 }
                 "UnloadTheme" => {
                     manager.config.theme_setting = ThemeSetting::default();
                     write_to_pipe(&mut return_pipe, "OK: Command executed successfully");
-                    manager.reload_config()
+                    manager.load_theme_config()
                 }
                 _ => {
                     tracing::warn!("Command not recognized: {}", command);
@@ -483,7 +483,7 @@ impl leftwm_core::Config for Config {
                 "UnloadTheme" => {
                     manager.config.theme_setting = ThemeSetting::default();
                     write_to_pipe(&mut return_pipe, "OK: Command executed successfully");
-                    manager.reload_config()
+                    manager.load_theme_config()
                 }
                 _ => {
                     tracing::warn!("Command not recognized: {}", command);

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -8,7 +8,7 @@ use self::keybind::Modifier;
 
 #[cfg(feature = "lefthk")]
 use super::BaseCommand;
-use super::ThemeSetting;
+use super::ThemeConfig;
 #[cfg(feature = "lefthk")]
 use crate::config::keybind::Keybind;
 use anyhow::Result;
@@ -207,7 +207,7 @@ pub struct Config {
     // NOTE: any newly added parameters must be inserted before `pub keybind: Vec<Keybind>,`
     //       at least when `TOML` is used as config language
     #[serde(skip)]
-    pub theme_setting: ThemeSetting,
+    pub theme_setting: ThemeConfig,
 }
 
 #[must_use]
@@ -463,7 +463,7 @@ impl leftwm_core::Config for Config {
                     manager.load_theme_config()
                 }
                 "UnloadTheme" => {
-                    manager.config.theme_setting = ThemeSetting::default();
+                    manager.config.theme_setting = ThemeConfig::default();
                     write_to_pipe(&mut return_pipe, "OK: Command executed successfully");
                     manager.load_theme_config()
                 }
@@ -481,7 +481,7 @@ impl leftwm_core::Config for Config {
                     false
                 }
                 "UnloadTheme" => {
-                    manager.config.theme_setting = ThemeSetting::default();
+                    manager.config.theme_setting = ThemeConfig::default();
                     write_to_pipe(&mut return_pipe, "OK: Command executed successfully");
                     manager.load_theme_config()
                 }

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -2,7 +2,7 @@ use leftwm_core::models::{ScratchPad, Size};
 
 #[cfg(feature = "lefthk")]
 use super::{default_terminal, exit_strategy, BaseCommand, Keybind};
-use super::{Config, Default, FocusBehaviour, LayoutMode, ThemeSetting};
+use super::{Config, Default, FocusBehaviour, LayoutMode, ThemeConfig};
 
 impl Default for Config {
     // We allow this because this function would be difficult to reduce. If someone would like to
@@ -233,7 +233,7 @@ impl Default for Config {
             mousekey: Some("Mod4".into()), // win key
             #[cfg(feature = "lefthk")]
             keybind: commands,
-            theme_setting: ThemeSetting::default(),
+            theme_setting: ThemeConfig::default(),
             max_window_width: None,
             state_path: None,
             sloppy_mouse_follows_focus: true,

--- a/leftwm/src/lib.rs
+++ b/leftwm/src/lib.rs
@@ -2,8 +2,8 @@ pub mod utils;
 
 mod command;
 mod config;
-mod theme_setting;
+mod theme_config;
 
 pub use command::*;
 pub use config::*;
-pub use theme_setting::*;
+pub use theme_config::*;

--- a/leftwm/src/theme_config.rs
+++ b/leftwm/src/theme_config.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct ThemeSetting {
+pub struct ThemeConfig {
     pub border_width: Option<i32>,
     pub margin: Option<CustomMargins>,
     pub workspace_margin: Option<CustomMargins>,
@@ -22,7 +22,7 @@ pub struct ThemeSetting {
     pub on_new_window_cmd: Option<String>,
 }
 
-impl ThemeSetting {
+impl ThemeConfig {
     pub fn load(&mut self, path: impl AsRef<Path>) {
         let path = path.as_ref();
         match load_theme_file(path) {
@@ -34,7 +34,7 @@ impl ThemeSetting {
     }
 }
 
-impl Default for ThemeSetting {
+impl Default for ThemeConfig {
     fn default() -> Self {
         Self {
             border_width: Some(1),
@@ -53,15 +53,15 @@ impl Default for ThemeSetting {
     }
 }
 
-fn load_theme_file(path: impl AsRef<Path>) -> Result<ThemeSetting> {
+fn load_theme_file(path: impl AsRef<Path>) -> Result<ThemeConfig> {
     let contents = fs::read_to_string(&path)?;
     if path.as_ref().extension() == Some(std::ffi::OsStr::new("ron")) {
         let ron = Options::default()
             .with_default_extension(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES);
-        let from_file: ThemeSetting = ron.from_str(&contents)?;
+        let from_file: ThemeConfig = ron.from_str(&contents)?;
         Ok(from_file)
     } else {
-        let from_file: ThemeSetting = toml::from_str(&contents)?;
+        let from_file: ThemeConfig = toml::from_str(&contents)?;
         Ok(from_file)
     }
 }
@@ -121,11 +121,11 @@ on_new_window = 'echo Hello World'
 side = "Top"
 value = 0
 "#;
-        let config: ThemeSetting = toml::from_str(config).unwrap();
+        let config: ThemeConfig = toml::from_str(config).unwrap();
 
         assert_eq!(
             config,
-            ThemeSetting {
+            ThemeConfig {
                 border_width: Some(0),
                 margin: Some(CustomMargins::Int(5)),
                 workspace_margin: Some(CustomMargins::Int(5)),
@@ -168,11 +168,11 @@ value = 0
         )]
     )
 )"##;
-        let config: ThemeSetting = ron::from_str(config).unwrap();
+        let config: ThemeConfig = ron::from_str(config).unwrap();
 
         assert_eq!(
             config,
-            ThemeSetting {
+            ThemeConfig {
                 border_width: Some(0),
                 margin: Some(CustomMargins::Int(5)),
                 workspace_margin: Some(CustomMargins::Int(5)),


### PR DESCRIPTION
# Description

Slightly rework the way the theme config is loaded into leftwm and untangle some of the color loading.

Fixes #(1213)

# Changes
> [!Note]
> This pr is best reviewed per-commit, as there are a lot of renames.

- 2eace8188a226ebace36b7ddabb03d4b6604eb8d
  Add `default_width/height` to loaded theme vars (replaces #1218 by a simpler solution)
  https://github.com/leftwm/leftwm/blob/2eace8188a226ebace36b7ddabb03d4b6604eb8d/leftwm-core/src/state.rs#L181-L182

- 5debd321132ce0b18c5c486319be3b662b291837
  Xlib Display Server `new()` now first loads the config into `Xwrap` and then calls `init()` without the config param.
  https://github.com/leftwm/leftwm/blob/5debd321132ce0b18c5c486319be3b662b291837/display-servers/xlib-display-server/src/lib.rs#L38-L39
  Split `load_colors()` into `load_config()` and `update_colors()`. `reload_config()` now first fully loads the new config and then updates the colors.

- 439f9a673f7b4770964f260a4e98db4e532ddfd3
  Rename `ThemeSettings` to `ThemeConfig` for consistency`
  
- bb993b48dd8e0bd77592818e422c407b2ea90fdd
  Rename `load_config` to `reload_config`, as the config struct is already given with the `new()` function. In both cases the config is relayed to Xwrap's `load_config()`.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
