### PR TITLE
config: Add SerializableRegex to serialize Regex (#1307)

### DIFF
--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -92,9 +92,14 @@ pub struct SerializableRegex {
 }
 
 impl SerializableRegex {
-    pub fn new(str: String) -> Self {
+    /// # Panics
+    ///
+    /// Function can only panic if the str used is not a valid regex
+    #[must_use]
+    pub fn new(str: &str) -> Self {
         SerializableRegex {
-            regex: Regex::new(&str).unwrap(),
+            regex: Regex::new(str)
+                .unwrap_or_else(|e| panic!("Can't create regex from {str} error {e}")),
         }
     }
 }
@@ -116,7 +121,7 @@ impl<'de> Deserialize<'de> for SerializableRegex {
             None => Err(<D::Error as serde::de::Error>::custom(
                 "Error during MyRegex deserialization",
             )),
-            Some(re) => Ok(SerializableRegex::new(re)),
+            Some(re) => Ok(SerializableRegex::new(re.as_str())),
         }
     }
 }

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -801,4 +801,33 @@ mod tests {
         let ron_config = ron::from_str::<'_, Config>(ron.unwrap().as_str());
         assert!(ron_config.is_ok(), "Could not deserialize default config");
     }
+
+    #[test]
+    fn serialize_deserialize_valid_regex() {
+        let serializable_regex = SerializableRegex::new(".*");
+
+        assert!(serializable_regex.is_ok());
+
+        let serialized = serde_json::to_string(&serializable_regex.unwrap()).unwrap();
+
+        let deserialized: Result<SerializableRegex, serde_json::Error> =
+            serde_json::from_str(&serialized);
+
+        assert!(deserialized.is_ok());
+    }
+
+    #[test]
+    fn attempt_to_serialize_invalid_regex() {
+        // A regex that defines only an open bracket is invalid
+        // because is interpreted as the start of a group
+        let regex_str = "(";
+        let deserialized: Result<SerializableRegex, serde_json::Error> =
+            serde_json::from_str(regex_str);
+
+        // The deserialization process should return an error
+        assert!(
+            deserialized.is_err(),
+            "Regex: \"{regex_str}\" should return an error"
+        );
+    }
 }

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -803,10 +803,24 @@ mod tests {
     }
 
     #[test]
-    fn serialize_deserialize_valid_regex() {
+    fn create_valid_regex() {
         let serializable_regex = SerializableRegex::new(".*");
 
         assert!(serializable_regex.is_ok());
+    }
+
+    #[test]
+    fn create_invalid_regex() {
+        // A regex that defines only an open bracket is invalid
+        // because is interpreted as the start of a group
+        let serializable_regex = SerializableRegex::new("(");
+
+        assert!(serializable_regex.is_err());
+    }
+
+    #[test]
+    fn serialize_deserialize_valid_regex() {
+        let serializable_regex = SerializableRegex::new(".*");
 
         let serialized = serde_json::to_string(&serializable_regex.unwrap()).unwrap();
 
@@ -817,7 +831,7 @@ mod tests {
     }
 
     #[test]
-    fn attempt_to_serialize_invalid_regex() {
+    fn attempt_to_deserialize_invalid_regex() {
         // A regex that defines only an open bracket is invalid
         // because is interpreted as the start of a group
         let regex_str = "(";


### PR DESCRIPTION
# Description

 SerializableRegex allows to serialize Regex without using a reference to an option. This will avoid the clippy warning about ref_option.

Fixes #(1307)

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x ] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
