### PR TITLE
Fix build without lefthk

### DIFF
--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -1,25 +1,28 @@
-#![cfg(feature = "lefthk")]
-
+#[cfg(feature = "lefthk")]
 use lefthk_core::{config::Config, worker::Worker};
+#[cfg(feature = "lefthk")]
 use xdg::BaseDirectories;
 
 fn main() {
-    leftwm::utils::log::setup_logging();
+    #[cfg(feature = "lefthk")]
+    {
+        leftwm::utils::log::setup_logging();
 
-    tracing::info!("lefthk-worker booted!");
+        tracing::info!("lefthk-worker booted!");
 
-    let exit_status = std::panic::catch_unwind(|| {
-        let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
-        let _rt_guard = rt.enter();
-        let config = leftwm::load();
-        let path = BaseDirectories::with_prefix("leftwm-lefthk")
-            .expect("ERROR: could not find base directory");
+        let exit_status = std::panic::catch_unwind(|| {
+            let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
+            let _rt_guard = rt.enter();
+            let config = leftwm::load();
+            let path = BaseDirectories::with_prefix("leftwm-lefthk")
+                .expect("ERROR: could not find base directory");
 
-        rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
-    });
+            rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
+        });
 
-    match exit_status {
-        Ok(()) => tracing::info!("Completed"),
-        Err(err) => tracing::error!("Completed with error: {:?}", err),
+        match exit_status {
+            Ok(()) => tracing::info!("Completed"),
+            Err(err) => tracing::error!("Completed with error: {:?}", err),
+        }
     }
 }

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -7,14 +7,15 @@ use anyhow::{ensure, Context, Result};
 #[cfg(feature = "lefthk")]
 use lefthk_core::config::Command;
 #[cfg(feature = "lefthk")]
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "lefthk")]
 use std::fmt::Write;
 #[cfg(feature = "lefthk")]
 use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+// Modifier (built even without lefthk) needs this
+use serde::{Deserialize, Serialize};
+
 #[cfg(feature = "lefthk")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Keybind {
     pub command: BaseCommand,
     #[serde(default)]


### PR DESCRIPTION
# Description

Fix builds without lefthk feature.

revert eaa13b3 and partially revert f78ed16 with minor edit.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
