### PR TITLE
fix: include path in warning when path does not exists

### DIFF
--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -486,7 +486,7 @@ impl leftwm_core::Config for Config {
                         manager.config.theme_setting.load(absolute);
                         write_to_pipe(&mut return_pipe, "OK: Command executed successfully");
                     } else {
-                        tracing::warn!("Path submitted does not exist.");
+                        tracing::warn!("Path submitted does not exist: {}", value.trim());
                         write_to_pipe(&mut return_pipe, "ERROR: Path submitted does not exist");
                     }
                     manager.load_theme_config()


### PR DESCRIPTION
# Description

This small change enhances the warning message when a submitted path does not exist by including the actual path value.

## Type of change

- [X] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update
