### PR TITLE
xlib, x11rb: fix ClickTo focus after switching tags

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -279,12 +279,16 @@ impl XWrap {
                 }
             }
 
-            // Set WM_STATE to iconic state.
-            if hiding_strategy == WindowHidingStrategy::Unmap
+            // make sure to always change the window state, so we don't forget
+            // to grab mouse button events when we show the window again.
+            let new_state = if hiding_strategy == WindowHidingStrategy::Unmap
                 || hiding_strategy == WindowHidingStrategy::MoveMinimize
             {
-                self.set_wm_state(window, WMStateWindowState::Iconic)?;
-            }
+                WMStateWindowState::Iconic
+            } else {
+                WMStateWindowState::Withdrawn
+            };
+            self.set_wm_state(window, new_state)?;
         }
 
         maybe_change_mask(root_event_mask())

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -284,12 +284,16 @@ impl XWrap {
                 }
             }
 
-            // Set WM_STATE to iconic state.
-            if hiding_strategy == WindowHidingStrategy::Unmap
+            // make sure to always change the window state, so we don't forget
+            // to grab mouse button events when we show the window again.
+            let new_state = if hiding_strategy == WindowHidingStrategy::Unmap
                 || hiding_strategy == WindowHidingStrategy::MoveMinimize
             {
-                self.set_wm_states(window, &[ICONIC_STATE]);
-            }
+                ICONIC_STATE
+            } else {
+                WITHDRAWN_STATE
+            };
+            self.set_wm_states(window, &[new_state]);
         }
 
         maybe_change_mask(ROOT_EVENT_MASK);


### PR DESCRIPTION
When switching tags back and forth in `ClickTo` focus, we can't click to focus any windows. Only after the windows have come into focus through other means, are we able to click on them.

So when switching tags, windows are hidden using the `OnlyMove` strategy. In this case these windows are left in the `Normal` window state, even if they aren't visible. When we switch back to the original tag, we then don't call `toggle_window_visibility`, because we think there's nothing to do. This in turn means we don't call `grab_mouse_events` on these windows, so we're never receiving any click events that enable us to click to focus.

So when marking windows invisible, always make sure we take them out of the 'normal' state.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
