### PR TITLE
feat(#1296): add default_layout option to config

### DIFF
--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -9,6 +9,7 @@ pub struct Workspace {
     pub output: String,
     pub relative: Option<bool>,
     pub layouts: Option<Vec<String>>,
+    /// The default layout from the config; introduced in 0.5.4
     #[serde(default)]
     pub default_layout: Option<String>,
 }

--- a/leftwm-core/src/config/workspace_config.rs
+++ b/leftwm-core/src/config/workspace_config.rs
@@ -9,4 +9,6 @@ pub struct Workspace {
     pub output: String,
     pub relative: Option<bool>,
     pub layouts: Option<Vec<String>>,
+    #[serde(default)]
+    pub default_layout: Option<String>,
 }

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -107,13 +107,11 @@ impl LayoutManager {
             layouts: HashMap::new(),
         };
 
-        // set the current layout to the default layout for workspaces that have one configured, if in workspace mode
-        if config.layout_mode() == LayoutMode::Workspace {
-            for (i, ws) in config.workspaces().unwrap_or_default().iter().enumerate() {
-                if let Some(default_layout) = &ws.default_layout {
-                    let wsid = i + 1;
-                    layout_manager.set_layout(wsid, wsid, default_layout);
-                }
+        // set the current layout to the default layout for workspaces that have one configured
+        for (i, ws) in config.workspaces().unwrap_or_default().iter().enumerate() {
+            if let Some(default_layout) = &ws.default_layout {
+                let wsid = i + 1;
+                layout_manager.set_layout(wsid, wsid, default_layout);
             }
         }
 

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -296,7 +296,7 @@ mod tests {
                 // same as above, but workspace explicitly given no layouts
                 crate::config::Workspace {
                     layouts: Some(vec![]),
-                    default_layout: Some(layouts::EVEN_HORIZONTAL.to_string()),
+                    default_layout: Some(layouts::LEFT_MAIN.to_string()),
                     ..Default::default()
                 },
                 // case where default is available globally, but not locally

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -65,6 +65,26 @@ impl LayoutManager {
                     }
                 }
             }
+            if let Some(default_layout) = &ws.default_layout {
+                let wsid = i + 1;
+                if let Some(layout) = config
+                    .layout_definitions()
+                    .iter()
+                    .find(|layout| layout.name == *default_layout)
+                {
+                    // add the default layout to the available layouts if it's not already there
+                    available_layouts_per_ws
+                        .entry(wsid)
+                        .and_modify(|layouts| {
+                            if !layouts.iter().any(|l| l.name == layout.name) {
+                                layouts.push(layout.clone());
+                            }
+                        })
+                        .or_insert_with(|| vec![layout.clone()]);
+                } else {
+                    tracing::warn!("There is no Layout with the name {:?}, but was configured as default on workspace {:?}", default_layout, wsid);
+                }
+            }
         }
 
         if available_layouts.is_empty() {
@@ -80,12 +100,24 @@ impl LayoutManager {
             available_layouts_per_ws
         );
 
-        Self {
+        let mut layout_manager = Self {
             mode: config.layout_mode(),
             available_layouts,
             available_layouts_per_ws,
             layouts: HashMap::new(),
+        };
+
+        // set the current layout to the default layout for workspaces that have one configured, if in workspace mode
+        if config.layout_mode() == LayoutMode::Workspace {
+            for (i, ws) in config.workspaces().unwrap_or_default().iter().enumerate() {
+                if let Some(default_layout) = &ws.default_layout {
+                    let wsid = i + 1;
+                    layout_manager.set_layout(wsid, wsid, default_layout);
+                }
+            }
         }
+
+        layout_manager
     }
 
     pub fn restore(&mut self, old: &LayoutManager) {
@@ -241,6 +273,41 @@ mod tests {
                     layouts: Some(vec![]),
                     ..Default::default()
                 },
+                // case where default is available globally
+                crate::config::Workspace {
+                    default_layout: Some(layouts::MAIN_AND_HORIZONTAL_STACK.to_string()),
+                    ..Default::default()
+                },
+                // case where default is available to the workspace, but not globally
+                crate::config::Workspace {
+                    layouts: Some(vec![
+                        layouts::CENTER_MAIN.to_string(),
+                        layouts::CENTER_MAIN_BALANCED.to_string(),
+                        layouts::MAIN_AND_VERT_STACK.to_string(),
+                    ]),
+                    default_layout: Some(layouts::MAIN_AND_VERT_STACK.to_string()),
+                    ..Default::default()
+                },
+                // case where the default exists but is not previously available
+                crate::config::Workspace {
+                    default_layout: Some(layouts::FIBONACCI.to_string()),
+                    ..Default::default()
+                },
+                // same as above, but workspace explicitly given no layouts
+                crate::config::Workspace {
+                    layouts: Some(vec![]),
+                    default_layout: Some(layouts::EVEN_HORIZONTAL.to_string()),
+                    ..Default::default()
+                },
+                // case where default is available globally, but not locally
+                crate::config::Workspace {
+                    layouts: Some(vec![
+                        layouts::CENTER_MAIN_BALANCED.to_string(),
+                        layouts::MAIN_AND_DECK.to_string(),
+                    ]),
+                    default_layout: Some(layouts::CENTER_MAIN.to_string()),
+                    ..Default::default()
+                },
             ]),
             ..Default::default()
         };
