### PR TITLE
fix(xlib-display-server): resolve 32-bit width issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3]
+
+### Fixed
+
+- Fixed compilation issue for xlib-display-server for 32-bit systems
+
 ## [0.5.2]
 
 ## CVEs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "anymap2"
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bitflags",
  "dirs-next",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm-macros"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "leftwm-watchdog"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "dirs-next",
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.160"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b21006cd1874ae9e650973c565615676dc4a274c965bb0a73796dac838ce4f"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libredox"
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -1159,9 +1159,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "e6e185e337f816bc8da115b8afcb3324006ccc82eeaddf35113888d3bd8e44ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "x11rb-display-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "leftwm-core",
@@ -1682,7 +1682,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xlib-display-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "futures",
  "leftwm-core",

--- a/display-servers/x11rb-display-server/Cargo.toml
+++ b/display-servers/x11rb-display-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "x11rb-display-server"
 description = "x11 backend for leftwm using pure rust + xcb specification"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leftwm-core = { path = "../../leftwm-core", version = '0.5.1' }
+leftwm-core = { path = "../../leftwm-core", version = '0.5.2' }
 futures = "0.3.21"
 tracing = "0.1.36"
 tokio = { version = "1.2.0", features = [ "sync", "time" ] }

--- a/display-servers/xlib-display-server/Cargo.toml
+++ b/display-servers/xlib-display-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlib-display-server"
-version = "0.1.3"
+version = "0.1.4"
 description = "A display server library for LeftWM" 
 license = "MIT"
 edition = "2021"
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leftwm-core = { path = "../../leftwm-core", version = '0.5.1' }
+leftwm-core = { path = "../../leftwm-core", version = '0.5.2' }
 x11-dl = "2.18.4"
 futures = "0.3.21"
 tracing = "0.1.36"

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -818,7 +818,11 @@ impl From<XWindowAttributesIntoScreen<'_>> for Screen<XlibWindowHandle> {
     }
 }
 
+#[cfg(target_pointer_width = "64")]
 struct SliceIntoDockArea<'a>(&'a [i64]);
+
+#[cfg(target_pointer_width = "32")]
+struct SliceIntoDockArea<'a>(&'a [i32]);
 
 impl From<SliceIntoDockArea<'_>> for DockArea {
     fn from(val: SliceIntoDockArea<'_>) -> Self {

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-core"
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.74.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["data-structures", "gui"]

--- a/leftwm-macros/Cargo.toml
+++ b/leftwm-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-macros"
-version = "0.5.1"
+version = "0.5.2"
 rust-version = "1.74.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["development-tools::procedural-macro-helpers"]

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm-watchdog"
-version = "0.5.2"
+version = "0.5.3"
 rust-version = "1.74.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["gui"]

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leftwm"
-version = "0.5.2"
+version = "0.5.3"
 rust-version = "1.74.0"
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["gui"]
@@ -23,8 +23,8 @@ once_cell = "1.13.0"
 futures = "0.3.21"
 git-version = "0.3.5"
 lefthk-core = { version = '0.2', optional = true }
-leftwm-core = { path = "../leftwm-core", version = '0.5.1' }
-leftwm-macros = {path = "../leftwm-macros", version = '0.5.1'}
+leftwm-core = { path = "../leftwm-core", version = '0.5.2' }
+leftwm-macros = {path = "../leftwm-macros", version = '0.5.2'}
 leftwm-layouts = "0.9.1"
 liquid = "0.26.0"
 mio = "1.0.2"


### PR DESCRIPTION
# Description
Fixes an issue in xlib-display-server where the slice width for 32 bit systems was assumed as 64 bits.

Releases 0.5.3.

Resolves #1291

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
