### PR TITLE
`cargo doc` error fixes, CI workflow, and `CONTRIBUTING.md` update.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     name: Run build
     uses: ./.github/workflows/run-build.yml
 
+  docs:
+    name: Generate Crate Docs
+    uses: ./.github/workflows/docs.yml
+
   msrv:
     name: Check MSRV
     strategy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Generate Crate Docs
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Generate Crate Docs
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: apt update
+        run: sudo apt update
+
+      - name: apt install libsystemd-dev
+        run: sudo apt install -y --no-install-recommends libsystemd-dev
+
+      - name: Generate Crate Docs
+        uses: actions-rs/cargo@v1
+        with:
+            command: doc
+            args: --all-features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,9 @@ Table of Contents:
 3. [Patches / Pull Requests](#patches--pull-requests)
     1. [Testing](#testing)
     2. [Performance](#performance)
-    3. [Documentation](#documentation)
+    3. [Code Documentation](#code-documentation)
     4. [Style](#style)
+    5. [User Documentation](#user-documentation)
 
 ## Feature Requests
 
@@ -38,7 +39,9 @@ cargo test --all-targets --all-features
 ```
 These tests are run by CI, but it is always easier to check before pushing.
 
-### Documentation
+### Code Documentation
+
+Code documentation is generated with `cargo doc --all-features`.
 
 The existing code can be used as a guidance here and the general rustfmt rules can be followed for formatting, which can be run with:
 ```

--- a/leftwm/src/command.rs
+++ b/leftwm/src/command.rs
@@ -18,15 +18,15 @@ pub enum BaseCommand {
     SwapTags,
     SoftReload,
     HardReload,
-    /// Args: <ScratchpadName>
+    /// Args: `ScratchpadName`
     AttachScratchPad,
-    /// Args: <tag_index> or <ScratchpadName>
+    /// Args: `tag_index` or `ScratchpadName`
     ReleaseScratchPad,
-    /// Args: <ScratchpadName>
+    /// Args: `ScratchpadName`
     NextScratchPadWindow,
-    /// Args: <ScratchpadName>
+    /// Args: `ScratchpadName`
     PrevScratchPadWindow,
-    /// Args: <ScratchpadName>
+    /// Args: `ScratchpadName`
     ToggleScratchPad,
     ToggleFullScreen,
     ToggleMaximized,
@@ -41,18 +41,18 @@ pub enum BaseCommand {
     MoveWindowDown,
     MoveWindowTop,
     SwapWindowTop,
-    /// Args: <behavior> (string, optional)
+    /// Args: `behavior` (string, optional)
     FocusNextTag,
-    /// Args: <behavior> (string, optional)
+    /// Args: `behavior` (string, optional)
     FocusPreviousTag,
-    /// Args: <WindowClass> or <visible-window-index> (int)
+    /// Args: `WindowClass` or `visible-window-index` (int)
     FocusWindow,
     FocusWindowUp,
     FocusWindowDown,
     FocusWindowTop,
     FocusWorkspaceNext,
     FocusWorkspacePrevious,
-    /// Args: <tag_index> (int)
+    /// Args: `tag_index` (int)
     /// Note: Please use `SendWindowToTag` instead.
     MoveToTag,
     MoveWindowToNextTag,
@@ -62,7 +62,7 @@ pub enum BaseCommand {
     MoveWindowToPreviousWorkspace,
     NextLayout,
     PreviousLayout,
-    /// Args: <LayoutName>
+    /// Args: `LayoutName`
     SetLayout,
     RotateTag,
     /// Note: This is deprecated and will be dropped in a future release.
@@ -73,10 +73,10 @@ pub enum BaseCommand {
     DecreaseMainSize,
     IncreaseMainCount,
     DecreaseMainCount,
-    /// Args: <multiplier-value> (float)
+    /// Args: `multiplier-value` (float)
     SetMarginMultiplier,
     UnloadTheme,
-    /// Args: <Path_to/theme.ron>
+    /// Args: `Path_to/theme.ron`
     /// Note: `theme.toml` will be deprecated but stays for backwards compatibility for a while
     LoadTheme,
 }


### PR DESCRIPTION
# Description

I noticed that `cargo doc` failed due to a simple markup problem, so I fixed the markup. Then, I also attempted to add a CI workflow to generate crate docs (I cannot test this), and updated `CONTRIBUTING.md` to encourage other developers to render and view crate docs.

The errors are all the same cause at different locations, as exemplified here:

```
error: unclosed HTML tag `ScratchpadName`
  --> leftwm/src/command.rs:21:15
   |
21 |     /// Args: <ScratchpadName>
   |               ^^^^^^^^^^^^^^^^
   |
   = note: `-D rustdoc::invalid-html-tags` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(rustdoc::invalid_html_tags)]`
```

I replaced angle brackets in all those cases with backticks:

```
`ScratchpadName`
```

-which is standard md markup to style as a code identifier: `ScratchpadName`. This seems correct and clear in the rendered docs.

Fixes: I did not search for issues to know if there is one complaining about `cargo doc` failing.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

Note: In this section, I'm a little confused how to categorize code docs. Is that a "Documentation only" change? Or does that imply User Documentation Only?

## Updated user documentation:

No change needed for user-facing documentation.

# Checklist:

- [❌] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.

I see the follow failure with `make test` which does not seem related to this PR in any way:

```
cd /home/user/src/github.com/leftwm/leftwm && cargo clippy -- -D warnings -W clippy::pedantic
   Compiling leftwm v0.5.1 (/home/user/src/github.com/leftwm/leftwm/leftwm)
   Compiling leftwm-macros v0.5.0 (/home/user/src/github.com/leftwm/leftwm/leftwm-macros)
    Checking leftwm-core v0.5.0 (/home/user/src/github.com/leftwm/leftwm/leftwm-core)
    Checking leftwm-watchdog v0.5.1 (/home/user/src/github.com/leftwm/leftwm/leftwm-watchdog)
    Checking xlib-display-server v0.1.2 (/home/user/src/github.com/leftwm/leftwm/display-servers/xlib-display-server)
error: long literal lacking separators
   --> display-servers/xlib-display-server/src/xwrap/setters.rs:155:22
    |
155 |             color |= 0xff000000;
    |                      ^^^^^^^^^^ help: consider: `0xff00_0000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal
    = note: `-D clippy::unreadable-literal` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unreadable_literal)]`

error: long literal lacking separators
   --> display-servers/xlib-display-server/src/xwrap/setters.rs:163:22
    |
163 |             color |= 0xff000000;
    |                      ^^^^^^^^^^ help: consider: `0xff00_0000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

error: could not compile `xlib-display-server` (lib) due to 2 previous errors
make: *** [Makefile:28: test] Error 101
```

- [ ] (Not relevant) Manual page has been updated accordingly
- [ ] (Not relevant) Wiki pages have been updated accordingly (to perform **after** merge)
