### PR TITLE
Implement window rule for `hiding_strategy`

### DIFF
--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 
 use super::WindowState;
 use super::WindowType;
+use crate::config::WindowHidingStrategy;
 use crate::models::Margins;
 use crate::models::TagId;
 use crate::models::Xyhw;
@@ -73,6 +74,7 @@ pub struct Window<H: Handle> {
     // Two strings that are within a XClassHint, kept separate for simpler comparing.
     pub res_name: Option<String>,
     pub res_class: Option<String>,
+    pub hiding_strategy: Option<WindowHidingStrategy>,
 }
 
 impl<H: Handle> Window<H> {
@@ -105,6 +107,7 @@ impl<H: Handle> Window<H> {
             strut: None,
             res_name: None,
             res_class: None,
+            hiding_strategy: None,
         }
     }
 

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -90,6 +90,7 @@ pub struct WindowHook {
     pub spawn_fullscreen: Option<bool>,
     /// Handle the window as if it was of this `_NET_WM_WINDOW_TYPE`
     pub spawn_as_type: Option<WindowType>,
+    pub hiding_strategy: Option<WindowHidingStrategy>,
 }
 
 impl WindowHook {
@@ -171,6 +172,7 @@ impl WindowHook {
         if let Some(w_type) = self.spawn_as_type.clone() {
             window.r#type = w_type;
         }
+        window.hiding_strategy = self.hiding_strategy;
     }
 }
 
@@ -655,7 +657,7 @@ impl leftwm_core::Config for Config {
             if let Some((hook, _)) = best_match {
                 hook.apply(state, window);
                 tracing::trace!(
-                    "Window [[ TITLE={:?}, {:?}; WM_CLASS={:?}, {:?} ]] spawned in tag={:?} on workspace={:?} as type={:?} with floating={:?}, sticky={:?} and fullscreen={:?}",
+                    "Window [[ TITLE={:?}, {:?}; WM_CLASS={:?}, {:?} ]] spawned in tag={:?} on workspace={:?} as type={:?} with floating={:?}, sticky={:?} and fullscreen={:?}, hiding_stategy={:?}",
                     window.name,
                     window.legacy_name,
                     window.res_name,
@@ -666,6 +668,7 @@ impl leftwm_core::Config for Config {
                     hook.spawn_floating,
                     hook.spawn_sticky,
                     hook.spawn_fullscreen,
+                    hook.hiding_strategy,
                 );
                 return true;
             }


### PR DESCRIPTION
# Description

In addition of #1274, this PR adds a new window rule parameter in case some window do not behave correctly under `MoveMinimize` or `MoveOnly` hiding behaviours, or if you want to be able to share specific windows but still have `Unmap` for other windows.

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

- `hiding_strategy` When specified, will force the window to hide in a certain way. See `window_hiding_strategy` for values.

# Checklist:

- [ ] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
