### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ With LeftWM, there are two types of configuration files:
   these settings out into themes, you can now easily tweak, switch, and share your experiences. This
   configuration is spread between `theme.ron` and related files contained within a theme's folder.
 
-**Note:** some example config and themes can be found in the share dir, e.g. `/usr/share/leftwm` oh Arch based disros.
+**Note:** some example config and themes can be found in the share dir, e.g. `/usr/share/leftwm` on Arch based disros.
 
 [ricing]: https://www.reddit.com/r/unixporn/comments/3iy3wd/stupid_question_what_is_ricing/
 


### PR DESCRIPTION
Fix spelling mistake on README ('oh' -> 'on')

# Description

Fixed a typo on line 95 of the README file ('oh' -> 'on')

## Type of change

- Documentation only update (no change to the actual codebase)