### PR TITLE
x11rb: getters: fix getting the output name

### DIFF
--- a/display-servers/x11rb-display-server/src/xwrap/getters.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/getters.rs
@@ -1,4 +1,4 @@
-use std::{backtrace::Backtrace, ffi::CStr};
+use std::backtrace::Backtrace;
 
 use leftwm_core::models::{
     BBox, DockArea, Screen, WindowHandle, WindowState, WindowType, XyhwChange,
@@ -166,11 +166,7 @@ impl XWrap {
                 })
                 .filter_map(|res| res.reply().ok())
                 .filter_map(|output_info| {
-                    //FIX: This always fails
-                    let name = match CStr::from_bytes_with_nul(&output_info.name) {
-                        Ok(name) => name.to_str().unwrap(),
-                        Err(_) => "output_name",
-                    };
+                    let name = std::str::from_utf8(&output_info.name).unwrap_or("output_name");
                     Some((
                         randr::get_crtc_info(
                             &self.conn,


### PR DESCRIPTION
Getting the output name always fails, as indicated by the `FIX` note, leading to leftwm-state to always say the current output is `"output_name"`.

This happens because we're assuming we're still doing ffi here and as such are trying to read a null-terminated string from some bytes. In fact the data isn't null-terminated, at least not here. And since there is no null-termination, the conversion always fails.

To get this to work, we can simply convert the data to `str` and drop the whole `CStr` use.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
