### PR TITLE
fix sloppy focus with margins

### DIFF
--- a/display-servers/x11rb-display-server/src/lib.rs
+++ b/display-servers/x11rb-display-server/src/lib.rs
@@ -439,11 +439,6 @@ fn from_window_take_focus(
 fn from_focus_window_under_cursor(
     xw: &mut XWrap,
 ) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
-    let mut window = xw.get_cursor_window()?;
-    if window == WindowHandle(X11rbWindowHandle(0)) {
-        window = xw.get_default_root_handle();
-        return Ok(Some(DisplayEvent::WindowTakeFocus(window)));
-    }
     let point = xw.get_cursor_point()?;
     let evt = DisplayEvent::MoveFocusTo(point.0, point.1);
     Ok(Some(evt))

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -411,12 +411,6 @@ fn from_window_take_focus(
 }
 
 fn from_focus_window_under_cursor(xw: &mut XWrap) -> Option<DisplayEvent<XlibWindowHandle>> {
-    if let Ok(mut window) = xw.get_cursor_window() {
-        if window == WindowHandle(XlibWindowHandle(0)) {
-            window = xw.get_default_root_handle();
-        }
-        return Some(DisplayEvent::WindowTakeFocus(window));
-    }
     let point = xw.get_cursor_point().ok()?;
     let evt = DisplayEvent::MoveFocusTo(point.0, point.1);
     Some(evt)


### PR DESCRIPTION
Commit 4f765b4ba14 ('Various fixes') claims to 'make it work for non-sloppy focus' but in doing so, it breaks it for sloppy focus by forcing the focus to the root window. This doesn't seem to be the correct place to make this kind of decision anyway.

Removing this bit of code also doesn't really seem to break anything obvious on ClickTo or Driven focus, so we might as well get rid of it.

fixes #1108

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
