### PR TITLE
chore: remove obsolete `max_window_width` variable 

### DIFF
--- a/examples/config-with-comments.ron
+++ b/examples/config-with-comments.ron
@@ -24,7 +24,6 @@
         "8",
         "9",
     ],
-    max_window_width: None,
     layouts: [
         "EvenHorizontal",
         "EvenVertical",

--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::models::Size;
-
 #[derive(Serialize, Default, Deserialize, Debug, Clone, PartialEq)]
 pub struct Workspace {
     pub x: i32,

--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -10,6 +10,5 @@ pub struct Workspace {
     pub width: i32,
     pub output: String,
     pub relative: Option<bool>,
-    pub max_window_width: Option<Size>,
     pub layouts: Option<Vec<String>>,
 }

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -1,4 +1,4 @@
-use super::{window::Handle, DockArea, Size, WindowHandle, WorkspaceId};
+use super::{window::Handle, DockArea, WindowHandle, WorkspaceId};
 use crate::config::Workspace;
 use serde::{Deserialize, Serialize};
 use std::convert::From;

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -10,7 +10,6 @@ pub struct Screen<H: Handle> {
     pub output: String,
     pub id: Option<WorkspaceId>,
     pub bbox: BBox,
-    pub max_window_width: Option<Size>,
 }
 
 /// Screen Bounding Box
@@ -29,7 +28,6 @@ impl<H: Handle> Screen<H> {
             root: WindowHandle::<H>(H::default()),
             output,
             bbox,
-            max_window_width: None,
             id: None,
         }
     }
@@ -80,7 +78,6 @@ impl<H: Handle> From<&Workspace> for Screen<H> {
                 y: wsc.y,
             },
             output: wsc.output.clone(),
-            max_window_width: wsc.max_window_width,
             ..Default::default()
         }
     }
@@ -98,7 +95,6 @@ impl<H: Handle> Default for Screen<H> {
                 x: 0,
                 y: 0,
             },
-            max_window_width: None,
         }
     }
 }

--- a/leftwm-core/src/models/workspace.rs
+++ b/leftwm-core/src/models/workspace.rs
@@ -122,8 +122,7 @@ impl Workspace {
         self.is_displaying(window) && window.is_managed()
     }
 
-    /// Returns the original x position of the workspace,
-    /// disregarding the optional `max_window_width` configuration
+    /// Returns the original x position of the workspace
     #[must_use]
     pub fn x(&self) -> i32 {
         let left = self.margin.left as f32;
@@ -147,8 +146,7 @@ impl Workspace {
         self.xyhw_avoided.h() - (self.margin_multiplier * (top + bottom)) as i32 - gutter
     }
 
-    /// Returns the original width for the workspace,
-    /// disregarding the optional `max_window_width` configuration
+    /// Returns the original width for the workspace
     #[must_use]
     pub fn width(&self) -> i32 {
         let left = self.margin.left as f32;

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -202,7 +202,6 @@ pub struct Config {
     pub mousekey: Option<Modifier>,
     pub workspaces: Option<Vec<Workspace>>,
     pub tags: Option<Vec<String>>,
-    pub max_window_width: Option<Size>,
     pub layouts: Vec<String>,
     pub layout_definitions: Vec<Layout>,
     pub layout_mode: LayoutMode,

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 use leftwm_core::{
     config::{InsertBehavior, ScratchPad, Workspace},
     layouts::LayoutMode,
-    models::{FocusBehaviour, Gutter, Handle, Margins, Size, Window, WindowState, WindowType},
+    models::{FocusBehaviour, Gutter, Handle, Margins, Window, WindowState, WindowType},
     state::State,
     DisplayAction, DisplayServer, Manager, ReturnPipe,
 };

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -240,7 +240,6 @@ impl Default for Config {
             #[cfg(feature = "lefthk")]
             keybind: commands,
             theme_setting: ThemeConfig::default(),
-            max_window_width: None,
             state_path: None,
             sloppy_mouse_follows_focus: true,
             create_follows_cursor: None,


### PR DESCRIPTION
# Description

Fixes #1259 

This PR removes all references to the obsolete `max_window_width` variable from the codebase.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update


# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