@@ -261,5 +328,21 @@ mod tests {
         assert_eq!(MONOCLE, &layout_manager.layout(2, 1).name);
         layout_manager.set_layout(2, 1, EVEN_VERTICAL);
         assert_eq!(EVEN_VERTICAL, &layout_manager.layout(2, 1).name);
+    }
+
+    #[test]
+    fn default_layouts_should_be_set() {
+        let mut layout_manager = layout_manager();
+        assert_eq!(
+            layouts::MAIN_AND_HORIZONTAL_STACK,
+            &layout_manager.layout(4, 1).name
+        );
+        assert_eq!(
+            layouts::MAIN_AND_VERT_STACK,
+            &layout_manager.layout(5, 1).name
+        );
+        assert_eq!(layouts::FIBONACCI, &layout_manager.layout(6, 1).name);
+        assert_eq!(layouts::LEFT_MAIN, &layout_manager.layout(7, 1).name);
+        assert_eq!(layouts::CENTER_MAIN, &layout_manager.layout(8, 1).name);
     }
 }

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -296,7 +296,7 @@ mod tests {
                 // same as above, but workspace explicitly given no layouts
                 crate::config::Workspace {
                     layouts: Some(vec![]),
-                    default_layout: Some(layouts::LEFT_MAIN.to_string()),
+                    default_layout: Some(layouts::EVEN_VERTICAL.to_string()),
                     ..Default::default()
                 },
                 // case where default is available globally, but not locally
@@ -342,7 +342,7 @@ mod tests {
             &layout_manager.layout(5, 1).name
         );
         assert_eq!(layouts::FIBONACCI, &layout_manager.layout(6, 1).name);
-        assert_eq!(layouts::LEFT_MAIN, &layout_manager.layout(7, 1).name);
+        assert_eq!(layouts::EVEN_VERTICAL, &layout_manager.layout(7, 1).name);
         assert_eq!(layouts::CENTER_MAIN, &layout_manager.layout(8, 1).name);
     }
 }

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -75,7 +75,7 @@ impl
 {
     pub fn new_with_screens(
         config: crate::config::tests::TestConfig,
-        screens: Vec<super::Screen<crate::models::window::MockHandle>>,
+        screens: &[super::Screen<crate::models::window::MockHandle>],
     ) -> Self {
         // needs to mimic what the display server would do when it starts,
         // specifically in respect to how workspaces are created for the screens
@@ -217,7 +217,7 @@ mod pr_1301_issue {
         let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
             Manager::new_with_screens(
                 test_config(),
-                vec![
+                &[
                     Screen::new(
                         BBox {
                             x: 0,
@@ -255,7 +255,7 @@ mod pr_1301_issue {
         let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
             Manager::new_with_screens(
                 test_config(),
-                vec![Screen::new(
+                &[Screen::new(
                     BBox {
                         x: 0,
                         y: 0,
@@ -284,7 +284,7 @@ mod pr_1301_issue {
         let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
             Manager::new_with_screens(
                 test_config(),
-                vec![
+                &[
                     Screen::new(
                         BBox {
                             x: 0,

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -73,6 +73,65 @@ impl
         crate::display_servers::MockDisplayServer<crate::models::window::MockHandle>,
     >
 {
+    pub fn new_with_screens(
+        config: crate::config::tests::TestConfig,
+        screens: Vec<super::Screen<crate::models::window::MockHandle>>,
+    ) -> Self {
+        // needs to mimic what the display server would do when it starts,
+        // specifically in respect to how workspaces are created for the screens
+        // even more specifically, I'm recreating the behavior of `XlibDisplayServer::initial_events`)
+        // by iterating through the configured workspaces and creating them for screens whose outputs match a workspace's output
+
+        // figure out all the screens that need to be created
+        let mut events = vec![];
+        if let Some(workspaces) = config.workspaces() {
+            for (i, wsc) in workspaces.iter().enumerate() {
+                let mut screen = super::Screen::from(wsc);
+                screen.root =
+                    crate::models::WindowHandle(crate::models::window::MockHandle::default());
+                // If there is a screen corresponding to the given output, create the workspace
+                match screens.iter().find(|s| s.output == wsc.output) {
+                    Some(output_match) => {
+                        if wsc.relative.unwrap_or(false) {
+                            screen.bbox.add(output_match.bbox);
+                        }
+                        screen.id = Some(i + 1);
+                    }
+                    None => continue,
+                }
+
+                // the only events we care about are ScreenCreate events, so instead of collecting DisplayEvents, we'll just collect Screens
+                events.push(screen);
+            }
+
+            let auto_derive_workspaces: bool = config.auto_derive_workspaces() || events.is_empty();
+            let mut next_id = workspaces.len() + 1;
+
+            // If there is no hardcoded workspace layout, add every screen not mentioned in the config.
+            if auto_derive_workspaces {
+                screens
+                    .iter()
+                    .filter(|screen| !workspaces.iter().any(|wsc| wsc.output == screen.output))
+                    .for_each(|screen| {
+                        let mut s = screen.clone();
+                        s.id = Some(next_id);
+                        next_id += 1;
+                        events.push(s);
+                    });
+            }
+        }
+
+        // now, create the manager
+        let mut manager = Self::new(config);
+
+        // and apply the events
+        for screen in events {
+            manager.screen_create_handler(screen);
+        }
+
+        manager
+    }
+
     pub fn new_test(tags: Vec<String>) -> Self {
         use crate::config::tests::TestConfig;
         let defs = Layouts::default().layouts;
@@ -97,5 +156,171 @@ impl
             single_window_border: false,
             ..TestConfig::default()
         })
+    }
+}
+
+#[cfg(test)]
+mod pr_1301_issue {
+    //! A set of tests to reproduce the issue described in the [comments of PR #1301](https://github.com/leftwm/leftwm/pull/1301#issuecomment-2542006937)
+    //! where despite the default layout being set in the config, it was not being used,
+    //! and instead "Grid" was being used for both workspaces since it was the first
+    //! layout in the layouts list.
+
+    use leftwm_layouts::layouts::Layouts;
+
+    use crate::{
+        config::tests::TestConfig,
+        display_servers::MockDisplayServer,
+        layouts,
+        models::{BBox, MockHandle, Screen},
+        Manager,
+    };
+
+    fn test_config() -> TestConfig {
+        TestConfig {
+            layouts: vec![
+                layouts::FIBONACCI.to_string(),
+                "Grid".to_string(),
+                layouts::MONOCLE.to_string(),
+            ],
+            layout_definitions: Layouts::default().layouts,
+            workspaces: Some(vec![
+                crate::config::Workspace {
+                    output: "DP-3".to_string(),
+                    y: 0,
+                    x: 0,
+                    height: 1080,
+                    width: 1920,
+                    default_layout: Some(layouts::MONOCLE.to_string()),
+                    ..Default::default()
+                },
+                crate::config::Workspace {
+                    output: "DP-4".to_string(),
+                    y: 1080,
+                    x: 0,
+                    height: 1080,
+                    width: 1920,
+                    default_layout: Some("Grid".to_string()),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    /// assume that the users screens are the same as the ones in the config
+    ///
+    /// this is to validate that the default layout is used when workspaces
+    /// are configured properly
+    fn default_layout_with_correct_screen() {
+        let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
+            Manager::new_with_screens(
+                test_config(),
+                vec![
+                    Screen::new(
+                        BBox {
+                            x: 0,
+                            y: 0,
+                            width: 1920,
+                            height: 1080,
+                        },
+                        "DP-3".to_string(),
+                    ),
+                    Screen::new(
+                        BBox {
+                            x: 0,
+                            y: 1080,
+                            width: 1920,
+                            height: 1080,
+                        },
+                        "DP-4".to_string(),
+                    ),
+                ],
+            );
+
+        assert_eq!(2, manager.state.workspaces.len());
+        assert_eq!(
+            layouts::MONOCLE,
+            &manager.state.layout_manager.layout(1, 1).name
+        );
+        assert_eq!("Grid", &manager.state.layout_manager.layout(2, 1).name);
+    }
+
+    #[test]
+    /// assume that the users screens are not the same as the ones in the config
+    ///
+    /// this is to reproduce the issue, and demonstrate that it is not necessarily a bug
+    fn default_layout_with_incorrect_screen() {
+        let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
+            Manager::new_with_screens(
+                test_config(),
+                vec![Screen::new(
+                    BBox {
+                        x: 0,
+                        y: 0,
+                        width: 1920,
+                        height: 1080,
+                    },
+                    // notice how this is not one of the configured outputs
+                    "eDP-1".to_string(),
+                )],
+            );
+
+        // there is only one workspace
+        assert_eq!(1, manager.state.workspaces.len());
+        // that workspace is not one of the 2 configured
+        assert_eq!(3, manager.state.workspaces[0].id);
+        // so it defaults to the first layout in the list
+        assert_eq!(
+            layouts::FIBONACCI,
+            &manager.state.layout_manager.layout(3, 1).name
+        );
+    }
+
+    #[test]
+    /// Assume that the user has 2 screens, but only one is configured
+    fn default_layout_with_one_configured_screen() {
+        let mut manager: Manager<MockHandle, TestConfig, MockDisplayServer<MockHandle>> =
+            Manager::new_with_screens(
+                test_config(),
+                vec![
+                    Screen::new(
+                        BBox {
+                            x: 0,
+                            y: 0,
+                            width: 1920,
+                            height: 1080,
+                        },
+                        "DP-3".to_string(),
+                    ),
+                    Screen::new(
+                        BBox {
+                            x: 0,
+                            y: 1080,
+                            width: 1920,
+                            height: 1080,
+                        },
+                        "eDP-1".to_string(),
+                    ),
+                ],
+            );
+
+        // there are 2 workspaces
+        assert_eq!(2, manager.state.workspaces.len());
+        // the first screen's workspace is configured as expected
+        assert_eq!(
+            layouts::MONOCLE,
+            &manager.state.layout_manager.layout(1, 1).name
+        );
+        // and has the expected id
+        assert_eq!(1, manager.state.workspaces[0].id);
+        // the second screen has no configuration, and fallsback to defaults
+        assert_eq!(
+            layouts::FIBONACCI,
+            &manager.state.layout_manager.layout(3, 1).name
+        );
+        // and has the expected id
+        assert_eq!(3, manager.state.workspaces[1].id);
     }
 }

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -323,6 +323,30 @@ workspaces: [
 ]
 \f[R]
 .fi
+.PP
+Workspaces can also be given their own list of layouts, which will override the global layouts list for that workspace only.
+.PP
+Example:
+.IP
+.nf
+\f[C]
+workspaces: [
+    ( output: "HDMI-1", y: 0, x: 0, height: 1440, width: 1720, layouts: [ "CenterMain", "MainAndVertStack", "MainAndDeck" ] ),
+]
+\f[R]
+.fi
+.PP
+You can also set the default layout for a workspace by using the default_layout field, this set the layout the workspace will start with.
+.PP
+Example (setting the default layout of workspace 1 to MainAndVertStack):
+.IP
+.nf
+\f[C]
+workspaces: [
+    ( output: "HDMI-1", y: 0, x: 0, height: 1440, width: 1720, default_layout: "MainAndVertStack" ),
+]
+\f[R]
+.fi
 
 .SS Tags
 .PP


### PR DESCRIPTION
# Description

Implements the feature discussed in #1296, allowing you to set a "default layout" for a workspace, and implementing corresponding layout management logic

Non-breaking since the `default_layout` field is annotated with the `#[serde(default)]` macro, so will just be set to `None` if not given

Note: I haven't actually ran this locally to ensure it actually works, but the tests pass.

Fixes #1296

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

There currently isn't documentation for the `layouts` field of a workspace, so that should probably be added too, but just for this feature it could look like adding

"""
Example (setting the default layout of workspace 1 to `Monocle`):

```ron
workspaces: [
    ( output: "HDMI-1", y: 0, x: 0, height: 1440, width: 1720, default_layout: "Monocle"),
]
```
"""

somewhere in

https://github.com/leftwm/leftwm/wiki/Config#workspaces


See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
