### PR TITLE
X11rb: Fix sys-log by dropping boot-logger earlier

### DIFF
--- a/leftwm/src/bin/leftwm-worker.rs
+++ b/leftwm/src/bin/leftwm-worker.rs
@@ -36,11 +36,12 @@ fn main() {
     #[cfg(not(feature = "lefthk"))]
     let config = leftwm::load();
 
+    // Drop init log config as the config files have been read and the global default can be loaded.
+    // Has to be before global init due to sys-log only allowing one logger at a time.
+    drop(log_guard);
     let (subscribers, log_parse_err) = utils::log::parse_log_level(&config.log_level);
     tracing::subscriber::set_global_default(subscribers)
         .expect("Couldn't setup global subscriber (logger)");
-    // Drop init log config as the config files have been read and applied to the global default.
-    drop(log_guard);
     if let Some(err) = log_parse_err {
         tracing::warn!("Error parsing log_level config: {err}");
     }


### PR DESCRIPTION
# Description

See title, for details see https://github.com/leftwm/leftwm/issues/1245#issuecomment-2040237340

(probably, can't reproduce) fixes #1245 

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
