### PR TITLE
Add distinction between visible and busy workspace

### DIFF
--- a/leftwm-core/src/models/dto.rs
+++ b/leftwm-core/src/models/dto.rs
@@ -1,5 +1,5 @@
-use crate::state::State;
 use crate::models::TagId;
+use crate::state::State;
 use serde::{Deserialize, Serialize};
 
 use super::Handle;
@@ -135,7 +135,12 @@ impl<H: Handle> From<&State<H>> for ManagerState {
             .tags
             .all()
             .iter()
-            .filter(|tag| state.windows.iter().any(|w| w.has_tag(&tag.id) && w.is_managed()))
+            .filter(|tag| {
+                state
+                    .windows
+                    .iter()
+                    .any(|w| w.has_tag(&tag.id) && w.is_managed())
+            })
             .map(|t| t.id)
             .collect();
 


### PR DESCRIPTION
# Description

This patch updates the behavior of the ```busy``` attribute. Previously, it would be set to ```true``` even if there were no windows in a workspace. With this patch, a workspace tag is considered ```busy``` only if the tag is both visible in that workspace and at least one window (excluding dock and desktop windows) has that tag.

Closes #787 

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)   