### PR TITLE
X11rb: Invert input hint

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -77,7 +77,7 @@ impl XWrap {
         w.requested = Some(requested);
         w.can_resize = can_resize;
         if let Some(hint) = wm_hint {
-            w.never_focus = hint.input.unwrap_or(false);
+            w.never_focus = !hint.input.unwrap_or(true);
             w.urgent = hint.urgent;
         }
         // Is this needed? Made it so it doens't overwrite prior sizing.


### PR DESCRIPTION
# Description

The X11 input hint wasn't correctly interpreted, causing dialogs and similar to not get input focus upon spawning (`never_focus` is set until un-focusing and focusing again, causing the window to get updated).

Fixes https://github.com/leftwm/leftwm/pull/1221#discussion_r1513520014 (see for more info on the bug)

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
