### PR TITLE
fix sloppy focus after window closes

### DIFF
--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -120,6 +120,9 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             {
                 let act = DisplayAction::FocusWindowUnderCursor;
                 self.state.actions.push_back(act);
+                // Make sure we actually update the focus, as the currently
+                // focused window will be removed from history.
+                self.state.focus_manager.window_history.push_front(None);
             } else if let Some(parent) =
                 find_transient_parent(&self.state.windows, transient).map(|p| p.handle)
             {


### PR DESCRIPTION
After a window closes, the focus is updated to another window. For sloppy focus this happens by queueing FocusWindowUnderCursor. However, when this action is being executed, there is a check for change in focus which happens _after_ the window being destroyed has been removed from the window history. This in turn causes us to think there is nothing to do and we exit early.

Push a None focus onto the window history to force an update. After all, we don't actually have anything in focus at the moment.

fixes #1295

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

Note: make test already fails for me on main. ~~I'll make a separate PR for that.~~ No actions required for the other two items.

- [ ] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
