### PR TITLE
x11rb: Fixed numlock preventing from moving and resizing floating windows

### DIFF
--- a/display-servers/x11rb-display-server/src/event_translate.rs
+++ b/display-servers/x11rb-display-server/src/event_translate.rs
@@ -200,8 +200,9 @@ fn from_button_press(
     _xw: &mut XWrap,
 ) -> DisplayEvent<X11rbWindowHandle> {
     let h = WindowHandle(X11rbWindowHandle(event.event));
-    let mod_mask = event.state;
-    mod_mask.remove(xproto::KeyButMask::MOD2 | xproto::KeyButMask::LOCK);
+    let mod_mask = event
+        .state
+        .remove(xproto::KeyButMask::MOD2 | xproto::KeyButMask::LOCK);
     DisplayEvent::MouseCombo(
         ModMask::from_bits_retain(mod_mask.bits()),
         Button::from(event.detail),


### PR DESCRIPTION
# Description

This is fixing windows not being able to be moved and resized when the numlock is active under x11rb backend.
<sub>Just a very dum bug when you look at the code...</sub>

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
