### PR TITLE
Lazily call randr on windows hiding

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -255,10 +255,18 @@ impl XWrap {
                 WindowHidingStrategy::MoveMinimize | WindowHidingStrategy::MoveOnly => {
                     // Move the window out of view, so it can still be captured if necessary
                     let window_geometry = self.get_window_geometry(window)?;
-                    let screen_dimentions = self.get_screens_area_dimensions()?;
+                    let (x, y) = if window_geometry.w.is_some() && window_geometry.h.is_some() {
+                        (window_geometry.w.unwrap(), window_geometry.h.unwrap())
+                    } else {
+                        let screen_dimensions = self.get_screens_area_dimensions()?;
+                        (
+                            window_geometry.w.unwrap_or(screen_dimensions.0),
+                            window_geometry.h.unwrap_or(screen_dimensions.1),
+                        )
+                    };
                     let attrs = xproto::ConfigureWindowAux {
-                        x: Some(window_geometry.w.unwrap_or(screen_dimentions.0) * -2),
-                        y: Some(window_geometry.h.unwrap_or(screen_dimentions.1) * -2),
+                        x: Some(x * -2),
+                        y: Some(y * -2),
                         ..Default::default()
                     };
                     xproto::configure_window(&self.conn, window, &attrs)?;

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -254,9 +254,18 @@ impl XWrap {
                         tracing::error!("Error querying window geometry for window {}", window);
                         return;
                     };
-                    let screen_dimentions = self.get_screens_area_dimensions();
-                    let x = window_geometry.w.unwrap_or(screen_dimentions.0) * -2;
-                    let y = window_geometry.h.unwrap_or(screen_dimentions.1) * -2;
+                    let (x, y) = if window_geometry.w.is_some() && window_geometry.h.is_some() {
+                        (
+                            window_geometry.w.unwrap() * -2,
+                            window_geometry.h.unwrap() * -2,
+                        )
+                    } else {
+                        let screen_dimensions = self.get_screens_area_dimensions();
+                        (
+                            window_geometry.w.unwrap_or(screen_dimensions.0) * -2,
+                            window_geometry.h.unwrap_or(screen_dimensions.1) * -2,
+                        )
+                    };
 
                     let mut window_changes: xlib::XWindowChanges = unsafe { std::mem::zeroed() };
                     window_changes.x = x;
@@ -266,13 +275,7 @@ impl XWrap {
                         window_changes,
                         u32::from(xlib::CWX | xlib::CWY),
                     );
-                    self.move_resize_window(
-                        window,
-                        window_geometry.w.unwrap_or(screen_dimentions.0) * -2,
-                        window_geometry.h.unwrap_or(screen_dimentions.1) * -2,
-                        0,
-                        0,
-                    );
+                    self.move_resize_window(window, x, y, 0, 0);
                 }
             }
 


### PR DESCRIPTION
# Description

This makes some calls for the screens context when windows are hidden lazy. In particular this avoids some randr calls, which on some setups (when using nvidia prime for example) requires the dGPU to be awake: when it isn't, there is a noticeable latency. This avoids these lags as well as the unnecessary gpu wake up calls.

There may be a more in depth way to avoid these calls, but this removed the (quite frequently recurring) issue for me.

## Type of change

- [x] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
