### PR TITLE
update xmobar source url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ List of common dependencies for themes:
 [picom-pkg]: https://pkgs.org/download/picom
 [polybar-git]: https://github.com/polybar/polybar
 [polybar-pkg]: https://pkgs.org/download/polybar
-[xmobar-git]: https://github.com/jaor/xmobar
+[xmobar-git]: https://codeberg.org/xmobar/xmobar
 [xmobar-pkg]: https://pkgs.org/download/xmobar
 [lemonbar-git]: https://github.com/LemonBoy/bar
 [lemonbar-pkg]: https://pkgs.org/download/lemonbar


### PR DESCRIPTION
# Description

This updates the url for the xmobar repo in the README.md to codeberg as the github repo isn't existing anymore. Also see issue.

Fixes #1327

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [ ] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
