### PR TITLE
Revert "Fix build without lefthk"

### DIFF
--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 repository = "https://github.com/leftwm/leftwm"
 description = "A window manager for Adventurers"
 
+[[bin]]
+name = "lefthk-worker"
+required-features = ["lefthk"]
+
 [dependencies]
 anyhow = "1.0.48"
 clap = { version = "4.0.0", features = ["cargo"] }

--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -1,28 +1,25 @@
-#[cfg(feature = "lefthk")]
+#![cfg(feature = "lefthk")]
+
 use lefthk_core::{config::Config, worker::Worker};
-#[cfg(feature = "lefthk")]
 use xdg::BaseDirectories;
 
 fn main() {
-    #[cfg(feature = "lefthk")]
-    {
-        leftwm::utils::log::setup_logging();
+    leftwm::utils::log::setup_logging();
 
-        tracing::info!("lefthk-worker booted!");
+    tracing::info!("lefthk-worker booted!");
 
-        let exit_status = std::panic::catch_unwind(|| {
-            let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
-            let _rt_guard = rt.enter();
-            let config = leftwm::load();
-            let path = BaseDirectories::with_prefix("leftwm-lefthk")
-                .expect("ERROR: could not find base directory");
+    let exit_status = std::panic::catch_unwind(|| {
+        let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
+        let _rt_guard = rt.enter();
+        let config = leftwm::load();
+        let path = BaseDirectories::with_prefix("leftwm-lefthk")
+            .expect("ERROR: could not find base directory");
 
-            rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
-        });
+        rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
+    });
 
-        match exit_status {
-            Ok(()) => tracing::info!("Completed"),
-            Err(err) => tracing::error!("Completed with error: {:?}", err),
-        }
+    match exit_status {
+        Ok(()) => tracing::info!("Completed"),
+        Err(err) => tracing::error!("Completed with error: {:?}", err),
     }
 }

--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "lefthk")]
-
 use lefthk_core::{config::Config, worker::Worker};
 use xdg::BaseDirectories;
 

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[cfg(feature = "lefthk")]
 use super::BaseCommand;
 #[cfg(feature = "lefthk")]
@@ -6,8 +8,6 @@ use crate::Config;
 use anyhow::{ensure, Context, Result};
 #[cfg(feature = "lefthk")]
 use lefthk_core::config::Command;
-#[cfg(feature = "lefthk")]
-use serde::{Deserialize, Serialize};
 #[cfg(feature = "lefthk")]
 use std::fmt::Write;
 #[cfg(feature = "lefthk")]

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -7,15 +7,14 @@ use anyhow::{ensure, Context, Result};
 #[cfg(feature = "lefthk")]
 use lefthk_core::config::Command;
 #[cfg(feature = "lefthk")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "lefthk")]
 use std::fmt::Write;
 #[cfg(feature = "lefthk")]
 use std::str::FromStr;
 
-// Modifier (built even without lefthk) needs this
-use serde::{Deserialize, Serialize};
-
-#[cfg(feature = "lefthk")]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg(feature = "lefthk")]
 pub struct Keybind {
     pub command: BaseCommand,
     #[serde(default)]


### PR DESCRIPTION
Reverts leftwm/leftwm#1228

# Description

Uses @Eskaan's approach which prevents lefthk-worker from being built in the first place to resolve #1228.

## Type of change

- [X] Development change (no change visible to user)
- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Delete branch once merged
