### PR TITLE
fix: block focus change when current window is fullscreen

### DIFF
--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -805,10 +805,15 @@ fn focus_window_change<H: Handle>(
     val: i32,
 ) -> Option<bool> {
     let is_handle = |x: &Window<H>| -> bool { x.handle == handle };
+    let is_fullscreen = helpers::relative_find(&to_reorder, is_handle, 0, true)?;
+    if is_fullscreen.is_fullscreen() {
+        // state.windows.append(&mut to_reorder);
+        state.handle_window_focus(&is_fullscreen.handle);
+        return Some(!is_fullscreen.is_fullscreen());
+    }
+    // For the Monocle layout and the deck in the MainAndDeck layout we want to also move windows up/down
+    // Not the best solution but results in desired behaviour
     if layout == Some(layouts::MONOCLE.to_string()).as_ref() {
-        // For Monocle we want to also move windows up/down
-        // Not the best solution but results
-        // in desired behaviour
         handle = helpers::relative_find(&to_reorder, is_handle, -val, true)?.handle;
         let _ = helpers::cycle_vec(&mut to_reorder, val);
     } else if layout == Some(layouts::MAIN_AND_DECK.to_string()).as_ref() {


### PR DESCRIPTION
# Description

When the currently focused window is fullscreen it is possible to move focus away from it. This can lead to a chaotic situation, especially, when one tries to un-fullscreen the window as this results in fullscreening the next focused window in the background.

Marking as draft because:
- [ ] Can't personally test, right now
- [ ] Unsure if this little fix is sufficient, or if we need to check in other places as well
- [ ] Want to write tests for this szenario (yes I know that this is kinda backwards :joy:)

Fixes #1329

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
