### PR TITLE
chore: update dependencies, fix clippy errors, dismiss spurious warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,43 +43,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "anymap2"
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"
@@ -152,18 +152,18 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -173,30 +173,30 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "const_format"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -205,27 +205,27 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -318,19 +318,19 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures"
@@ -485,16 +485,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -502,9 +496,12 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "e5d80fade88dd420ce0d9ab6f7c58ef2272dde38db874657950f827d4982c817"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -523,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "kstring"
@@ -555,7 +552,7 @@ dependencies = [
  "ron",
  "serde",
  "signal-hook",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "x11-dl",
@@ -586,7 +583,7 @@ dependencies = [
  "signal-hook",
  "syslog-tracing",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "time",
  "tokio",
  "toml",
@@ -613,7 +610,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "x11-dl",
@@ -647,15 +644,15 @@ dependencies = [
  "nix",
  "signal-hook",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "xdg",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
@@ -753,20 +750,19 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "log",
  "wasi",
@@ -821,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -854,20 +850,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.9",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -875,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -888,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
@@ -899,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -923,18 +919,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -947,18 +943,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -973,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1014,16 +1010,22 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1033,18 +1035,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1053,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "itoa",
  "memchr",
@@ -1137,9 +1139,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1159,9 +1161,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.80"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e185e337f816bc8da115b8afcb3324006ccc82eeaddf35113888d3bd8e44ac"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1194,18 +1196,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1224,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -1247,9 +1269,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1257,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1318,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1334,16 +1356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1352,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1362,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
 dependencies = [
  "libc",
  "tracing-core",
@@ -1384,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1414,9 +1436,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"

--- a/display-servers/x11rb-display-server/src/error.rs
+++ b/display-servers/x11rb-display-server/src/error.rs
@@ -48,12 +48,9 @@ impl Display for BackendError {
         f.debug_list().entry(&kind).finish()?;
         f.write_str(" ")?;
         f.write_str(self.msg)?;
-        match &self.src {
-            Some(e) => {
-                f.write_str(": ")?;
-                e.fmt(f)?;
-            }
-            None => (),
+        if let Some(e) = &self.src {
+            f.write_str(": ")?;
+            e.fmt(f)?;
         };
         f.write_str("\nBacktrace:\n")?;
         self.backtrace.fmt(f)

--- a/display-servers/x11rb-display-server/src/event_translate.rs
+++ b/display-servers/x11rb-display-server/src/event_translate.rs
@@ -1,3 +1,4 @@
+#[cfg(debug_assertions)]
 use std::backtrace::BacktraceStatus;
 
 use leftwm_core::{

--- a/display-servers/xlib-display-server/src/event_translate.rs
+++ b/display-servers/xlib-display-server/src/event_translate.rs
@@ -13,7 +13,7 @@ use x11_dl::xlib;
 
 pub struct XEvent<'a>(pub &'a mut XWrap, pub xlib::XEvent);
 
-impl<'a> From<XEvent<'a>> for Option<DisplayEvent<XlibWindowHandle>> {
+impl From<XEvent<'_>> for Option<DisplayEvent<XlibWindowHandle>> {
     fn from(x_event: XEvent) -> Self {
         let raw_event = x_event.1;
         let normal_mode = x_event.0.mode == Mode::Normal;

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -20,7 +20,7 @@ nix = {version = "0.29.0", features = ["fs", "signal"]}
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = "1.0.44"
 signal-hook = "0.3.4"
-thiserror = "1.0.30"
+thiserror = "2.0.9"
 tokio = { version = "1.2.0", features = [
   "fs",
   "io-util",

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -44,7 +44,7 @@ macro_rules! move_focus_common_vars {
             |x: &Window<H>| -> bool { x.tag == Some(tag_id) && x.is_managed() };
 
         let to_reorder = helpers::vec_extract(&mut $state.windows, for_active_workspace);
-        $func($state, handle, &layout, to_reorder, $($arg),*)
+        $func($state, handle, layout.as_ref(), to_reorder, $($arg),*)
     }};
 }
 
@@ -672,15 +672,15 @@ fn toggle_floating<H: Handle>(state: &mut State<H>) -> Option<bool> {
 fn move_window_change<H: Handle>(
     state: &mut State<H>,
     mut handle: WindowHandle<H>,
-    layout: &Option<String>,
+    layout: Option<&String>,
     mut to_reorder: Vec<Window<H>>,
     val: i32,
 ) -> Option<bool> {
     let is_handle = |x: &Window<H>| -> bool { x.handle == handle };
-    if layout == &Some(MONOCLE.to_string()) {
+    if layout == Some(MONOCLE.to_string()).as_ref() {
         handle = helpers::relative_find(&to_reorder, is_handle, -val, true)?.handle;
         let _ = helpers::cycle_vec(&mut to_reorder, val);
-    } else if layout == &Some(MAIN_AND_DECK.to_string()) {
+    } else if layout == Some(MAIN_AND_DECK.to_string()).as_ref() {
         if let Some(index) = to_reorder.iter().position(|x: &Window<H>| !x.floating()) {
             let mut window_group = to_reorder.split_off(index + 1);
             if !to_reorder.iter().any(|w| w.handle == handle) {
@@ -701,7 +701,7 @@ fn move_window_change<H: Handle>(
 fn move_window_top<H: Handle>(
     state: &mut State<H>,
     handle: WindowHandle<H>,
-    _layout: &Option<String>,
+    _layout: Option<&String>,
     mut to_reorder: Vec<Window<H>>,
     swap: bool,
 ) -> Option<bool> {
@@ -734,7 +734,7 @@ fn move_window_top<H: Handle>(
 fn move_window_direction<H: Handle>(
     state: &mut State<H>,
     mut handle: WindowHandle<H>,
-    _layout: &Option<String>,
+    _layout: Option<&String>,
     mut to_reorder: Vec<Window<H>>,
     dir: FocusDirection,
 ) -> Option<bool> {
@@ -768,7 +768,7 @@ fn move_window_direction<H: Handle>(
 fn swap_window_top<H: Handle>(
     state: &mut State<H>,
     handle: WindowHandle<H>,
-    _layout: &Option<String>,
+    _layout: Option<&String>,
     mut to_reorder: Vec<Window<H>>,
     swap: bool,
 ) -> Option<bool> {
@@ -800,18 +800,18 @@ fn swap_window_top<H: Handle>(
 fn focus_window_change<H: Handle>(
     state: &mut State<H>,
     mut handle: WindowHandle<H>,
-    layout: &Option<String>,
+    layout: Option<&String>,
     mut to_reorder: Vec<Window<H>>,
     val: i32,
 ) -> Option<bool> {
     let is_handle = |x: &Window<H>| -> bool { x.handle == handle };
-    if layout == &Some(layouts::MONOCLE.to_string()) {
+    if layout == Some(layouts::MONOCLE.to_string()).as_ref() {
         // For Monocle we want to also move windows up/down
         // Not the best solution but results
         // in desired behaviour
         handle = helpers::relative_find(&to_reorder, is_handle, -val, true)?.handle;
         let _ = helpers::cycle_vec(&mut to_reorder, val);
-    } else if layout == &Some(layouts::MAIN_AND_DECK.to_string()) {
+    } else if layout == Some(layouts::MAIN_AND_DECK.to_string()).as_ref() {
         let len = to_reorder.len() as i32;
         if len > 0 {
             let index = match to_reorder.iter().position(|x: &Window<H>| !x.floating()) {
@@ -832,7 +832,7 @@ fn focus_window_change<H: Handle>(
     }
     state.windows.append(&mut to_reorder);
     state.handle_window_focus(&handle);
-    Some(layout == &Some(layouts::MONOCLE.to_string()))
+    Some(layout == Some(layouts::MONOCLE.to_string()).as_ref())
 }
 
 fn focus_window_top<H: Handle>(state: &mut State<H>, swap: bool) -> Option<bool> {

--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -708,11 +708,10 @@ mod tests {
         });
 
         // Assert
-        assert!(manager
+        assert!(!manager
             .state
             .active_scratchpads
-            .get(&scratchpad_name)
-            .is_none());
+            .contains_key(&scratchpad_name));
         assert_eq!(
             *manager.state.focus_manager.tag_history.front().unwrap(),
             expected_tag

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -440,11 +440,7 @@ fn setup_window<H: Handle>(
             find_terminal(state, window.pid).map_or_else(|| ws.tag, |terminal| terminal.tag);
     }
     *on_same_tag = ws.tag == window.tag;
-    *layout = state
-        .layout_manager
-        .layout(ws.id, window.tag.unwrap())
-        .name
-        .clone();
+    layout.clone_from(&state.layout_manager.layout(ws.id, window.tag.unwrap()).name);
 
     // Setup a scratchpad window.
     if let Some((scratchpad_name, _)) = state

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -8,7 +8,7 @@ use super::LayoutMode;
 /// The [`LayoutManager`] holds the actual set of [`Layout`].
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LayoutManager {
-    /// LayoutMode to be used when applying layouts
+    /// `LayoutMode` to be used when applying layouts
     mode: LayoutMode,
 
     /// All the available layouts. Loaded from the config and
@@ -105,7 +105,7 @@ impl LayoutManager {
             );
             return;
         }
-        self.layouts = old.layouts.clone();
+        self.layouts.clone_from(&old.layouts);
     }
 
     /// Get back either the workspace ID or the tag ID, based on the current [`LayoutMode`]

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -146,10 +146,9 @@ impl Tags {
         if let Some(normal) = self.normal.get_mut(id - 1) {
             return Some(normal);
         }
-        return self
-            .hidden
+        self.hidden
             .iter_mut()
-            .find(|hidden_tag| hidden_tag.id == id);
+            .find(|hidden_tag| hidden_tag.id == id)
     }
 
     /// Get a hidden tag by its label
@@ -191,7 +190,7 @@ pub struct Tag {
     /// but labels of hidden tags must be unique.
     ///
     /// ## Hint
-    /// Unlike in earlier versions of LeftWM,
+    /// Unlike in earlier versions of `LeftWM`,
     /// the label of a Tag is not something that
     /// actually identifies a Tag. Tags are always
     /// identified and referenced by their ID (ie. `[1, 2, 3, ...]`).

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -238,7 +238,7 @@ impl<H: Handle> State<H> {
                     new_tag.iter().for_each(|&tag_id| new_window.tag(&tag_id));
                 }
                 new_window.strut = old_window.strut;
-                new_window.states = old_window.states.clone();
+                new_window.states.clone_from(&old_window.states);
                 ordered.push(new_window.clone());
                 self.windows.remove(index);
 
@@ -283,7 +283,9 @@ impl<H: Handle> State<H> {
         }
 
         // Restore focus.
-        self.focus_manager.tags_last_window = old_state.focus_manager.tags_last_window.clone();
+        self.focus_manager
+            .tags_last_window
+            .clone_from(&old_state.focus_manager.tags_last_window);
         self.focus_manager
             .tags_last_window
             .retain(|&id, _| all_tags.get(id).is_some());

--- a/leftwm-core/src/utils/modmask_lookup.rs
+++ b/leftwm-core/src/utils/modmask_lookup.rs
@@ -122,7 +122,7 @@ impl<'de> Deserialize<'de> for ModMask {
     {
         struct ModmaskVisitor;
 
-        impl<'de> Visitor<'de> for ModmaskVisitor {
+        impl Visitor<'_> for ModmaskVisitor {
             type Value = ModMask;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/leftwm-watchdog/Cargo.toml
+++ b/leftwm-watchdog/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.0.0", features = ["cargo"] }
 dirs-next = "2.0.0"
 nix = { version = "0.29.0", features = ["fs", "signal"] }
 signal-hook = "0.3.4"
-thiserror = "1.0.30"
+thiserror = "2.0.9"
 xdg = "2.2.0"
 
 [dev-dependencies]

--- a/leftwm-watchdog/src/utils.rs
+++ b/leftwm-watchdog/src/utils.rs
@@ -30,7 +30,7 @@ pub const fn get_help_template() -> &'static str {
 /// There are some principles about autostart file:
 /// 1. An application `.desktop` file must have the format as defined in the [Desktop Entry Specification](http://standards.freedesktop.org/desktop-entry-spec/)
 /// 2. If two files have the same filename in `$XDG_CONFIG_DIRS/autostart` and `$XDG_CONFIG_HOME/autostart`,
-/// e.g. `foo.desktop`, `$XDG_CONFIG_DIRS/autostart/foo.desktop` will be ignored.
+///     e.g. `foo.desktop`, `$XDG_CONFIG_DIRS/autostart/foo.desktop` will be ignored.
 ///
 /// `Autostart Entry` will be ignored when:
 /// 1. the `.desktop` file has the `Hidden` key set to true.

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = "1.0.44"
 shellexpand = "3.0.0"
 signal-hook = "0.3.4"
-thiserror = "1.0.30"
+thiserror = "2.0.9"
 time_leftwm = { package = "time", version = "0.3.7", features = [
   "macros",
   "formatting",

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -406,6 +406,7 @@ where
 ///         - Disable the feature (remove from --features at compile time)
 ///         - Install any dependency/dependencies which are missing
 ///         - Ensure all binaries are installed to a location in your PATH
+#[allow(unused_variables)]
 fn check_enabled_features(verbose: bool) -> Result<()> {
     if env!("LEFTWM_FEATURES").is_empty() {
         println!("\x1b[0;94m::\x1b[0m Built with no enabled features.");

--- a/leftwm/src/bin/leftwm-log.rs
+++ b/leftwm/src/bin/leftwm-log.rs
@@ -1,9 +1,13 @@
 use clap::{arg, command, ArgGroup, Id};
-use std::process::{exit, Command};
+use std::process::exit;
+#[cfg(any(feature = "sys-log", feature = "journald-log", feature = "file-log"))]
+use std::process::Command;
 
 fn main() {
     let matches = get_command().get_matches();
+    #[cfg(any(feature = "sys-log", feature = "journald-log", feature = "file-log"))]
     let follow = matches.get_flag("follow");
+    #[cfg(any(feature = "sys-log", feature = "journald-log", feature = "file-log"))]
     let level = matches.get_count("verbose");
 
     #[allow(unreachable_patterns)]

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -16,8 +16,8 @@ use leftwm_core::{
     config::{InsertBehavior, ScratchPad, WindowHidingStrategy, Workspace},
     layouts::LayoutMode,
     models::{
-        FocusBehaviour, FocusOnActivationBehaviour, Gutter, Handle, Margins, Size, Window,
-        WindowState, WindowType,
+        FocusBehaviour, FocusOnActivationBehaviour, Gutter, Handle, Margins, Window, WindowState,
+        WindowType,
     },
     state::State,
     DisplayAction, DisplayServer, Manager, ReturnPipe,

--- a/leftwm/src/utils/log/file.rs
+++ b/leftwm/src/utils/log/file.rs
@@ -59,7 +59,6 @@ fn get_log_dir<P: AsRef<Path> + Clone>(path: P) -> Box<Path> {
 /// # Panics
 /// - If HOME is not set
 /// - If path permissions are not at least 0700
-
 pub fn get_log<P: AsRef<Path>>(path: P) -> Box<Path> {
     let file_name = path.as_ref().file_name().unwrap().to_owned();
 


### PR DESCRIPTION
# Description
- Bumps implicit dependencies for numerous crates and explicit ones for `thiserror` 
- Fixes numerous clippy errors present in recent builds
- Addresses warnings around conditional compilation for the benefit of package review.  


Fixes N/A

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

N/A

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- N/A Manual page has been updated accordingly
- N/A Wiki pages have been updated accordingly (to perform **after** merge)
