### PR TITLE
fix creating a scratchpad window on x11rb

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/getters.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/getters.rs
@@ -496,7 +496,7 @@ impl XWrap {
         r#type: xproto::Atom,
     ) -> Result<Vec<xproto::Atom>> {
         let res =
-            xproto::get_property(&self.conn, false, window, property, r#type, 0, 0)?.reply()?;
+            xproto::get_property(&self.conn, false, window, property, r#type, 0, 1)?.reply()?;
 
         let rt = match res.value32() {
             Some(props) => props.collect(),


### PR DESCRIPTION
On x11rb, scratchpad windows are handled like any normal window: the window doesn't float in the designated area, and is just added to the active tag's window stack. This is because the WindowCreate event doesn't receive a usable pid and due to that, the window can't be matched up to any of the active scratchpads.

This all happens because `xwrap::get_property` calls `xproto::get_property` with `0` as the last argument, which effectively tells it to return no items.

So set it to `1` instead.

fixes #1294

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
