### PR TITLE
x11rb: allow legacy name to not exist

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -26,7 +26,7 @@ impl XWrap {
         let handle = WindowHandle(X11rbWindowHandle(window));
         // Gather info about the window from xlib.
         let name = self.get_window_name(window)?;
-        let legacy_name = self.get_window_legacy_name(window)?;
+        let legacy_name = self.get_window_legacy_name(window).ok();
         let class = self.get_window_class(window)?;
         let pid = self.get_window_pid(window)?;
         let r#type = self.get_window_type(window)?;
@@ -43,7 +43,7 @@ impl XWrap {
             .as_ref()
             .and_then(|c| String::from_utf8(c.instance().to_vec()).ok());
         w.res_class = class.and_then(|c| String::from_utf8(c.class().to_vec()).ok());
-        w.legacy_name = Some(legacy_name);
+        w.legacy_name = legacy_name;
         w.r#type = r#type.clone();
         w.states = states;
         w.transient = trans.map(|h| WindowHandle(X11rbWindowHandle(h)));


### PR DESCRIPTION
When opening a dialog in a Qt application like wireshark, the dialog isn't mapped due to the fact that the window doesn't have a legacy name. In the case of wireshark, this blocks further use of the application.

We store the legacy name in an `Option`, so we should be able to deal with it being `None`. Translate any errors when fetching the legacy name into it just not being available, pretty much like the xlib backend does.

Fixes #1317 

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
