### PR TITLE
Fix hiding window behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The currently supported MSRV is 1.74.0
+- Added `window_hiding_strategy` config option (via #1274 by @Syudagye)
 
 ### Fixed
+
+- Hidden window are not able to be captured (fixes #1100 via #1274 by @Syudagye)
+- Numlock prevents moving and resizing for floating windows (via #1276 by @Syudagye)
 
 ## [0.5.0]
 

--- a/display-servers/x11rb-display-server/src/xwrap.rs
+++ b/display-servers/x11rb-display-server/src/xwrap.rs
@@ -1,6 +1,7 @@
 use std::{io::IoSlice, os::fd::AsRawFd, sync::Arc, time::Duration};
 
 use leftwm_core::{
+    config::WindowHidingStrategy,
     models::{FocusBehaviour, WindowHandle},
     utils::{self, modmask_lookup::ModMask},
     Config, Mode, Window,
@@ -74,6 +75,7 @@ pub(crate) struct XWrap {
     pub focus_behaviour: FocusBehaviour,
     pub mouse_key_mask: ModMask,
     pub mode_origin: (i32, i32),
+    pub window_hiding_strategy: WindowHidingStrategy,
 
     #[allow(unused)]
     task_guard: oneshot::Receiver<()>,
@@ -164,6 +166,7 @@ impl XWrap {
             focus_behaviour: FocusBehaviour::Sloppy,
             mouse_key_mask: ModMask::Zero,
             mode_origin: (0, 0),
+            window_hiding_strategy: Default::default(),
 
             task_guard,
             task_notify,
@@ -194,6 +197,7 @@ impl XWrap {
             active: self.get_color(&config.focused_border_color())?,
             background: self.get_color(&config.background_color())?,
         };
+        self.window_hiding_strategy = config.window_hiding_strategy();
         Ok(())
     }
 

--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -209,12 +209,12 @@ impl XWrap {
         Ok(())
     }
 
-    /// "hides" a window my moving it out of view.
+    /// "hides" a window by moving it out of view.
     /// see https://github.com/leftwm/leftwm/issues/1100
     pub fn toggle_window_visibility(&self, window: xproto::Window, visible: bool) -> Result<()> {
         if visible {
             // NOTE: The window does not need to be moved here, if it's beeing made visible it's
-            // going to be naturally tiled of placed floating where it should
+            // going to be naturally tiled or placed floating where it should
 
             // Set WM_STATE to normal state.
             self.set_wm_state(window, WMStateWindowState::Normal)?;

--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -210,8 +210,11 @@ impl XWrap {
         Ok(())
     }
 
-    /// "hides" a window by moving it out of view.
-    /// see https://github.com/leftwm/leftwm/issues/1100
+    /// Show or hide a window, depending on its current visibility.
+    /// Depending on the configured window_hiding_strategy, this will toggle window visibility by moving
+    /// the window out of / in to view, or map / unmap it in the display server.
+    ///
+    /// see `<https://github.com/leftwm/leftwm/issues/1100>` and `<https://github.com/leftwm/leftwm/pull/1274>` for details
     pub fn toggle_window_visibility(&self, window: xproto::Window, visible: bool) -> Result<()> {
         let maybe_change_mask = |mask| -> Result<()> {
             if let WindowHidingStrategy::Unmap = self.window_hiding_strategy {

--- a/display-servers/xlib-display-server/src/xwrap.rs
+++ b/display-servers/xlib-display-server/src/xwrap.rs
@@ -11,7 +11,7 @@ use crate::XlibWindowHandle;
 use super::xatom::XAtom;
 use super::xcursor::XCursor;
 use super::{utils, Screen, Window, WindowHandle};
-use leftwm_core::config::Config;
+use leftwm_core::config::{Config, WindowHidingStrategy};
 use leftwm_core::models::{FocusBehaviour, Mode};
 use leftwm_core::utils::modmask_lookup::ModMask;
 use std::ffi::CString;
@@ -120,6 +120,7 @@ pub struct XWrap {
     pub task_notify: Arc<Notify>,
     pub motion_event_limiter: c_ulong,
     pub refresh_rate: c_short,
+    pub window_hiding_strategy: WindowHidingStrategy,
 }
 
 impl Default for XWrap {
@@ -241,6 +242,7 @@ impl XWrap {
             task_notify,
             motion_event_limiter: 0,
             refresh_rate,
+            window_hiding_strategy: Default::default(),
         };
 
         // Check that another WM is not running.
@@ -272,6 +274,7 @@ impl XWrap {
             active: self.get_color(config.focused_border_color()),
             background: self.get_color(config.background_color()),
         };
+        self.window_hiding_strategy = config.window_hiding_strategy();
     }
 
     /// Initialize the xwrapper.

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -210,8 +210,11 @@ impl XWrap {
         }
     }
 
-    /// "hides" a window by moving it out of view.
-    /// see https://github.com/leftwm/leftwm/issues/1100
+    /// Show or hide a window, depending on its current visibility.
+    /// Depending on the configured window_hiding_strategy, this will toggle window visibility by moving
+    /// the window out of / in to view, or map / unmap it in the display server.
+    ///
+    /// see `<https://github.com/leftwm/leftwm/issues/1100>` and `<https://github.com/leftwm/leftwm/pull/1274>` for details
     pub fn toggle_window_visibility(&self, window: xlib::Window, visible: bool) {
         let maybe_change_mask = |mask| {
             if let WindowHidingStrategy::Unmap = self.window_hiding_strategy {

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -232,6 +232,13 @@ impl XWrap {
                 return;
             };
             let screen_dimentions = self.get_screens_area_dimensions();
+            let x = window_geometry.w.unwrap_or(screen_dimentions.0) * -2;
+            let y = window_geometry.h.unwrap_or(screen_dimentions.1) * -2;
+
+            let mut window_changes: xlib::XWindowChanges = unsafe { std::mem::zeroed() };
+            window_changes.x = x;
+            window_changes.y = y;
+            self.set_window_config(window, window_changes, u32::from(xlib::CWX | xlib::CWY));
             self.move_resize_window(
                 window,
                 window_geometry.w.unwrap_or(screen_dimentions.0) * -2,

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -209,12 +209,12 @@ impl XWrap {
         }
     }
 
-    /// "hides" a window my moving it out of view.
+    /// "hides" a window by moving it out of view.
     /// see https://github.com/leftwm/leftwm/issues/1100
     pub fn toggle_window_visibility(&self, window: xlib::Window, visible: bool) {
         if visible {
             // NOTE: The window does not need to be moved here, if it's beeing made visible it's
-            // going to be naturally tiled of placed floating where it should
+            // going to be naturally tiled or placed floating where it should
 
             // Set WM_STATE to normal state.
             self.set_wm_states(window, &[NORMAL_STATE]);

--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -1,4 +1,5 @@
 mod insert_behavior;
+mod window_hiding_strategy;
 mod workspace_config;
 
 use crate::display_servers::DisplayServer;
@@ -9,6 +10,7 @@ use crate::models::{Handle, Manager, Window, WindowType};
 use crate::state::State;
 pub use insert_behavior::InsertBehavior;
 use leftwm_layouts::Layout;
+pub use window_hiding_strategy::WindowHidingStrategy;
 pub use workspace_config::Workspace;
 
 pub trait Config {
@@ -61,6 +63,7 @@ pub trait Config {
     fn sloppy_mouse_follows_focus(&self) -> bool;
     fn create_follows_cursor(&self) -> bool;
     fn reposition_cursor_on_resize(&self) -> bool;
+    fn window_hiding_strategy(&self) -> WindowHidingStrategy;
 
     /// Attempt to write current state to a file.
     ///
@@ -240,6 +243,10 @@ pub(crate) mod tests {
 
         fn create_follows_cursor(&self) -> bool {
             false
+        }
+
+        fn window_hiding_strategy(&self) -> WindowHidingStrategy {
+            Default::default()
         }
     }
 

--- a/leftwm-core/src/config/window_hiding_strategy.rs
+++ b/leftwm-core/src/config/window_hiding_strategy.rs
@@ -6,9 +6,9 @@ pub enum WindowHidingStrategy {
     /// The common behaviour for a window manager, but it prevents hidden windows from being
     /// captured by other applications
     Unmap,
-    /// Move the windows out of the visible area, so it can still be baptured by some applications.
+    /// Move the windows out of the visible area, so it can still be captured by some applications.
     /// We still inform the window that it is in a "minimized"-like state, so it can probably
-    /// decide to not render it's content as if it was focused.
+    /// decide to not render its content as if it was focused.
     MoveMinimize,
     /// Move the windows out of the visible area and don't minilize them.
     /// This should allow all applications to be captured by any other applications.

--- a/leftwm-core/src/config/window_hiding_strategy.rs
+++ b/leftwm-core/src/config/window_hiding_strategy.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+/// The stategy used to hide windows when switching tags in the backend
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum WindowHidingStrategy {
+    /// The common behaviour for a window manager, but it prevents hidden windows from being
+    /// captured by other applications
+    Unmap,
+    /// Move the windows out of the visible area, so it can still be baptured by some applications.
+    /// We still inform the window that it is in a "minimized"-like state, so it can probably
+    /// decide to not render it's content as if it was focused.
+    MoveMinimize,
+    /// Move the windows out of the visible area and don't minilize them.
+    /// This should allow all applications to be captured by any other applications.
+    /// This could result in higher resource usage, since windows will render their content like
+    /// normal even if hidden.
+    #[default]
+    MoveOnly,
+}

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -13,7 +13,7 @@ use super::ThemeConfig;
 use crate::config::keybind::Keybind;
 use anyhow::Result;
 use leftwm_core::{
-    config::{InsertBehavior, ScratchPad, Workspace},
+    config::{InsertBehavior, ScratchPad, WindowHidingStrategy, Workspace},
     layouts::LayoutMode,
     models::{FocusBehaviour, Gutter, Handle, Margins, Window, WindowState, WindowType},
     state::State,
@@ -219,6 +219,7 @@ pub struct Config {
     pub create_follows_cursor: Option<bool>,
     pub auto_derive_workspaces: bool,
     pub disable_cursor_reposition_on_resize: bool,
+    pub window_hiding_strategy: WindowHidingStrategy,
     #[cfg(feature = "lefthk")]
     pub keybind: Vec<Keybind>,
     pub state_path: Option<PathBuf>,
@@ -691,6 +692,10 @@ impl leftwm_core::Config for Config {
         // If not, set it to true in Sloppy mode only.
         self.create_follows_cursor
             .unwrap_or(self.focus_behaviour == FocusBehaviour::Sloppy)
+    }
+
+    fn window_hiding_strategy(&self) -> WindowHidingStrategy {
+        self.window_hiding_strategy
     }
 }
 

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -235,6 +235,7 @@ impl Default for Config {
             focus_new_windows: true, // default behaviour: focuses windows on creation
             single_window_border: true,
             insert_behavior: leftwm_core::config::InsertBehavior::Bottom,
+            window_hiding_strategy: Default::default(),
             modkey: "Mod4".to_owned(),     // win key
             mousekey: Some("Mod4".into()), // win key
             #[cfg(feature = "lefthk")]


### PR DESCRIPTION
# Description

Fixes #1100 by moving the window out of the screen rather than using `Map`/`Unmap` requests, which causes the window to appear black when captured when hidden

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
<sub>(clippy seems mad at some previous change....)</sub>