### PR TITLE
add comments

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -478,6 +478,7 @@ fn swap_tags(state: &mut State) -> Option<bool> {
     None
 }
 
+// TODO: closing windows breaks focus, see gh-1204
 fn close_window(state: &mut State) -> Option<bool> {
     let window = state.focus_manager.window(&state.windows)?;
     if window.is_managed() {

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -33,31 +33,33 @@ impl FocusBehaviour {
     }
 }
 
+/// `FocusManager` stores the history of which workspaces, tags, and windows had focus.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FocusManager {
-    pub behaviour: FocusBehaviour,
-    pub focus_new_windows: bool,
     pub workspace_history: VecDeque<usize>,
     pub window_history: VecDeque<MaybeWindowHandle>,
     pub tag_history: VecDeque<TagId>,
     pub tags_last_window: HashMap<TagId, WindowHandle>,
+    pub last_mouse_position: Option<(i32, i32)>,
+    // entries below are configuration variables and are never changed
+    pub behaviour: FocusBehaviour,
+    pub focus_new_windows: bool,
     pub sloppy_mouse_follows_focus: bool,
     pub create_follows_cursor: bool,
-    pub last_mouse_position: Option<(i32, i32)>,
 }
 
 impl FocusManager {
     pub fn new(config: &impl Config) -> Self {
         Self {
-            behaviour: config.focus_behaviour(),
-            focus_new_windows: config.focus_new_windows(),
             workspace_history: Default::default(),
             window_history: Default::default(),
             tag_history: Default::default(),
             tags_last_window: Default::default(),
+            last_mouse_position: None,
+            behaviour: config.focus_behaviour(),
+            focus_new_windows: config.focus_new_windows(),
             sloppy_mouse_follows_focus: config.sloppy_mouse_follows_focus(),
             create_follows_cursor: config.create_follows_cursor(),
-            last_mouse_position: None,
         }
     }
 
@@ -114,6 +116,7 @@ impl FocusManager {
         None
     }
 
+    // seems like duplicate code
     pub fn create_follows_cursor(&self) -> bool {
         self.create_follows_cursor
     }


### PR DESCRIPTION
# Description

Add comments to some parts of codebase. Reordering some of the entries in certain structs to disambiguate which entries are static (never changed by program) and which are mutable (changed by program).

Add TODO for #1204

## Type of change

- [X] Development change (no change visible to user)
- [X] Documentation only update (no change to the factual codebase)

# Checklist:

- [X] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.