### PR TITLE
Add 'args' Scratchpad config entry

### DIFF
--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    child_process::{exec_shell, ChildID},
+    child_process::{exec_shell_with_args, ChildID},
     models::{ScratchPadName, TagId, WindowHandle},
     Command, Config, DisplayAction, DisplayServer, Manager, Window,
 };
@@ -253,7 +253,11 @@ pub fn toggle_scratchpad<C: Config, SERVER: DisplayServer>(
         name
     );
 
-    let pid: ChildID = exec_shell(&scratchpad.value, &mut manager.children)?;
+    let pid: ChildID = exec_shell_with_args(
+        &scratchpad.value,
+        scratchpad.args.unwrap_or_else(|| Vec::new()),
+        &mut manager.children,
+    )?;
 
     match manager.state.active_scratchpads.get_mut(name) {
         Some(windows) => {
@@ -613,6 +617,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: String::new(),
+            args: None,
             x: None,
             y: None,
             height: None,
@@ -787,6 +792,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: "scratchpad".to_string(),
+            args: None,
             x: None,
             y: None,
             height: None,
@@ -970,6 +976,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: "scratchpad".to_string(),
+            args: None,
             x: None,
             y: None,
             height: None,
@@ -1079,6 +1086,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: "scratchpad".to_string(),
+            args: None,
             x: None,
             y: None,
             height: None,
@@ -1189,6 +1197,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: "scratchpad".to_string(),
+            args: None,
             x: None,
             y: None,
             height: None,
@@ -1253,6 +1262,7 @@ mod tests {
         manager.state.scratchpads.push(ScratchPad {
             name: scratchpad_name.clone(),
             value: String::new(),
+            args: None,
             x: None,
             y: None,
             height: None,

--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -253,6 +253,7 @@ pub fn toggle_scratchpad<H: Handle, C: Config, SERVER: DisplayServer<H>>(
         "No active scratchpad found for name {:?}. Creating a new one",
         name
     );
+    tracing::debug!("Args for scratchpad: {:?}", &scratchpad.args);
 
     let pid: ChildID = exec_shell_with_args(
         &scratchpad.value,

--- a/leftwm-core/src/models/scratchpad.rs
+++ b/leftwm-core/src/models/scratchpad.rs
@@ -6,6 +6,7 @@ use super::{Xyhw, XyhwBuilder};
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ScratchPad {
     pub name: ScratchPadName,
+    pub args: Option<Vec<String>>,
     pub value: String,
     // relative x of scratchpad, 25 means 25% of workspace x
     pub x: Option<Size>,

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -1,6 +1,5 @@
 //! Starts programs in autostart, runs global 'up' script, and boots theme. Provides function to
 //! boot other desktop files also.
-use crate::errors::Result;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::collections::HashMap;
@@ -9,8 +8,11 @@ use std::fs;
 use std::iter::{Extend, FromIterator};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{Arc, atomic::AtomicBool};
+
 use xdg::BaseDirectories;
+
+use crate::errors::Result;
 
 pub type ChildID = u32;
 
@@ -166,7 +168,14 @@ pub fn register_child_hook(flag: Arc<AtomicBool>) {
 /// Sends command to shell for execution
 /// Assumes STDIN/STDERR/STDOUT unwanted.
 pub fn exec_shell(command: &str, children: &mut Children) -> Option<ChildID> {
+    exec_shell_with_args(command, Vec::new(), children)
+}
+
+/// Sends command to shell for execution including arguments.
+/// Assumes STDIN/STDERR/STDOUT unwanted.
+pub fn exec_shell_with_args(command: &str, args: Vec<String>, children: &mut Children) -> Option<ChildID> {
     let child = Command::new(command)
+        .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::iter::{Extend, FromIterator};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, atomic::AtomicBool};
+use std::sync::{atomic::AtomicBool, Arc};
 
 use xdg::BaseDirectories;
 
@@ -173,7 +173,11 @@ pub fn exec_shell(command: &str, children: &mut Children) -> Option<ChildID> {
 
 /// Sends command to shell for execution including arguments.
 /// Assumes STDIN/STDERR/STDOUT unwanted.
-pub fn exec_shell_with_args(command: &str, args: Vec<String>, children: &mut Children) -> Option<ChildID> {
+pub fn exec_shell_with_args(
+    command: &str,
+    args: Vec<String>,
+    children: &mut Children,
+) -> Option<ChildID> {
     let child = Command::new(command)
         .args(args)
         .stdin(Stdio::null())

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -317,6 +317,7 @@ workspaces: [
 ]
 \f[R]
 .fi
+
 .SS Tags
 .PP
 Tags are the names of the virtual desktops where windows live.
@@ -326,6 +327,27 @@ popular icon libraries such as font-awesome.
 .PP
 Default:
 \f[C]tags: [\[dq]1\[dq], \[dq]2\[dq], \[dq]3\[dq], \[dq]4\[dq], \[dq]5\[dq], \[dq]6\[dq], \[dq]7\[dq], \[dq]8\[dq], \[dq]9\[dq]]\f[R]
+
+.SS Scratchpads
+.PP 
+A scratchpad is a set of windows which you can call to any tag and hide it when not needed. These windows can be any set of application which can be run from a terminal. To call a scratchpad you will require a keybind for ToggleScratchPad. When you want to manipulate the currently focused scratchpad, other commands like ReleaseScratchPad, AttachScratchPad and NextScratchPadWindow/PrevScratchPadWindow are available.
+.PP 
+Example:
+.IP
+.nf
+\f[C]
+scratchpad: [
+    ( name: "Alacritty", // This is the name which is referenced when calling (case-sensitive)
+      value: "alacritty", // The command to load the application if it isn't started (first application to start)
+      args: ["-e", "python"], // Any arguments to pass to the command
+      // x, y, width, height are in pixels when an integer is inputted or a percentage when a float is inputted.
+      // These values are relative to the size of the workspace, and will be restricted depending on the workspace size.
+      x: 860, y: 390, height: 300, width: 200 
+    ),
+]
+\f[R]
+.fi
+
 
 
 .SH WIKI

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -204,6 +204,7 @@ impl Default for Config {
         let scratchpad = ScratchPad {
             name: "Alacritty".into(),
             value: "alacritty".to_string(),
+            args: None,
             x: Some(Size::Pixel(860)),
             y: Some(Size::Pixel(390)),
             height: Some(Size::Pixel(300)),


### PR DESCRIPTION
# Description

This adds a new optional field for scratchpads that allows their child process to be called with arguments.

Fixes #1223
History of the art: #1216, #958.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Updated user documentation:

> # Scratchpads
> 
> A scratchpad is a set of windows which you can call to any tag and hide it when not needed. These windows can be any set of application which can be run from a terminal. To call a scratchpad you will require a keybind for [ToggleScratchPad](#togglescratchpad). When you want to manipulate the currently focused scratchpad, other commands like [ReleaseScratchPad](#releasescratchpad), [AttachScratchPad](#attachscratchpad) and [NextScratchPadWindow/PrevScratchPadWindow](#nextscratchpadwindowprevscratchpadwindow) are available.
> 
> Example:
> 
> ```rust
> scratchpad: [
>     ( name: "Alacritty", // This is the name which is referenced when calling (case-sensitive)
>       value: "alacritty", // The command to load the application if it isn't started (first application to start)
>       args: ["-e", "python"], // Any arguments to pass to the command
>       // x, y, width, height are in pixels when an integer is inputted or a percentage when a float is inputted.
>       // These values are relative to the size of the workspace, and will be restricted depending on the workspace size.
>       x: 860, y: 390, height: 300, width: 200 
>     ),
> ]
> ```
> 
> **Note: The scratchpad and `ToggleScratchPad` are only available in LeftWM >=0.2.8, the other scratchpad manipulating commands in LeftWM > 0.2.11**, and `args` in >0.5.1.

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
