### PR TITLE
Simplify setting the fourth byte of a pixel to 0xff

### DIFF
--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -151,20 +151,16 @@ impl XWrap {
     // `XSetWindowBorder`: https://tronche.com/gui/x/xlib/window/XSetWindowBorder.html
     pub fn set_window_border_color(&self, window: xlib::Window, mut color: c_ulong) {
         unsafe {
-            // Force border opacity to 0xff.
-            let mut bytes = color.to_le_bytes();
-            bytes[3] = 0xff;
-            color = c_ulong::from_le_bytes(bytes);
+            // Force border opacity to 0xff. (color is <aarrggbb> in hex format)
+            color |= 0xff000000;
             (self.xlib.XSetWindowBorder)(self.display, window, color);
         }
     }
 
     pub fn set_background_color(&self, mut color: c_ulong) {
         unsafe {
-            // Force border opacity to 0xff.
-            let mut bytes = color.to_le_bytes();
-            bytes[3] = 0xff;
-            color = c_ulong::from_le_bytes(bytes);
+            // Force border opacity to 0xff. (color is <aarrggbb> in hex format)
+            color |= 0xff000000;
             (self.xlib.XSetWindowBackground)(self.display, self.root, color);
             (self.xlib.XClearWindow)(self.display, self.root);
             (self.xlib.XFlush)(self.display);


### PR DESCRIPTION
# Description

Replace the complicated solution for setting the fourth byte by a simple OR operation.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.