### PR TITLE
feat!(MSRV): update edition to 2024, MSRV to 1.85.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Check MSRV
     strategy:
       matrix:
-        toolchain: ["1.83.0"]
+        toolchain: ["1.85.0"]
         target: ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
     uses: ./.github/workflows/check-msrv.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.5]
 ### Breaking Change 
 - feat(watchdog): deprecate leftwm-watchdog bin; gate leftwm behind feature (via #1324 by @mautamu)
+- feat(MSRV): update edition to 2024, MSRV to 1.85.0
 
 ### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,36 +43,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -89,16 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -111,15 +105,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -141,9 +135,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -153,18 +147,18 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -174,15 +168,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const_format"
@@ -285,7 +279,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -313,12 +307,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -444,14 +438,14 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -487,15 +481,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -549,9 +543,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lefthk-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c671622c3f29c33d4b0716da390cd5748a755906dee89134d0d07d55951683dd"
+version = "0.3.0"
 dependencies = [
  "inventory",
  "mio",
@@ -559,7 +551,7 @@ dependencies = [
  "ron",
  "serde",
  "signal-hook",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "x11-dl",
@@ -646,15 +638,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags",
  "libc",
@@ -743,36 +735,36 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -821,6 +813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,9 +838,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -851,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -861,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -874,11 +872,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -927,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_users"
@@ -999,21 +996,22 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
 dependencies = [
  "base64",
  "bitflags",
  "serde",
  "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustix"
@@ -1030,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1043,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1087,18 +1085,18 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1125,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1144,24 +1142,21 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1181,9 +1176,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1203,14 +1198,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -1256,12 +1251,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1299,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1326,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1338,25 +1332,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1383,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1394,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1492,9 +1493,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1546,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,11 +1579,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1589,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1631,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1613,10 +1651,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1631,6 +1681,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1697,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1655,6 +1717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,10 +1735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.7"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -1727,9 +1801,9 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xlib-display-server"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,18 +147,18 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -505,6 +505,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,9 +657,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags",
  "libc",
@@ -1030,15 +1041,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1075,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1207,7 +1218,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -1295,15 +1306,17 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -1744,9 +1757,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,8 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lefthk-core"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421be189d655a184af40049b70a917b87000bff5db76fa397c2444339cdbe2f"
 dependencies = [
  "inventory",
  "mio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+edition = "2024"
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 
 [profile.optimized]
 inherits = "release"

--- a/display-servers/x11rb-display-server/Cargo.toml
+++ b/display-servers/x11rb-display-server/Cargo.toml
@@ -3,8 +3,8 @@ name = "x11rb-display-server"
 description = "x11 backend for leftwm using pure rust + xcb specification"
 version = "0.1.4"
 license = "MIT"
-edition = "2021"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+edition = "2024"
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/display-servers/x11rb-display-server/src/error.rs
+++ b/display-servers/x11rb-display-server/src/error.rs
@@ -85,7 +85,7 @@ impl Display for ErrorKind {
 
 /// Implement From<T> for given error
 macro_rules! from_err {
-    ($e:ty, $kind:expr, $msg:literal) => {
+    ($e:ty, $kind:expr_2021, $msg:literal) => {
         impl core::convert::From<$e> for BackendError {
             fn from(value: $e) -> Self {
                 Self {

--- a/display-servers/x11rb-display-server/src/event_translate.rs
+++ b/display-servers/x11rb-display-server/src/event_translate.rs
@@ -2,14 +2,14 @@
 use std::backtrace::BacktraceStatus;
 
 use leftwm_core::{
+    DisplayEvent, Mode,
     models::{WindowChange, WindowHandle, WindowType, XyhwChange},
     utils::modmask_lookup::{Button, ModMask},
-    DisplayEvent, Mode,
 };
-use x11rb::protocol::{xproto, Event};
+use x11rb::protocol::{Event, xproto};
 
 use crate::xwrap::XWrap;
-use crate::{error::Result, X11rbWindowHandle};
+use crate::{X11rbWindowHandle, error::Result};
 
 mod client_message;
 mod property_notify;

--- a/display-servers/x11rb-display-server/src/event_translate/client_message.rs
+++ b/display-servers/x11rb-display-server/src/event_translate/client_message.rs
@@ -1,10 +1,10 @@
 use leftwm_core::{
-    models::{WindowChange, WindowHandle},
     Command, DisplayEvent,
+    models::{WindowChange, WindowHandle},
 };
 use x11rb::protocol::xproto;
 
-use crate::{xwrap::XWrap, X11rbWindowHandle};
+use crate::{X11rbWindowHandle, xwrap::XWrap};
 
 use crate::error::Result;
 

--- a/display-servers/x11rb-display-server/src/event_translate/property_notify.rs
+++ b/display-servers/x11rb-display-server/src/event_translate/property_notify.rs
@@ -1,11 +1,11 @@
 use leftwm_core::{
-    models::{WindowChange, WindowHandle, WindowType, Xyhw},
     DisplayEvent,
+    models::{WindowChange, WindowHandle, WindowType, Xyhw},
 };
 use x11rb::{properties::WmHints, protocol::xproto};
 
 use crate::xwrap::XWrap;
-use crate::{error::Result, X11rbWindowHandle};
+use crate::{X11rbWindowHandle, error::Result};
 
 pub(crate) fn from_event(
     event: &xproto::PropertyNotifyEvent,

--- a/display-servers/x11rb-display-server/src/lib.rs
+++ b/display-servers/x11rb-display-server/src/lib.rs
@@ -1,8 +1,8 @@
 //! x11rb backend for leftwm
 
 use leftwm_core::{
-    models::{Handle, Screen, TagId, WindowHandle, WindowState},
     Config, DisplayAction, DisplayEvent, DisplayServer, Mode, Window, Workspace,
+    models::{Handle, Screen, TagId, WindowHandle, WindowState},
 };
 use serde::{Deserialize, Serialize};
 use x11rb::protocol::xproto;
@@ -204,7 +204,9 @@ impl X11rbDisplayServer {
             let auto_derive_workspaces: bool = if config.auto_derive_workspaces() {
                 true
             } else if events.is_empty() {
-                tracing::warn!("No Workspace in Workspace config matches connected screen. Falling back to \"auto_derive_workspaces: true\".");
+                tracing::warn!(
+                    "No Workspace in Workspace config matches connected screen. Falling back to \"auto_derive_workspaces: true\"."
+                );
                 true
             } else {
                 false

--- a/display-servers/x11rb-display-server/src/xwrap/getters.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/getters.rs
@@ -10,12 +10,12 @@ use x11rb::{
 };
 
 use crate::{
+    X11rbWindowHandle,
     error::{BackendError, ErrorKind, Result},
     xatom::WMStateWindowState,
-    X11rbWindowHandle,
 };
 
-use super::{XWrap, MAX_PROPERTY_VALUE_LEN};
+use super::{MAX_PROPERTY_VALUE_LEN, XWrap};
 
 impl XWrap {
     // Public functions.

--- a/display-servers/x11rb-display-server/src/xwrap/mouse.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/mouse.rs
@@ -1,7 +1,7 @@
 //! Xlib calls related to a mouse.
 use x11rb::{protocol::xproto, x11_utils::Serialize};
 
-use super::{button_event_mask, mouse_event_mask, XWrap};
+use super::{XWrap, button_event_mask, mouse_event_mask};
 
 use crate::error::Result;
 

--- a/display-servers/x11rb-display-server/src/xwrap/setters.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/setters.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use leftwm_core::models::{TagId, WindowHandle};
 use x11rb::protocol::xproto::{self, ChangeWindowAttributesAux, PropMode};
 
-use crate::{error::Result, xatom, X11rbWindowHandle};
+use crate::{X11rbWindowHandle, error::Result, xatom};
 
 use super::XWrap;
 

--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -1,16 +1,16 @@
 //! Xlib calls related to a window.
 
 use leftwm_core::{
+    DisplayEvent, Window,
     config::WindowHidingStrategy,
     models::{WindowChange, WindowHandle, WindowType, Xyhw},
-    DisplayEvent, Window,
 };
 use x11rb::{protocol::xproto, x11_utils::Serialize};
 
 use crate::xatom::WMStateWindowState;
-use crate::{error::Result, X11rbWindowHandle};
+use crate::{X11rbWindowHandle, error::Result};
 
-use super::{root_event_mask, XWrap};
+use super::{XWrap, root_event_mask};
 
 impl XWrap {
     /// Sets up a window before we manage it.

--- a/display-servers/xlib-display-server/Cargo.toml
+++ b/display-servers/xlib-display-server/Cargo.toml
@@ -3,8 +3,8 @@ name = "xlib-display-server"
 version = "0.1.5"
 description = "A display server library for LeftWM" 
 license = "MIT"
-edition = "2021"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+edition = "2024"
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/display-servers/xlib-display-server/src/event_translate.rs
+++ b/display-servers/xlib-display-server/src/event_translate.rs
@@ -1,8 +1,8 @@
 use crate::XlibWindowHandle;
 
 use super::{
-    event_translate_client_message, event_translate_property_notify, xwrap::WITHDRAWN_STATE,
-    DisplayEvent, XWrap,
+    DisplayEvent, XWrap, event_translate_client_message, event_translate_property_notify,
+    xwrap::WITHDRAWN_STATE,
 };
 use leftwm_core::{
     models::{Mode, WindowChange, WindowHandle, WindowType, XyhwChange},

--- a/display-servers/xlib-display-server/src/event_translate_client_message.rs
+++ b/display-servers/xlib-display-server/src/event_translate_client_message.rs
@@ -2,7 +2,7 @@ use crate::XlibWindowHandle;
 
 use super::{DisplayEvent, XWrap};
 use leftwm_core::models::WindowHandle;
-use leftwm_core::{models::WindowChange, Command};
+use leftwm_core::{Command, models::WindowChange};
 use std::convert::TryFrom;
 use std::os::raw::c_long;
 

--- a/display-servers/xlib-display-server/src/lib.rs
+++ b/display-servers/xlib-display-server/src/lib.rs
@@ -183,7 +183,9 @@ impl XlibDisplayServer {
             let auto_derive_workspaces: bool = if config.auto_derive_workspaces() {
                 true
             } else if events.is_empty() {
-                tracing::warn!("No Workspace in Workspace config matches connected screen. Falling back to \"auto_derive_workspaces: true\".");
+                tracing::warn!(
+                    "No Workspace in Workspace config matches connected screen. Falling back to \"auto_derive_workspaces: true\"."
+                );
                 true
             } else {
                 false

--- a/display-servers/xlib-display-server/src/xwrap.rs
+++ b/display-servers/xlib-display-server/src/xwrap.rs
@@ -294,7 +294,7 @@ impl XWrap {
                 self.display,
                 self.root,
                 xlib::CWEventMask | xlib::CWCursor,
-                &mut attrs,
+                &raw mut attrs,
             );
         }
 
@@ -348,13 +348,13 @@ impl XWrap {
                 ptr,
                 clist_tags.len() as i32,
                 xlib::XUTF8StringStyle,
-                &mut text,
+                &raw mut text,
             );
             std::mem::forget(clist_tags);
             (self.xlib.XSetTextProperty)(
                 self.display,
                 self.root,
-                &mut text,
+                &raw mut text,
                 self.atoms.NetDesktopNames,
             );
         }
@@ -413,7 +413,7 @@ impl XWrap {
             let mut array: *mut xlib::Atom = std::mem::zeroed();
             let mut length: c_int = std::mem::zeroed();
             let status: xlib::Status =
-                (self.xlib.XGetWMProtocols)(self.display, window, &mut array, &mut length);
+                (self.xlib.XGetWMProtocols)(self.display, window, &raw mut array, &raw mut length);
             let protocols: &[xlib::Atom] = slice::from_raw_parts(array, length as usize);
             status > 0 && protocols.contains(&atom)
         }

--- a/display-servers/xlib-display-server/src/xwrap.rs
+++ b/display-servers/xlib-display-server/src/xwrap.rs
@@ -53,11 +53,7 @@ const X_POLYSEGMENT: u8 = 66;
 const X_POLYFILLRECTANGLE: u8 = 70;
 const X_POLYTEXT8: u8 = 74;
 
-// This is allowed for now as const extern fns
-// are not yet stable (1.56.0, 16 Sept 2021)
-// see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information.
-#[allow(clippy::missing_const_for_fn)]
-pub extern "C" fn on_error_from_xlib(_: *mut xlib::Display, er: *mut xlib::XErrorEvent) -> c_int {
+const extern "C" fn on_error_from_xlib(_: *mut xlib::Display, er: *mut xlib::XErrorEvent) -> c_int {
     let err = unsafe { *er };
     let ec = err.error_code;
     let rc = err.request_code;

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -1,5 +1,5 @@
 //! `XWrap` getters.
-use super::{Screen, WindowHandle, XlibError, MAX_PROPERTY_VALUE_LEN, MOUSEMASK};
+use super::{MAX_PROPERTY_VALUE_LEN, MOUSEMASK, Screen, WindowHandle, XlibError};
 use crate::{XWrap, XlibWindowHandle};
 use leftwm_core::models::{BBox, DockArea, WindowState, WindowType, XyhwChange};
 use std::ffi::{CStr, CString};
@@ -303,11 +303,7 @@ impl XWrap {
             let mut transient: xlib::Window = std::mem::zeroed();
             let status: c_int =
                 (self.xlib.XGetTransientForHint)(self.display, window, &mut transient);
-            if status > 0 {
-                Some(transient)
-            } else {
-                None
-            }
+            if status > 0 { Some(transient) } else { None }
         }
     }
 

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -43,7 +43,13 @@ impl XWrap {
             let cmap: xlib::Colormap = (self.xlib.XDefaultColormap)(self.display, screen);
             let color_cstr = CString::new(color).unwrap_or_default().into_raw();
             let mut color: xlib::XColor = std::mem::zeroed();
-            (self.xlib.XAllocNamedColor)(self.display, cmap, color_cstr, &mut color, &mut color);
+            (self.xlib.XAllocNamedColor)(
+                self.display,
+                cmap,
+                color_cstr,
+                &raw mut color,
+                &raw mut color,
+            );
             color.pixel
         }
     }
@@ -67,13 +73,13 @@ impl XWrap {
                 (self.xlib.XQueryPointer)(
                     self.display,
                     w,
-                    &mut root_return,
-                    &mut child_return,
-                    &mut root_x_return,
-                    &mut root_y_return,
-                    &mut win_x_return,
-                    &mut win_y_return,
-                    &mut mask_return,
+                    &raw mut root_return,
+                    &raw mut child_return,
+                    &raw mut root_x_return,
+                    &raw mut root_y_return,
+                    &raw mut win_x_return,
+                    &raw mut win_y_return,
+                    &raw mut mask_return,
                 )
             };
             if success > 0 {
@@ -102,13 +108,13 @@ impl XWrap {
                 (self.xlib.XQueryPointer)(
                     self.display,
                     w,
-                    &mut root_return,
-                    &mut child_return,
-                    &mut root_x_return,
-                    &mut root_y_return,
-                    &mut win_x_return,
-                    &mut win_y_return,
-                    &mut mask_return,
+                    &raw mut root_return,
+                    &raw mut child_return,
+                    &raw mut root_x_return,
+                    &raw mut root_y_return,
+                    &raw mut win_x_return,
+                    &raw mut win_y_return,
+                    &raw mut mask_return,
                 )
             };
             if success > 0 {
@@ -192,7 +198,7 @@ impl XWrap {
             (self.xlib.XMaskEvent)(
                 self.display,
                 MOUSEMASK | xlib::SubstructureRedirectMask | xlib::ExposureMask,
-                &mut event,
+                &raw mut event,
             );
             event
         }
@@ -204,7 +210,7 @@ impl XWrap {
     pub fn get_next_event(&self) -> xlib::XEvent {
         unsafe {
             let mut event: xlib::XEvent = std::mem::zeroed();
-            (self.xlib.XNextEvent)(self.display, &mut event);
+            (self.xlib.XNextEvent)(self.display, &raw mut event);
             event
         }
     }
@@ -259,7 +265,7 @@ impl XWrap {
             let root = self.get_default_root_handle();
             let mut screen_count = 0;
             let info_array_raw =
-                unsafe { (xlib.XineramaQueryScreens)(self.display, &mut screen_count) };
+                unsafe { (xlib.XineramaQueryScreens)(self.display, &raw mut screen_count) };
             // Take ownership of the array.
             let xinerama_infos: &[XineramaScreenInfo] =
                 unsafe { slice::from_raw_parts(info_array_raw, screen_count as usize) };
@@ -302,7 +308,7 @@ impl XWrap {
         unsafe {
             let mut transient: xlib::Window = std::mem::zeroed();
             let status: c_int =
-                (self.xlib.XGetTransientForHint)(self.display, window, &mut transient);
+                (self.xlib.XGetTransientForHint)(self.display, window, &raw mut transient);
             if status > 0 { Some(transient) } else { None }
         }
     }
@@ -325,11 +331,11 @@ impl XWrap {
                 MAX_PROPERTY_VALUE_LEN / 4,
                 xlib::False,
                 xlib::XA_ATOM,
-                &mut type_return,
-                &mut format_return,
-                &mut nitems_return,
-                &mut bytes_remaining,
-                &mut prop_return,
+                &raw mut type_return,
+                &raw mut format_return,
+                &raw mut nitems_return,
+                &raw mut bytes_remaining,
+                &raw mut prop_return,
             );
             if status == i32::from(xlib::Success) && !prop_return.is_null() {
                 #[allow(clippy::cast_lossless, clippy::cast_ptr_alignment)]
@@ -351,7 +357,8 @@ impl XWrap {
         window: xlib::Window,
     ) -> Result<xlib::XWindowAttributes, XlibError> {
         let mut attrs: xlib::XWindowAttributes = unsafe { std::mem::zeroed() };
-        let status = unsafe { (self.xlib.XGetWindowAttributes)(self.display, window, &mut attrs) };
+        let status =
+            unsafe { (self.xlib.XGetWindowAttributes)(self.display, window, &raw mut attrs) };
         if status == 0 {
             return Err(XlibError::FailedStatus);
         }
@@ -364,7 +371,7 @@ impl XWrap {
     pub fn get_window_class(&self, window: xlib::Window) -> Option<(String, String)> {
         unsafe {
             let mut class_return: xlib::XClassHint = std::mem::zeroed();
-            let status = (self.xlib.XGetClassHint)(self.display, window, &mut class_return);
+            let status = (self.xlib.XGetClassHint)(self.display, window, &raw mut class_return);
             if status == 0 {
                 return None;
             }
@@ -399,13 +406,13 @@ impl XWrap {
             let status = (self.xlib.XGetGeometry)(
                 self.display,
                 window,
-                &mut root_return,
-                &mut x_return,
-                &mut y_return,
-                &mut width_return,
-                &mut height_return,
-                &mut border_width_return,
-                &mut depth_return,
+                &raw mut root_return,
+                &raw mut x_return,
+                &raw mut y_return,
+                &raw mut width_return,
+                &raw mut height_return,
+                &raw mut border_width_return,
+                &raw mut depth_return,
             );
             if status == 0 {
                 return Err(XlibError::FailedStatus);
@@ -512,11 +519,11 @@ impl XWrap {
                 MAX_PROPERTY_VALUE_LEN / 4,
                 xlib::False,
                 xlib::XA_ATOM,
-                &mut type_return,
-                &mut format_return,
-                &mut nitems_return,
-                &mut bytes_remaining,
-                &mut prop_return,
+                &raw mut type_return,
+                &raw mut format_return,
+                &raw mut nitems_return,
+                &raw mut bytes_remaining,
+                &raw mut prop_return,
             );
             if status == i32::from(xlib::Success) && !prop_return.is_null() {
                 #[allow(clippy::cast_lossless, clippy::cast_ptr_alignment)]
@@ -617,8 +624,9 @@ impl XWrap {
     fn get_hint_sizing(&self, window: xlib::Window) -> Option<xlib::XSizeHints> {
         let mut xsize: xlib::XSizeHints = unsafe { std::mem::zeroed() };
         let mut msize: c_long = xlib::PSize;
-        let status =
-            unsafe { (self.xlib.XGetWMNormalHints)(self.display, window, &mut xsize, &mut msize) };
+        let status = unsafe {
+            (self.xlib.XGetWMNormalHints)(self.display, window, &raw mut xsize, &raw mut msize)
+        };
         match status {
             0 => None,
             _ => Some(xsize),
@@ -650,11 +658,11 @@ impl XWrap {
                 MAX_PROPERTY_VALUE_LEN / 4,
                 xlib::False,
                 r#type,
-                &mut type_return,
-                &mut format_return,
-                &mut nitems_return,
-                &mut bytes_after_return,
-                &mut prop_return,
+                &raw mut type_return,
+                &raw mut format_return,
+                &raw mut nitems_return,
+                &raw mut bytes_after_return,
+                &raw mut prop_return,
             );
             if status == i32::from(xlib::Success) && !prop_return.is_null() {
                 return Ok((prop_return, nitems_return));
@@ -667,7 +675,7 @@ impl XWrap {
     // `XRootWindowOfScreen`: https://tronche.com/gui/x/xlib/display/screen-information.html#RootWindowOfScreen
     fn get_roots(&self) -> impl Iterator<Item = xlib::Window> + '_ {
         self.get_xscreens()
-            .map(|mut s| unsafe { (self.xlib.XRootWindowOfScreen)(&mut s) })
+            .map(|mut s| unsafe { (self.xlib.XRootWindowOfScreen)(&raw mut s) })
     }
 
     /// Returns a text property for a window.
@@ -681,7 +689,7 @@ impl XWrap {
         unsafe {
             let mut text_prop: xlib::XTextProperty = std::mem::zeroed();
             let status: c_int =
-                (self.xlib.XGetTextProperty)(self.display, window, &mut text_prop, atom);
+                (self.xlib.XGetTextProperty)(self.display, window, &raw mut text_prop, atom);
             if status == 0 {
                 return Err(XlibError::FailedStatus);
             }
@@ -706,10 +714,10 @@ impl XWrap {
             let status: xlib::Status = (self.xlib.XQueryTree)(
                 self.display,
                 root,
-                &mut root_return,
-                &mut parent_return,
-                &mut array,
-                &mut length,
+                &raw mut root_return,
+                &raw mut parent_return,
+                &raw mut array,
+                &raw mut length,
             );
             let windows: &[xlib::Window] = slice::from_raw_parts(array, length as usize);
             match status {

--- a/display-servers/xlib-display-server/src/xwrap/mouse.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mouse.rs
@@ -1,7 +1,7 @@
 //! Xlib calls related to a mouse.
-use super::{XlibError, MOUSEMASK};
-use crate::xwrap::BUTTONMASK;
+use super::{MOUSEMASK, XlibError};
 use crate::XWrap;
+use crate::xwrap::BUTTONMASK;
 use std::os::raw::{c_int, c_uint, c_ulong};
 use x11_dl::xlib;
 

--- a/display-servers/xlib-display-server/src/xwrap/mouse.rs
+++ b/display-servers/xlib-display-server/src/xwrap/mouse.rs
@@ -146,13 +146,13 @@ impl XWrap {
                 (self.xlib.XQueryPointer)(
                     self.display,
                     event.window,
-                    &mut event.root,
-                    &mut event.subwindow,
-                    &mut event.x_root,
-                    &mut event.y_root,
-                    &mut event.x,
-                    &mut event.y,
-                    &mut event.state,
+                    &raw mut event.root,
+                    &raw mut event.subwindow,
+                    &raw mut event.x_root,
+                    &raw mut event.y_root,
+                    &raw mut event.x,
+                    &raw mut event.y,
+                    &raw mut event.state,
                 );
             }
 

--- a/display-servers/xlib-display-server/src/xwrap/setters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/setters.rs
@@ -179,7 +179,9 @@ impl XWrap {
         mut window_changes: xlib::XWindowChanges,
         unlock: u32,
     ) {
-        unsafe { (self.xlib.XConfigureWindow)(self.display, window, unlock, &mut window_changes) };
+        unsafe {
+            (self.xlib.XConfigureWindow)(self.display, window, unlock, &raw mut window_changes)
+        };
         self.sync();
     }
 

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -415,7 +415,7 @@ impl XWrap {
         mut attrs: xlib::XSetWindowAttributes,
     ) {
         unsafe {
-            (self.xlib.XChangeWindowAttributes)(self.display, window, mask, &mut attrs);
+            (self.xlib.XChangeWindowAttributes)(self.display, window, mask, &raw mut attrs);
         }
     }
 

--- a/display-servers/xlib-display-server/src/xwrap/window.rs
+++ b/display-servers/xlib-display-server/src/xwrap/window.rs
@@ -1,12 +1,12 @@
 //! Xlib calls related to a window.
 use super::{
-    on_error_from_xlib, on_error_from_xlib_dummy, Window, WindowHandle, ICONIC_STATE, NORMAL_STATE,
-    ROOT_EVENT_MASK, WITHDRAWN_STATE,
+    ICONIC_STATE, NORMAL_STATE, ROOT_EVENT_MASK, WITHDRAWN_STATE, Window, WindowHandle,
+    on_error_from_xlib, on_error_from_xlib_dummy,
 };
 use crate::{XWrap, XlibWindowHandle};
+use leftwm_core::DisplayEvent;
 use leftwm_core::config::WindowHidingStrategy;
 use leftwm_core::models::{WindowChange, WindowType, Xyhw, XyhwChange};
-use leftwm_core::DisplayEvent;
 use std::os::raw::{c_long, c_ulong};
 use x11_dl::xlib;
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1738652123,
-        "narHash": "sha256-zdZek5FXK/k95J0vnLF0AMnYuZl4AjARq83blKuJBYY=",
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c7e015a5fcefb070778c7d91734768680188a9cd",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {
@@ -50,14 +50,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {
@@ -75,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738722444,
-        "narHash": "sha256-DHVyKCiIQVDqjYoVU2j7UaLNIlOnpB9sP1cPRNRpqvY=",
+        "lastModified": 1751338093,
+        "narHash": "sha256-/yd9nPcTfUZPFtwjRbdB5yGLdt3LTPqz6Ja63Joiahs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "347fb01821c3cd8d54e563d244a599c1e27a393d",
+        "rev": "6cfb7821732dac2d3e2dea857a5613d3b856c20c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1750266157,
-        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "lastModified": 1752859226,
+        "narHash": "sha256-Vk9qUd0pCkyJZiSDRxJBEDkxEr8CNcwBtuFuZr/HYNc=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
+        "rev": "126943a6f7b7c6535c0348fe3ba472c3b19f0e20",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751338093,
-        "narHash": "sha256-/yd9nPcTfUZPFtwjRbdB5yGLdt3LTPqz6Ja63Joiahs=",
+        "lastModified": 1752892850,
+        "narHash": "sha256-LLvDqLiK2+dr7bQqKTnZIZ8F1H67DLt3FUyVrGolGVw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6cfb7821732dac2d3e2dea857a5613d3b856c20c",
+        "rev": "742248f12aed0183a124637e8b27a238a47f46a2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,18 @@
     };
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = inputs@{ self, flake-parts, rust-overlay, crane, nixpkgs, ... }:
+  outputs =
+    inputs@{
+      self,
+      flake-parts,
+      rust-overlay,
+      crane,
+      nixpkgs,
+      ...
+    }:
     let
       GIT_HASH = self.shortRev or self.dirtyShortRev;
     in
@@ -22,7 +29,8 @@
         "aarch64-linux"
       ];
 
-      perSystem = { pkgs, system, ... }:
+      perSystem =
+        { pkgs, system, ... }:
         let
           pkgs = import nixpkgs {
             inherit system;
@@ -45,21 +53,27 @@
 
           craneLib = (crane.mkLib pkgs).overrideToolchain pkgs.rust-bin.stable.latest.minimal;
 
-          cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
-            panme = "leftwm-deps";
-          });
+          cargoArtifacts = craneLib.buildDepsOnly (
+            commonArgs
+            // {
+              panme = "leftwm-deps";
+            }
+          );
 
-          leftwm = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
+          leftwm = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
 
-            postFixup = ''
-              for p in $out/bin/left*; do
-                patchelf --set-rpath "${pkgs.lib.makeLibraryPath commonArgs.buildInputs}" $p
-              done
-            '';
+              postFixup = ''
+                for p in $out/bin/left*; do
+                  patchelf --set-rpath "${pkgs.lib.makeLibraryPath commonArgs.buildInputs}" $p
+                done
+              '';
 
-            NIX_CFLAGS_LINK = "-fuse-ld=mold";
-          });
+              NIX_CFLAGS_LINK = "-fuse-ld=mold";
+            }
+          );
         in
         {
 
@@ -70,37 +84,39 @@
           };
 
           # `nix develop`
-          devShells.default = pkgs.mkShell
-            {
-              NIX_CFLAGS_LINK = "-fuse-ld=mold";
+          devShells.default = pkgs.mkShell {
+            NIX_CFLAGS_LINK = "-fuse-ld=mold";
 
-              buildInputs = with pkgs;[
+            buildInputs =
+              with pkgs;
+              [
                 mold
                 clang
                 pkg-config
                 systemd
-              ] ++ commonArgs.buildInputs;
-              nativeBuildInputs = with pkgs; [
-                gnumake
-                (rust-bin.stable.latest.default.override {
-                  extensions = [
-                    "cargo"
-                    "clippy"
-                    "rust-src"
-                    "rust-analyzer"
-                    "rustc"
-                    "rustfmt"
-                  ];
-                })
-                virt-viewer
-              ];
+              ]
+              ++ commonArgs.buildInputs;
+            nativeBuildInputs = with pkgs; [
+              gnumake
+              (rust-bin.stable.latest.default.override {
+                extensions = [
+                  "cargo"
+                  "clippy"
+                  "rust-src"
+                  "rust-analyzer"
+                  "rustc"
+                  "rustfmt"
+                ];
+              })
+              virt-viewer
+            ];
 
-              shellHook = ''
-                source ./.nixos-vm/vm.sh
-              '';
+            shellHook = ''
+              source ./.nixos-vm/vm.sh
+            '';
 
-              inherit GIT_HASH;
-            };
+            inherit GIT_HASH;
+          };
         };
 
       flake = {
@@ -110,19 +126,18 @@
         };
 
         # nixos development vm
-        nixosConfigurations.leftwm = nixpkgs.lib.nixosSystem
-          {
-            system = "x86_64-linux";
-            modules = [
-              {
-                nixpkgs.overlays = [
-                  self.overlays.default
-                ];
-              }
-              "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix"
-              ./.nixos-vm/configuration.nix
-            ];
-          };
+        nixosConfigurations.leftwm = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            {
+              nixpkgs.overlays = [
+                self.overlays.default
+              ];
+            }
+            "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix"
+            ./.nixos-vm/configuration.nix
+          ];
+        };
       };
     };
 }

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -16,7 +16,7 @@ dirs-next = "2.0.0"
 futures = "0.3.21"
 tracing = "0.1.37"
 mio = { version = "1.0.2", features = ["os-ext"] }
-nix = {version = "0.29.0", features = ["fs", "signal"]}
+nix = {version = "0.30.1", features = ["fs", "signal"]}
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = "1.0.44"
 signal-hook = "0.3.4"
@@ -32,7 +32,7 @@ tokio = { version = "1.43.1", features = [
 ] }
 leftwm-layouts = "0.9.1"
 x11-dl = "2.18.4"
-xdg = "2.2.0"
+xdg = "3.0.0"
 bitflags = "2.4.2"
 
 [dev-dependencies]

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "leftwm-core"
 version = "0.5.4"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["data-structures", "gui"]
-edition = "2021"
+edition = "2024"
 keywords = ["wm", "window", "manager"]
 license = "MIT"
 readme = "README.md"

--- a/leftwm-core/src/display_event.rs
+++ b/leftwm-core/src/display_event.rs
@@ -1,6 +1,6 @@
-use super::{models::Screen, models::Window, models::WindowHandle, Button, ModMask};
-use crate::models::{Handle, WindowChange};
+use super::{Button, ModMask, models::Screen, models::Window, models::WindowHandle};
 use crate::Command;
+use crate::models::{Handle, WindowChange};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]

--- a/leftwm-core/src/display_servers.rs
+++ b/leftwm-core/src/display_servers.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod mock_display_server;
 
+use crate::DisplayEvent;
 use crate::config::Config;
 use crate::display_action::DisplayAction;
 use crate::models::Handle;
 use crate::models::Window;
 use crate::models::WindowHandle;
 use crate::models::Workspace;
-use crate::DisplayEvent;
 
 use futures::prelude::*;
 use std::pin::Pin;

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -1,10 +1,10 @@
 use crate::models::Handle;
-use crate::{child_process::Nanny, config::Config};
 use crate::{
     Command, CommandPipe, DisplayEvent, DisplayServer, Manager, Mode, StateSocket, Window,
 };
+use crate::{child_process::Nanny, config::Config};
 use std::path::{Path, PathBuf};
-use std::sync::{atomic::Ordering, Once};
+use std::sync::{Once, atomic::Ordering};
 
 use tracing::error;
 
@@ -215,6 +215,6 @@ where
 }
 
 async fn timeout(mills: u64) {
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{Duration, sleep};
     sleep(Duration::from_millis(mills)).await;
 }

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -211,7 +211,7 @@ fn place_runtime_file<P>(path: P) -> std::io::Result<PathBuf>
 where
     P: AsRef<Path>,
 {
-    xdg::BaseDirectories::with_prefix("leftwm")?.place_runtime_file(path)
+    xdg::BaseDirectories::with_prefix("leftwm").place_runtime_file(path)
 }
 
 async fn timeout(mills: u64) {

--- a/leftwm-core/src/handlers.rs
+++ b/leftwm-core/src/handlers.rs
@@ -8,9 +8,9 @@ mod window_handler;
 mod window_move_handler;
 mod window_resize_handler;
 
+use super::DisplayEvent;
 use super::command::Command;
 use super::config::Config;
 use super::models::{
     Manager, Mode, Screen, Window, WindowChange, WindowHandle, WindowType, Workspace,
 };
-use super::DisplayEvent;

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -34,7 +34,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
 }
 
 macro_rules! move_focus_common_vars {
-    ($func:ident ($state:expr $(, $arg:expr )* $(,)? )) => {{
+    ($func:ident ($state:expr_2021 $(, $arg:expr_2021 )* $(,)? )) => {{
         let handle = $state.focus_manager.window(&$state.windows)?.handle;
         let tag_id = $state.focus_manager.tag(0)?;
         let ws_id = $state.focus_manager.workspace(&$state.workspaces)?.id;

--- a/leftwm-core/src/handlers/command_handler.rs
+++ b/leftwm-core/src/handlers/command_handler.rs
@@ -1003,20 +1003,24 @@ mod tests {
             );
         }
 
-        assert!(!manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Fullscreen)));
+        assert!(
+            !manager
+                .state
+                .windows
+                .iter()
+                .any(|w| w.states.contains(&WindowState::Fullscreen))
+        );
 
         manager.command_handler(&Command::ToggleFullScreen);
 
         mock_update(&mut manager);
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Fullscreen)));
+        assert!(
+            manager
+                .state
+                .windows
+                .iter()
+                .any(|w| w.states.contains(&WindowState::Fullscreen))
+        );
     }
 
     #[test]
@@ -1032,20 +1036,24 @@ mod tests {
             );
         }
 
-        assert!(!manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Maximized)));
+        assert!(
+            !manager
+                .state
+                .windows
+                .iter()
+                .any(|w| w.states.contains(&WindowState::Maximized))
+        );
 
         manager.command_handler(&Command::ToggleMaximized);
 
         mock_update(&mut manager);
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .any(|w| w.states.contains(&WindowState::Maximized)));
+        assert!(
+            manager
+                .state
+                .windows
+                .iter()
+                .any(|w| w.states.contains(&WindowState::Maximized))
+        );
     }
 
     #[test]

--- a/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
+++ b/leftwm-core/src/handlers/command_handler/scratchpad_handler.rs
@@ -8,9 +8,9 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    child_process::{exec_shell_with_args, ChildID},
-    models::{Handle, ScratchPadName, TagId, WindowHandle},
     Command, Config, DisplayAction, DisplayServer, Manager, Window,
+    child_process::{ChildID, exec_shell_with_args},
+    models::{Handle, ScratchPadName, TagId, WindowHandle},
 };
 
 /// Describes the options for the release scratchpad command
@@ -703,10 +703,12 @@ mod tests {
         });
 
         // Assert
-        assert!(!manager
-            .state
-            .active_scratchpads
-            .contains_key(&scratchpad_name));
+        assert!(
+            !manager
+                .state
+                .active_scratchpads
+                .contains_key(&scratchpad_name)
+        );
         assert_eq!(
             *manager.state.focus_manager.tag_history.front().unwrap(),
             expected_tag
@@ -759,23 +761,27 @@ mod tests {
             .get_mut(&scratchpad_name)
             .unwrap();
 
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .find(|w| w.pid == Some(mock_window1))
-            .map(|w| !w.has_tag(&nsp_tag))
-            .unwrap());
-        for mock_window_pid in [mock_window2, mock_window3] {
-            let window_pid = scratchpad.pop_front();
-            assert_eq!(window_pid, Some(mock_window_pid));
-            assert!(!manager
+        assert!(
+            manager
                 .state
                 .windows
                 .iter()
-                .find(|w| w.pid == window_pid)
-                .map(|w| w.has_tag(&nsp_tag))
-                .unwrap());
+                .find(|w| w.pid == Some(mock_window1))
+                .map(|w| !w.has_tag(&nsp_tag))
+                .unwrap()
+        );
+        for mock_window_pid in [mock_window2, mock_window3] {
+            let window_pid = scratchpad.pop_front();
+            assert_eq!(window_pid, Some(mock_window_pid));
+            assert!(
+                !manager
+                    .state
+                    .windows
+                    .iter()
+                    .find(|w| w.pid == window_pid)
+                    .map(|w| w.has_tag(&nsp_tag))
+                    .unwrap()
+            );
         }
         assert_eq!(scratchpad.pop_front(), None);
 
@@ -836,23 +842,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(scratchpad.pop_front(), Some(mock_window1));
-        assert!(manager
-            .state
-            .windows
-            .iter()
-            .find(|w| w.pid == Some(mock_window1))
-            .map(|w| !w.has_tag(&nsp_tag))
-            .unwrap());
-        for mock_window_pid in [mock_window2, mock_window3] {
-            let window_pid = scratchpad.pop_front();
-            assert_eq!(window_pid, Some(mock_window_pid));
-            assert!(manager
+        assert!(
+            manager
                 .state
                 .windows
                 .iter()
-                .find(|w| w.pid == window_pid)
-                .map(|w| w.has_tag(&nsp_tag))
-                .unwrap());
+                .find(|w| w.pid == Some(mock_window1))
+                .map(|w| !w.has_tag(&nsp_tag))
+                .unwrap()
+        );
+        for mock_window_pid in [mock_window2, mock_window3] {
+            let window_pid = scratchpad.pop_front();
+            assert_eq!(window_pid, Some(mock_window_pid));
+            assert!(
+                manager
+                    .state
+                    .windows
+                    .iter()
+                    .find(|w| w.pid == window_pid)
+                    .map(|w| w.has_tag(&nsp_tag))
+                    .unwrap()
+            );
         }
         assert_eq!(scratchpad.pop_front(), None);
     }
@@ -1017,11 +1027,8 @@ mod tests {
             .get(&scratchpad_name)
             .unwrap()
             .iter();
-        assert!(is_only_first_visible(
-            &manager,
-            scratchpad_iterator.clone().copied(),
-            nsp_tag
-        ),
+        assert!(
+            is_only_first_visible(&manager, scratchpad_iterator.clone().copied(), nsp_tag),
             "On the second forward cycle, the first window is not visible or the other windows are visible"
         );
         assert_eq!(scratchpad_iterator.next(), Some(&mock_window3));
@@ -1036,11 +1043,8 @@ mod tests {
             .get(&scratchpad_name)
             .unwrap()
             .iter();
-        assert!(is_only_first_visible(
-            &manager,
-            scratchpad_iterator.clone().copied(),
-            nsp_tag
-        ),
+        assert!(
+            is_only_first_visible(&manager, scratchpad_iterator.clone().copied(), nsp_tag),
             "After 2 forward and 1 backward cycles, the first window is not visible or the other windows are visible"
         );
         assert_eq!(scratchpad_iterator.next(), Some(&mock_window2));
@@ -1055,11 +1059,8 @@ mod tests {
             .get(&scratchpad_name)
             .unwrap()
             .iter();
-        assert!(is_only_first_visible(
-            &manager,
-            scratchpad_iterator.clone().copied(),
-            nsp_tag
-        ),
+        assert!(
+            is_only_first_visible(&manager, scratchpad_iterator.clone().copied(), nsp_tag),
             "After 2 forward and 2 backward cycles, the first window is not visible or the other windows are visible"
         );
         assert_eq!(scratchpad_iterator.next(), Some(&mock_window1));

--- a/leftwm-core/src/handlers/display_event_handler.rs
+++ b/leftwm-core/src/handlers/display_event_handler.rs
@@ -1,8 +1,8 @@
 use super::{Config, DisplayEvent, Manager, Mode};
+use crate::State;
 use crate::display_action::DisplayAction;
 use crate::display_servers::DisplayServer;
 use crate::models::{Handle, WindowHandle, WindowState};
-use crate::State;
 
 impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
     /// Process a collection of events, and apply changes to a manager.

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -279,7 +279,7 @@ fn distance<H: Handle>(window: &Window<H>, x: i32, y: i32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{models::MockHandle, Manager};
+    use crate::{Manager, models::MockHandle};
 
     #[test]
     fn focusing_a_workspace_should_make_it_active() {

--- a/leftwm-core/src/handlers/goto_tag_handler.rs
+++ b/leftwm-core/src/handlers/goto_tag_handler.rs
@@ -41,8 +41,8 @@ impl<H: Handle> State<H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::Screen;
     use crate::Manager;
+    use crate::models::Screen;
 
     #[test]
     fn going_to_a_workspace_that_is_already_visible_should_not_duplicate_the_workspace() {

--- a/leftwm-core/src/handlers/screen_create_handler.rs
+++ b/leftwm-core/src/handlers/screen_create_handler.rs
@@ -23,7 +23,9 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
 
         let mut new_workspace = Workspace::new(screen.bbox, workspace_id);
         if self.state.workspaces.len() >= tag_len {
-            tracing::warn!("The number of workspaces needs to be less than or equal to the number of tags available. No more workspaces will be added.");
+            tracing::warn!(
+                "The number of workspaces needs to be less than or equal to the number of tags available. No more workspaces will be added."
+            );
         }
         new_workspace.load_config(&self.config);
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -517,9 +517,9 @@ fn update_workspace_avoid_list<H: Handle>(state: &mut State<H>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Manager;
     use crate::layouts::MONOCLE;
     use crate::models::{MockHandle, Screen};
-    use crate::Manager;
 
     #[test]
     fn insert_behavior_bottom_add_window_at_the_end_of_the_stack() {

--- a/leftwm-core/src/layouts/layout_manager.rs
+++ b/leftwm-core/src/layouts/layout_manager.rs
@@ -61,7 +61,11 @@ impl LayoutManager {
                             .and_modify(|layouts| layouts.push(layout.clone()))
                             .or_insert_with(|| vec![layout.clone()]);
                     } else {
-                        tracing::warn!("There is no Layout with the name {:?}, but was configured on workspace {:?}", ws_layout_name, wsid);
+                        tracing::warn!(
+                            "There is no Layout with the name {:?}, but was configured on workspace {:?}",
+                            ws_layout_name,
+                            wsid
+                        );
                     }
                 }
             }
@@ -82,7 +86,11 @@ impl LayoutManager {
                         })
                         .or_insert_with(|| vec![layout.clone()]);
                 } else {
-                    tracing::warn!("There is no Layout with the name {:?}, but was configured as default on workspace {:?}", default_layout, wsid);
+                    tracing::warn!(
+                        "There is no Layout with the name {:?}, but was configured as default on workspace {:?}",
+                        default_layout,
+                        wsid
+                    );
                 }
             }
         }

--- a/leftwm-core/src/lib.rs
+++ b/leftwm-core/src/lib.rs
@@ -41,6 +41,6 @@ pub use models::Window;
 pub use models::Workspace;
 pub use state::State;
 pub use utils::child_process;
-pub use utils::command_pipe::{pipe_name, CommandPipe};
+pub use utils::command_pipe::{CommandPipe, pipe_name};
 pub use utils::return_pipe::ReturnPipe;
 pub use utils::state_socket::StateSocket;

--- a/leftwm-core/src/models/focus_manager.rs
+++ b/leftwm-core/src/models/focus_manager.rs
@@ -1,11 +1,11 @@
 use crate::config::Config;
-use crate::{models::TagId, models::WindowHandle, Window, Workspace};
+use crate::{Window, Workspace, models::TagId, models::WindowHandle};
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
-use super::window::Handle;
 use super::MaybeWindowHandle;
+use super::window::Handle;
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FocusBehaviour {

--- a/leftwm-core/src/models/manager.rs
+++ b/leftwm-core/src/models/manager.rs
@@ -5,7 +5,7 @@ use crate::config::Config;
 use crate::display_servers::DisplayServer;
 use crate::state::State;
 use crate::utils::child_process::Children;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use super::Handle;
 
@@ -169,11 +169,11 @@ mod pr_1301_issue {
     use leftwm_layouts::layouts::Layouts;
 
     use crate::{
+        Manager,
         config::tests::TestConfig,
         display_servers::MockDisplayServer,
         layouts,
         models::{BBox, MockHandle, Screen},
-        Manager,
     };
 
     fn test_config() -> TestConfig {

--- a/leftwm-core/src/models/screen.rs
+++ b/leftwm-core/src/models/screen.rs
@@ -1,4 +1,4 @@
-use super::{window::Handle, DockArea, WindowHandle, WorkspaceId};
+use super::{DockArea, WindowHandle, WorkspaceId, window::Handle};
 use crate::config::Workspace;
 use serde::{Deserialize, Serialize};
 use std::convert::From;

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -1,5 +1,5 @@
 use super::{Handle, TagId, Xyhw};
-use crate::{layouts::LayoutManager, Window, Workspace};
+use crate::{Window, Workspace, layouts::LayoutManager};
 use serde::{Deserialize, Serialize};
 
 /// Wrapper struct holding all the tags.

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -5,12 +5,12 @@ use std::fmt::Debug;
 
 use super::WindowState;
 use super::WindowType;
+use crate::Workspace;
 use crate::config::WindowHidingStrategy;
 use crate::models::Margins;
 use crate::models::TagId;
 use crate::models::Xyhw;
 use crate::models::XyhwBuilder;
-use crate::Workspace;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -274,11 +274,7 @@ impl<H: Handle> Window<H> {
 
     #[must_use]
     pub fn border(&self) -> i32 {
-        if self.is_fullscreen() {
-            0
-        } else {
-            self.border
-        }
+        if self.is_fullscreen() { 0 } else { self.border }
     }
 
     #[must_use]

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -1,5 +1,6 @@
 //! Save and restore manager state.
 
+use crate::DisplayAction;
 use crate::child_process::ChildID;
 use crate::config::{Config, InsertBehavior, ScratchPad};
 use crate::layouts::LayoutManager;
@@ -7,7 +8,6 @@ use crate::models::{
     FocusManager, Handle, Mode, ScratchPadName, Screen, Tags, Window, WindowHandle, WindowState,
     WindowType, Workspace,
 };
-use crate::DisplayAction;
 use leftwm_layouts::Layout;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -41,20 +41,16 @@ impl Nanny {
     /// 3. string identifying the desktop environments in `NotShowIn`
     ///
     /// The string identifying the desktop environments means `$XDG_CURRENT_DESKTOP`,
-    /// you can find some from [Registered `OnlyShowIn` Environments](https://specifications.freedesktop.org/menu-spec/latest/apb.html).  
+    /// you can find some from [Registered `OnlyShowIn` Environments](https://specifications.freedesktop.org/menu-spec/latest/apb.html).\
     /// `LeftWM` use **`LeftWM`** as identification (case-sensitive).
     #[must_use]
     pub fn autostart() -> Children {
         BaseDirectories::new()
-            .map(|xdg_dir| {
-                xdg_dir
-                    .list_config_files_once("autostart")
-                    .iter()
-                    .filter(|path| path.extension() == Some(std::ffi::OsStr::new("desktop")))
-                    .filter_map(|file| boot_desktop_file(file).ok())
-                    .collect::<Children>()
-            })
-            .unwrap_or_default()
+            .list_config_files_once("autostart")
+            .iter()
+            .filter(|path| path.extension() == Some(std::ffi::OsStr::new("desktop")))
+            .filter_map(|file| boot_desktop_file(file).ok())
+            .collect::<Children>()
     }
 
     /// Retrieve the path to the config directory. Tries to create it if it does not exist.
@@ -64,7 +60,7 @@ impl Nanny {
     /// Will error if unable to open or create the config directory.
     /// Could be caused by inadequate permissions.
     fn get_config_dir() -> Result<PathBuf> {
-        BaseDirectories::with_prefix("leftwm")?
+        BaseDirectories::with_prefix("leftwm")
             .create_config_directory("")
             .map_err(Into::into)
     }

--- a/leftwm-core/src/utils/child_process.rs
+++ b/leftwm-core/src/utils/child_process.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::iter::{Extend, FromIterator};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{Arc, atomic::AtomicBool};
 use tracing::error;
 use xdg::BaseDirectories;
 

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -1,7 +1,7 @@
 //! Creates a pipe to listen for external commands.
 use crate::models::{Handle, TagId};
 use crate::utils::return_pipe::ReturnPipe;
-use crate::{command, Command, ReleaseScratchPadOption};
+use crate::{Command, ReleaseScratchPadOption, command};
 use leftwm_layouts::geometry::Direction as FocusDirection;
 use std::error::Error;
 use std::fs::OpenOptions;

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -93,16 +93,15 @@ async fn read_from_pipe<H: Handle>(
                     cmd
                 } else {
                     let file_name = ReturnPipe::pipe_name();
-                    if let Ok(file_path) = BaseDirectories::with_prefix("leftwm") {
-                        if let Some(file_path) = file_path.find_runtime_file(&file_name) {
-                            if let Ok(mut file) = OpenOptions::new().append(true).open(file_path) {
-                                if let Err(e) = writeln!(file, "OK: command executed successfully")
-                                {
-                                    tracing::error!("Unable to write to return pipe: {e}");
-                                }
+                    let file_path = BaseDirectories::with_prefix("leftwm");
+                    if let Some(file_path) = file_path.find_runtime_file(&file_name) {
+                        if let Ok(mut file) = OpenOptions::new().append(true).open(file_path) {
+                            if let Err(e) = writeln!(file, "OK: command executed successfully") {
+                                tracing::error!("Unable to write to return pipe: {e}");
                             }
                         }
                     }
+
                     cmd
                 }
             }
@@ -110,12 +109,11 @@ async fn read_from_pipe<H: Handle>(
                 tracing::error!("An error occurred while parsing the command: {}", err);
                 // return to stdout
                 let file_name = ReturnPipe::pipe_name();
-                if let Ok(file_path) = BaseDirectories::with_prefix("leftwm") {
-                    if let Some(file_path) = file_path.find_runtime_file(file_name) {
-                        if let Ok(mut file) = OpenOptions::new().append(true).open(file_path) {
-                            if let Err(e) = writeln!(file, "ERROR: Error parsing command: {err}") {
-                                tracing::error!("Unable to write error to return pipe: {e}");
-                            }
+                let file_path = BaseDirectories::with_prefix("leftwm");
+                if let Some(file_path) = file_path.find_runtime_file(file_name) {
+                    if let Ok(mut file) = OpenOptions::new().append(true).open(file_path) {
+                        if let Err(e) = writeln!(file, "ERROR: Error parsing command: {err}") {
+                            tracing::error!("Unable to write error to return pipe: {e}");
                         }
                     }
                 }

--- a/leftwm-core/src/utils/modmask_lookup.rs
+++ b/leftwm-core/src/utils/modmask_lookup.rs
@@ -1,5 +1,5 @@
 use bitflags::bitflags;
-use serde::{de::Visitor, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Visitor};
 
 bitflags! {
     /// Represents the state of modifier keys

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -1,6 +1,6 @@
 use crate::errors::{LeftError, Result};
-use crate::models::dto::ManagerState;
 use crate::models::Handle;
+use crate::models::dto::ManagerState;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
@@ -88,12 +88,13 @@ impl StateSocket {
 
     async fn build_listener(&self) -> Result<tokio::task::JoinHandle<()>> {
         let state = self.state.clone();
-        let listener = match UnixListener::bind(&self.socket_file) { Ok(m) => {
-            m
-        } _ => {
-            fs::remove_file(&self.socket_file).await?;
-            UnixListener::bind(&self.socket_file)?
-        }};
+        let listener = match UnixListener::bind(&self.socket_file) {
+            Ok(m) => m,
+            _ => {
+                fs::remove_file(&self.socket_file).await?;
+                UnixListener::bind(&self.socket_file)?
+            }
+        };
 
         Ok(tokio::spawn(async move {
             loop {
@@ -114,8 +115,8 @@ impl StateSocket {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::utils::helpers::test::temp_path;
     use crate::Manager;
+    use crate::utils::helpers::test::temp_path;
     use tokio::io::{AsyncBufReadExt, BufReader};
 
     #[tokio::test]

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -88,12 +88,11 @@ impl StateSocket {
 
     async fn build_listener(&self) -> Result<tokio::task::JoinHandle<()>> {
         let state = self.state.clone();
-        let listener = match UnixListener::bind(&self.socket_file) {
-            Ok(m) => m,
-            _ => {
-                fs::remove_file(&self.socket_file).await?;
-                UnixListener::bind(&self.socket_file)?
-            }
+        let listener = if let Ok(m) = UnixListener::bind(&self.socket_file) {
+            m
+        } else {
+            fs::remove_file(&self.socket_file).await?;
+            UnixListener::bind(&self.socket_file)?
         };
 
         Ok(tokio::spawn(async move {

--- a/leftwm-core/src/utils/state_socket.rs
+++ b/leftwm-core/src/utils/state_socket.rs
@@ -88,12 +88,12 @@ impl StateSocket {
 
     async fn build_listener(&self) -> Result<tokio::task::JoinHandle<()>> {
         let state = self.state.clone();
-        let listener = if let Ok(m) = UnixListener::bind(&self.socket_file) {
+        let listener = match UnixListener::bind(&self.socket_file) { Ok(m) => {
             m
-        } else {
+        } _ => {
             fs::remove_file(&self.socket_file).await?;
             UnixListener::bind(&self.socket_file)?
-        };
+        }};
 
         Ok(tokio::spawn(async move {
             loop {

--- a/leftwm-macros/Cargo.toml
+++ b/leftwm-macros/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "leftwm-macros"
 version = "0.5.4"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["development-tools::procedural-macro-helpers"]
-edition = "2021"
+edition = "2024"
 keywords = ["wm", "window", "manager"]
 license = "MIT"
 readme = "README.md"

--- a/leftwm-macros/src/lib.rs
+++ b/leftwm-macros/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Error};
+use syn::{Data, DeriveInput, Error, parse_macro_input};
 
 use std::fmt::Write;
 

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "leftwm"
 version = "0.5.4"
-rust-version = "1.83.0" # MSRV MINIMUM SUPPORTED RUST VERSION
+rust-version = "1.85.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 authors = ["Lex Childs <lexchilds@gmail.com>"]
 categories = ["gui"]
-edition = "2021"
+edition = "2024"
 keywords = ["wm", "window", "manager"]
 license = "MIT"
 readme = "README.md"

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -27,15 +27,15 @@ once_cell = "1.13.0"
 dirs-next = "2.0.0"
 futures = "0.3.21"
 git-version = "0.3.5"
-lefthk-core = { version = '0.2', optional = true }
+lefthk-core = { version = '0.3', optional = true }
 leftwm-core = { path = "../leftwm-core", version = '0.5.4' }
 leftwm-macros = {path = "../leftwm-macros", version = '0.5.4'}
 leftwm-layouts = "0.9.1"
 liquid = "0.26.9"
 mio = "1.0.2"
-nix = { version = "0.29.0", features = ["fs", "signal"] }
+nix = { version = "0.30.1", features = ["fs", "signal"] }
 regex = "1"
-ron = "0.8.0"
+ron = "0.10.1"
 serde = { version = "1.0.104", features = ["derive", "rc"] }
 serde_json = "1.0.44"
 shellexpand = "3.0.0"
@@ -56,7 +56,7 @@ tokio = { version = "1.43.1", features = [
   "time",
 ] }
 toml = "0.8.2"
-xdg = "2.2.0"
+xdg = "3.0.0"
 
 # logging
 tracing = "0.1.36"

--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -20,6 +20,8 @@ fn main() {
     #[cfg(all(feature = "lefthk", not(target_os = "netbsd")))]
     match std::process::Command::new("lefthk-worker").spawn() {
         Ok(mut p) => p.kill().unwrap(),
-        Err(_) => println!("cargo:warning=When building with `lefthk` for the first time, you will need to completely restart `leftwm` in order to start the hotkey daemon properly. A `SoftReload` or `HardReload` will leave you with a session that is not responsive to keybinds but otherwise running well."),
+        Err(_) => println!(
+            "cargo:warning=When building with `lefthk` for the first time, you will need to completely restart `leftwm` in order to start the hotkey daemon properly. A `SoftReload` or `HardReload` will leave you with a session that is not responsive to keybinds but otherwise running well."
+        ),
     }
 }

--- a/leftwm/build.rs
+++ b/leftwm/build.rs
@@ -16,12 +16,4 @@ fn main() {
     });
 
     println!("cargo:rustc-env=LEFTWM_FEATURES={features_string}");
-
-    #[cfg(all(feature = "lefthk", not(target_os = "netbsd")))]
-    match std::process::Command::new("lefthk-worker").spawn() {
-        Ok(mut p) => p.kill().unwrap(),
-        Err(_) => println!(
-            "cargo:warning=When building with `lefthk` for the first time, you will need to completely restart `leftwm` in order to start the hotkey daemon properly. A `SoftReload` or `HardReload` will leave you with a session that is not responsive to keybinds but otherwise running well."
-        ),
-    }
 }

--- a/leftwm/src/bin/lefthk-worker.rs
+++ b/leftwm/src/bin/lefthk-worker.rs
@@ -15,9 +15,7 @@ fn main() {
         let rt = tokio::runtime::Runtime::new().expect("ERROR: couldn't init Tokio runtime");
         let _rt_guard = rt.enter();
         let config = leftwm::load();
-        let path = BaseDirectories::with_prefix("leftwm-lefthk")
-            .expect("ERROR: could not find base directory");
-
+        let path = BaseDirectories::with_prefix("leftwm-lefthk");
         rt.block_on(Worker::new(config.mapped_bindings(), path).event_loop());
     });
 

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -1,10 +1,10 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::{arg, command};
 use leftwm::{Config, ThemeConfig};
 use ron::{
-    extensions::Extensions,
-    ser::{to_string_pretty, PrettyConfig},
     Options,
+    extensions::Extensions,
+    ser::{PrettyConfig, to_string_pretty},
 };
 use std::env;
 use std::fs;
@@ -75,7 +75,9 @@ async fn main() -> Result<()> {
             config.check_mousekey(verbose);
             config.check_log_level(verbose);
             #[cfg(not(feature = "lefthk"))]
-            println!("\x1b[1;93mWARN: Ignoring checks on keybinds as you compiled for an external hot key daemon.\x1b[0m");
+            println!(
+                "\x1b[1;93mWARN: Ignoring checks on keybinds as you compiled for an external hot key daemon.\x1b[0m"
+            );
             #[cfg(feature = "lefthk")]
             config.check_keybinds(verbose);
         }
@@ -291,7 +293,9 @@ fn check_current_theme_set(filepath: Option<&PathBuf>, verbose: bool) -> Result<
                         fs::read_link(p).unwrap()
                     );
                 } else {
-                    println!("\x1b[1;93mWARN: Found `current` theme folder: {p:?}. Use of a symlink is recommended, instead.\x1b[0m");
+                    println!(
+                        "\x1b[1;93mWARN: Found `current` theme folder: {p:?}. Use of a symlink is recommended, instead.\x1b[0m"
+                    );
                 }
             }
             Ok(p)
@@ -325,7 +329,9 @@ fn check_up_file(filepath: PathBuf) -> Result<()> {
     let contents = fs::read_to_string(filepath)?;
     // Deprecate commands.pipe after 97de790. See #652 for details.
     if contents.contains("leftwm/commands.pipe") {
-        bail!("`commands.pipe` is deprecated. See https://github.com/leftwm/leftwm/issues/652 for workaround.");
+        bail!(
+            "`commands.pipe` is deprecated. See https://github.com/leftwm/leftwm/issues/652 for workaround."
+        );
     }
     Ok(())
 }
@@ -491,5 +497,7 @@ fn check_binary(binary: &str, verbose: bool) -> Result<()> {
         bail!("Could not find binary {} in PATH", binary)
     }
 
-    bail!("Binaries not checked. This is an error with leftwm-check, we would appreciate a bug report: https://github.com/leftwm/leftwm/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml")
+    bail!(
+        "Binaries not checked. This is an error with leftwm-check, we would appreciate a bug report: https://github.com/leftwm/leftwm/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml"
+    )
 }

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -284,11 +284,12 @@ fn check_current_theme_set(filepath: Option<&PathBuf>, verbose: bool) -> Result<
                 if fs::symlink_metadata(p)?.file_type().is_symlink() {
                     println!(
                         "Found symlink `current`, pointing to theme folder: {:?}",
-                        fs::read_link(p).unwrap()
+                        fs::read_link(p).unwrap().display()
                     );
                 } else {
                     println!(
-                        "\x1b[1;93mWARN: Found `current` theme folder: {p:?}. Use of a symlink is recommended, instead.\x1b[0m"
+                        "\x1b[1;93mWARN: Found `current` theme folder: {:?}. Use of a symlink is recommended, instead.\x1b[0m",
+                        p.display()
                     );
                 }
             }

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
     );
     if matches.get_flag("migrate") {
         println!("\x1b[0;94m::\x1b[0m Migrating configuration . . .");
-        let path = BaseDirectories::with_prefix("leftwm")?;
+        let path = BaseDirectories::with_prefix("leftwm");
         let ron_file = path.place_config_file("config.ron")?;
         let toml_file = path.place_config_file("config.toml")?;
 
@@ -104,8 +104,8 @@ pub fn load_from_file(fspath: Option<&str>, verbose: bool) -> Result<Config> {
         println!("\x1b[1;35mNote: Using file {fspath} \x1b[0m");
         PathBuf::from(fspath)
     } else {
-        let ron_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.ron")?;
-        let toml_file = BaseDirectories::with_prefix("leftwm")?.place_config_file("config.toml")?;
+        let ron_file = BaseDirectories::with_prefix("leftwm").place_config_file("config.ron")?;
+        let toml_file = BaseDirectories::with_prefix("leftwm").place_config_file("config.toml")?;
         if Path::new(&ron_file).exists() {
             ron_file
         } else if Path::new(&toml_file).exists() {
@@ -216,12 +216,6 @@ fn check_theme(verbose: bool) -> bool {
     let xdg_base_dir = BaseDirectories::with_prefix("leftwm/themes");
     let err_formatter = |s| println!("\x1b[1;91mERROR:\x1b[0m\x1b[1m {s} \x1b[0m");
 
-    if let Err(e) = xdg_base_dir {
-        err_formatter(e.to_string());
-        return false;
-    }
-
-    let xdg_base_dir = xdg_base_dir.unwrap();
     let path_current_theme = xdg_base_dir.find_config_file("current");
 
     match check_current_theme_set(path_current_theme.as_ref(), verbose) {

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
     let matches = get_command().get_matches();
 
     let file_name = leftwm_core::pipe_name();
-    let file_path = BaseDirectories::with_prefix("leftwm")?
+    let file_path = BaseDirectories::with_prefix("leftwm")
         .find_runtime_file(&file_name)
         .with_context(|| format!("ERROR: Couldn't find {}", file_name.display()))?;
     let mut file = OpenOptions::new()
@@ -106,7 +106,7 @@ fn place_runtime_file<P>(path: P) -> std::io::Result<PathBuf>
 where
     P: AsRef<Path>,
 {
-    xdg::BaseDirectories::with_prefix("leftwm")?.place_runtime_file(path)
+    xdg::BaseDirectories::with_prefix("leftwm").place_runtime_file(path)
 }
 
 async fn timeout(mills: u64) {

--- a/leftwm/src/bin/leftwm-command.rs
+++ b/leftwm/src/bin/leftwm-command.rs
@@ -110,6 +110,6 @@ where
 }
 
 async fn timeout(mills: u64) {
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{Duration, sleep};
     sleep(Duration::from_millis(mills)).await;
 }

--- a/leftwm/src/bin/leftwm-log.rs
+++ b/leftwm/src/bin/leftwm-log.rs
@@ -1,7 +1,7 @@
-use clap::{arg, command, ArgGroup, Id};
-use std::process::exit;
+use clap::{ArgGroup, Id, arg, command};
 #[cfg(any(feature = "sys-log", feature = "journald-log", feature = "file-log"))]
 use std::process::Command;
+use std::process::exit;
 
 fn main() {
     let matches = get_command().get_matches();

--- a/leftwm/src/bin/leftwm-state.rs
+++ b/leftwm/src/bin/leftwm-state.rs
@@ -160,7 +160,7 @@ fn template_handler(
 }
 
 async fn stream_reader() -> Result<Lines<BufReader<UnixStream>>> {
-    let base = BaseDirectories::with_prefix("leftwm")?;
+    let base = BaseDirectories::with_prefix("leftwm");
     let socket_file = base.place_runtime_file("current_state.sock")?;
     let stream = UnixStream::connect(socket_file).await?;
     Ok(BufReader::new(stream).lines())

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -126,10 +126,12 @@ fn parse_subcommands(args: &LeftwmArgs) -> ! {
 
 /// Sets some relevant environment variables for leftwm
 fn set_env_vars() {
-    env::set_var("XDG_CURRENT_DESKTOP", "LeftWM");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var("XDG_CURRENT_DESKTOP", "LeftWM") };
 
     // Fix for Java apps so they repaint correctly
-    env::set_var("_JAVA_AWT_WM_NONREPARENTING", "1");
+    // TODO: Audit that the environment access only happens in single-threaded code.
+    unsafe { env::set_var("_JAVA_AWT_WM_NONREPARENTING", "1") };
 }
 
 fn get_current_exe() -> std::path::PathBuf {

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -125,12 +125,14 @@ fn parse_subcommands(args: &LeftwmArgs) -> ! {
 }
 
 /// Sets some relevant environment variables for leftwm
+// The use of `unsafe` is needed here as the environment
+// isn't protected against race conditions by the OS
+// We need to ensure to only use this single-threaded
+#[allow(unsafe_code)]
 fn set_env_vars() {
-    // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { env::set_var("XDG_CURRENT_DESKTOP", "LeftWM") };
 
     // Fix for Java apps so they repaint correctly
-    // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { env::set_var("_JAVA_AWT_WM_NONREPARENTING", "1") };
 }
 
@@ -156,6 +158,7 @@ fn get_current_exe() -> std::path::PathBuf {
 fn start_leftwm() {
     let current_exe = get_current_exe();
 
+    // This call must happen before any child processes are created
     set_env_vars();
 
     // Boot everything WM agnostic or LeftWM related in ~/.config/autostart

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -6,10 +6,10 @@ use clap::command;
 use leftwm_core::child_process::{self, Nanny};
 use std::env;
 use std::path::Path;
-use std::process::{exit, Child, Command, ExitStatus};
+use std::process::{Child, Command, ExitStatus, exit};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 
 type Subcommand<'a> = &'a str;

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -735,7 +735,7 @@ fn from_regex<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Option<Regex
 #[allow(clippy::ref_option)]
 fn to_config_string<S: Serializer>(wc: &Option<Regex>, s: S) -> Result<S::Ok, S::Error> {
     match wc {
-        Some(ref re) => s.serialize_some(re.as_str()),
+        Some(re) => s.serialize_some(re.as_str()),
         None => s.serialize_none(),
     }
 }

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -13,6 +13,7 @@ use super::ThemeConfig;
 use crate::config::keybind::Keybind;
 use anyhow::Result;
 use leftwm_core::{
+    DisplayAction, DisplayServer, Manager, ReturnPipe,
     config::{InsertBehavior, ScratchPad, WindowHidingStrategy, Workspace},
     layouts::LayoutMode,
     models::{
@@ -20,15 +21,14 @@ use leftwm_core::{
         WindowType,
     },
     state::State,
-    DisplayAction, DisplayServer, Manager, ReturnPipe,
 };
 
 use leftwm_layouts::Layout;
 use regex::Regex;
 use ron::{
-    extensions::Extensions,
-    ser::{to_string_pretty, PrettyConfig},
     Options,
+    extensions::Extensions,
+    ser::{PrettyConfig, to_string_pretty},
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::env;
@@ -277,7 +277,9 @@ fn load_from_file() -> Result<Config> {
         );
         let contents = fs::read_to_string(config_file_toml)?;
         let config = toml::from_str(&contents)?;
-        tracing::info!("You are using TOML as config language which will be deprecated in the future.\nPlease consider migrating you config to RON. For further info visit the leftwm wiki.");
+        tracing::info!(
+            "You are using TOML as config language which will be deprecated in the future.\nPlease consider migrating you config to RON. For further info visit the leftwm wiki."
+        );
         Ok(config)
     } else {
         tracing::debug!("Config file not found. Using default config file.");

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -257,7 +257,7 @@ pub fn load() -> Config {
 fn load_from_file() -> Result<Config> {
     tracing::debug!("Loading config file");
 
-    let path = BaseDirectories::with_prefix("leftwm")?;
+    let path = BaseDirectories::with_prefix("leftwm");
 
     // the checks and fallback for `toml` can be removed when toml gets eventually deprecated
     let config_file_ron = path.place_config_file("config.ron")?;
@@ -627,7 +627,7 @@ impl leftwm_core::Config for Config {
                 return;
             }
         };
-        if let Err(err) = ron::ser::to_writer(state_file, state) {
+        if let Err(err) = ron::Options::default().to_io_writer(state_file, state) {
             tracing::error!("Cannot save state: {}", err);
         }
     }
@@ -744,7 +744,7 @@ fn to_config_string<S: Serializer>(wc: &Option<Regex>, s: S) -> Result<S::Ok, S:
 
 fn get_return_pipe() -> Result<File, Box<dyn std::error::Error>> {
     let file_name = ReturnPipe::pipe_name();
-    let file_path = BaseDirectories::with_prefix("leftwm")?;
+    let file_path = BaseDirectories::with_prefix("leftwm");
     let file_path = file_path
         .find_runtime_file(file_name)
         .ok_or("Unable to open return pipe")?;

--- a/leftwm/src/config/checks.rs
+++ b/leftwm/src/config/checks.rs
@@ -15,7 +15,9 @@ impl Config {
                 println!("Mousekey is set.");
             }
             if mousekey.is_empty() {
-                println!("Your mousekey is set to nothing, this will cause windows to move/resize with just a mouse press.");
+                println!(
+                    "Your mousekey is set to nothing, this will cause windows to move/resize with just a mouse press."
+                );
                 return;
             }
             if verbose {

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -6,7 +6,7 @@ use leftwm_core::{
 use crate::Backend;
 
 #[cfg(feature = "lefthk")]
-use super::{default_terminal, exit_strategy, BaseCommand, Keybind};
+use super::{BaseCommand, Keybind, default_terminal, exit_strategy};
 use super::{Config, Default, FocusBehaviour, LayoutMode, ThemeConfig};
 
 impl Default for Config {

--- a/leftwm/src/config/keybind.rs
+++ b/leftwm/src/config/keybind.rs
@@ -5,7 +5,7 @@ use super::BaseCommand;
 #[cfg(feature = "lefthk")]
 use crate::Config;
 #[cfg(feature = "lefthk")]
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 #[cfg(feature = "lefthk")]
 use lefthk_core::config::Command;
 #[cfg(feature = "lefthk")]
@@ -81,9 +81,16 @@ impl Keybind {
             }
             BaseCommand::FocusNextTag | BaseCommand::FocusPreviousTag if value_is_some => {
                 ensure!(
-                usize::from_str(&self.value).is_ok()
-                || matches!(&self.value.as_str(), &""|&"goto_empty"|&"ignore_empty"|&"goto_used"|&"ignore_used"|&"default"),
-            "Value should be empty, or one of 'default', 'goto_empty', 'ignore_empty', 'goto_used', 'ignore_used'"
+                    usize::from_str(&self.value).is_ok()
+                        || matches!(
+                            &self.value.as_str(),
+                            &"" | &"goto_empty"
+                                | &"ignore_empty"
+                                | &"goto_used"
+                                | &"ignore_used"
+                                | &"default"
+                        ),
+                    "Value should be empty, or one of 'default', 'goto_empty', 'ignore_empty', 'goto_used', 'ignore_used'"
                 );
             }
             _ => {}

--- a/leftwm/src/theme_config.rs
+++ b/leftwm/src/theme_config.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use leftwm_core::models::{Gutter, Margins};
-use ron::{extensions::Extensions, Options};
+use ron::{Options, extensions::Extensions};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;

--- a/leftwm/src/utils/log.rs
+++ b/leftwm/src/utils/log.rs
@@ -1,5 +1,5 @@
-use tracing::{metadata::LevelFilter, Subscriber};
-use tracing_subscriber::{filter::ParseError, layer::SubscriberExt, EnvFilter};
+use tracing::{Subscriber, metadata::LevelFilter};
+use tracing_subscriber::{EnvFilter, filter::ParseError, layer::SubscriberExt};
 
 #[cfg(feature = "journald-log")]
 mod journald;

--- a/leftwm/src/utils/log.rs
+++ b/leftwm/src/utils/log.rs
@@ -12,7 +12,7 @@ mod sys;
 
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn parse_log_level(level_regex: &str) -> (impl Subscriber, Option<ParseError>) {
+pub fn parse_log_level(level_regex: &str) -> (impl Subscriber + use<>, Option<ParseError>) {
     let mut parse_err = None;
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::DEBUG.into())

--- a/leftwm/src/utils/log/file.rs
+++ b/leftwm/src/utils/log/file.rs
@@ -32,7 +32,7 @@ where
 /// - If HOME is not set
 /// - If path permissions are not at least 0700
 pub fn get_log_path() -> Box<Path> {
-    let cache_dir = BaseDirectories::with_prefix(LOG_PREFIX).unwrap();
+    let cache_dir = BaseDirectories::with_prefix(LOG_PREFIX);
     cache_dir
         .place_state_file(LOG_FILE_NAME)
         .unwrap()


### PR DESCRIPTION
# Description

This pull request performs all updates to move lefthk to edition 2024 (which necessarily means an update to the MSRV to 1.85.0).

⚠️ Blocked on leftwm/lefthk#43

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:

All references to MSRV 1.83.0 should be updated to 1.85.0.

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
⚠️ Until leftwm/lefthk#43 is merged and 0.3.0 released, this will fail.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
