### PR TITLE
scratchpad_handler: remove try_bool macro

### DIFF
--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -182,18 +182,13 @@ fn is_scratchpad_visible<H: Handle, C: Config, SERVER: DisplayServer<H>>(
     manager: &Manager<H, C, SERVER>,
     scratchpad_name: &ScratchPadName,
 ) -> bool {
-    // Like Try operator but returns false and only works on `Option`s
-    macro_rules! try_bool {
-        ($cond:expr) => {
-            if let Some(value) = $cond {
-                value
-            } else {
-                return false;
-            }
-        };
-    }
-    let current_tag = try_bool!(manager.state.focus_manager.tag(0));
-    let scratchpad = try_bool!(manager.state.active_scratchpads.get(scratchpad_name));
+    let Some(current_tag) = manager.state.focus_manager.tag(0) else {
+        return false;
+    };
+
+    let Some(scratchpad) = manager.state.active_scratchpads.get(scratchpad_name) else {
+        return false;
+    };
 
     // Filter out all the non existing windows (invalid pid) and map to window
     // Check if any of them is in the current tag


### PR DESCRIPTION
Remove the try_bool macro definition and use and replace it with a let-else construction. I'm presuming the macro setup was written before 1.65, when let-else wasn't available yet. We can now reduce the implementation to about half the number of lines.

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
