### PR TITLE
fix: Remove destroyed window from history

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -89,8 +89,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             .window_history
             .iter()
             // Take the first window that is not the destroyed window.
-            .filter(|w| w != &&Some(*handle))
-            .next()
+            .find(|w| w != &&Some(*handle))
         {
             Some(*last_focused_window)
         } else {

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -83,8 +83,14 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     /// Returns true if changes need to be rendered.
     pub fn window_destroyed_handler(&mut self, handle: &WindowHandle<H>) -> bool {
         // Get the previous focused window else find the next or previous window on the workspace.
-        let new_handle = if let Some(Some(last_focused_window)) =
-            self.state.focus_manager.window_history.get(1)
+        let new_handle = if let Some(Some(last_focused_window)) = self
+            .state
+            .focus_manager
+            .window_history
+            .iter()
+            // Take the first window that is not the destroyed window.
+            .filter(|w| w != &&Some(*handle))
+            .next()
         {
             Some(*last_focused_window)
         } else {
@@ -127,6 +133,12 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
                 self.state.focus_manager.window_history.push_front(None);
             }
         }
+
+        // Remove destroyed window from history.
+        self.state
+            .focus_manager
+            .window_history
+            .retain(|w| w != &Some(*handle));
 
         // Only update windows if this window is visible.
         visible


### PR DESCRIPTION
This resolves several issues related to focusing.

# Description

The destroyed window is not removed from window history stack. Thus, on the next call `window_destroyed_handler()` tries to take the second window from windows history stack, but gets handler of already destroyed window, which is impossible to focus.

Fixes #1204, #1145

## Type of change

- [ ] Development change (no change visible to user)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [X] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
