### PR TITLE
feat(leftwm-watchdog): publish leftwm-watchdog crate, update documentation on how to install leftwm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,9 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           cargo publish --allow-dirty -p leftwm
+      - name: Publish binary crate
+        if: github.event_name == 'release'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --allow-dirty -p leftwm-watchdog

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ sudo xbps-install -S leftwm
 ## Cargo ([crates.io])
 
 ```sh
-cargo install leftwm
+cargo install leftwm leftwm-watchdog
 ```
 
 If you install LeftWM with crates.io, you will need to link to the [xsession desktop file](https://github.com/leftwm/leftwm/blob/758bbf837a8556cdc7e09ff2d394f528e7657333/leftwm.desktop) if you want
@@ -206,7 +206,8 @@ Also see [the build options](#optional-build-features) for more feature options,
 At the moment LeftWM is not packaged with OpenBSD package manager, but it could be installed via Cargo.
 
 ```sh
-cargo install leftwm --no-default-features --features lefthk
+cargo install leftwm --no-default-features --features lefthk &
+cargo install leftwm-watchdog
 ```
 
 `leftwm-config` not yet ported to OpenBSD, as it requires a nightly Rust compiler to build.
@@ -343,8 +344,8 @@ Use `cargo` with the added flags `--no-default-features --features=` and then co
 | journald-log | logging to `journald`, depends on `systemd`                                                                                                                                                    | ✔      |
 | sys-log      | use standard system logging                                                                                                                                                                    | ✘       |
 | file-log     | log to `/tmp/leftwm/<log-file-by-datetime-of-launch>`                                                                                                                                          | ✘       |
-| xlib (\*)    | legacy backend linking to `libX11`                                                                                                                                                             | ✔       |
-| x11rb (\*)   | rust based backend using [`x11rb`](https://github.com/psychon/x11rb)                                                                                                                           | ✔       |
+| xlib (\*)    | legacy backend linking to `libX11`                                                                                                                                                             | ✔      |
+| x11rb (\*)   | rust based backend using [`x11rb`](https://github.com/psychon/x11rb)                                                                                                                           | ✔      |
 
 ⚠️ You need to select **at least one** backend feature (\*) for leftwm to build ⚠️
 

--- a/leftwm-watchdog/README.md
+++ b/leftwm-watchdog/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
# Description
In #1192, we split the `leftwm` binary away from the other binaries into the `leftwm-watchdog` to reduce compile times significantly. The `leftwm` binary is therefore not being installed when attempting to run `cargo install leftwm`. One potential resolution to this issue is to add the `leftwm-watchdog` crate to crates.io and updating the documentation to users that install leftwm using cargo to include `leftwm-watchdog` when installing, e.g. they should now use `cargo install leftwm leftwm-watchdog`. There are potentially other solutions, so I will leave this pull request open awhile in case anyone has thoughts or opinions on resolving this through other means.

Fixes [this](https://discord.com/channels/889371782388256818/889374673593331712/1337532140048617537) Discord issue

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Updated user documentation:
Update https://github.com/leftwm/leftwm/wiki/Troubleshooting, update
> Try the following: Install leftwm using `cargo install --path {path}`  where {path} is a directory in your PATH variable; set the PATH variable, usually in .bashrc, .profile, or similar depending on your shell

to:

> Try the following: Install leftwm using `cargo install --path {path}` where {path} is a directory in your PATH variable; set the PATH variable, usually in .bashrc, .profile, or similar depending on your shell. If installing from crates.io, ensure you install both leftwm and leftwm-watchdog: `cargo install leftwm leftwm-watchdog`

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
Fixes  #1323
