### PR TITLE
chore: bump dependencies, run clippies, remove unneeded dep features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,54 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
 
 [[package]]
 name = "anyhow"
@@ -75,9 +31,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -89,6 +45,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -111,9 +78,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -124,10 +91,8 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -135,12 +100,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cpufeatures"
@@ -218,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "errno"
@@ -246,7 +205,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -270,32 +228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -315,15 +251,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -385,12 +316,6 @@ checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -512,15 +437,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -587,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matchers"
@@ -602,15 +527,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -620,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -631,19 +556,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -652,16 +568,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -720,9 +639,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "powerfmt"
@@ -853,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -890,7 +809,9 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
+ "bstr",
  "dirs",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -914,22 +835,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -942,10 +851,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -1043,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1080,11 +989,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror",
  "time",
  "tracing-subscriber",
@@ -1123,32 +1033,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1159,9 +1055,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -1177,15 +1073,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "valuable"

--- a/display-servers/x11rb-display-server/Cargo.toml
+++ b/display-servers/x11rb-display-server/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.88.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 
 [dependencies]
 leftwm-core = { path = "../../leftwm-core", version = '0.5.4' }
-futures = "0.3.21"
-tracing = "0.1.36"
-tokio = { version = "1.43.1", features = [ "sync", "time" ] }
-mio = { version = "1.0.2", features = ["os-ext"] }
-x11rb = { version = "0.13.1", features = ["cursor", "randr", "xinerama"] }
-serde = { version = "1.0.104", features = ["derive"] }
+futures = { version = "0.3.21", default-features = false }
+tracing = { version = "0.1.36", default-features = false }
+tokio = { version = "1.43.1", features = [ "sync", "time" ], default-features = false }
+mio = { version = "1.0.2", features = ["os-ext"], default-features = false }
+x11rb = { version = "0.13.1", features = ["cursor", "randr", "xinerama"], default-features=false}
+serde = { version = "1.0.104", features = ["derive", "std"], default-features = false }

--- a/display-servers/xlib-display-server/Cargo.toml
+++ b/display-servers/xlib-display-server/Cargo.toml
@@ -9,10 +9,11 @@ rust-version = "1.88.0" # MSRV MINIMUM SUPPORTED RUST VERSION
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leftwm-core = { path = "../../leftwm-core", version = '0.5.3' }
-x11-dl = "2.18.4"
-futures = "0.3.21"
-tracing = "0.1.36"
-mio = { version = "1.0.2", features = ["os-ext"] }
-tokio = { version = "1.43.1", features = [ "sync", "time" ] }
-serde = { version = "1.0.104", features = ["derive"] }
+leftwm-core = { path = "../../leftwm-core", version = '0.5.4' }
+x11-dl = { version = "2.18.4", default-features = false }
+futures = { version = "0.3.21", default-features = false }
+tracing = { version = "0.1.36", default-features = false }
+mio = { version = "1.0.2", features = ["os-ext"], default-features = false }
+tokio = { version = "1.43.1", features = ["sync", "time"], default-features = false }
+serde = { version = "1.0.104", features = ["derive", "std"], default-features = false }
+

--- a/display-servers/xlib-display-server/src/xwrap/getters.rs
+++ b/display-servers/xlib-display-server/src/xwrap/getters.rs
@@ -20,13 +20,11 @@ impl XWrap {
     pub fn get_all_windows(&self) -> Result<Vec<xlib::Window>, String> {
         let mut all = Vec::new();
         for root in self.get_roots() {
-            match self.get_windows_for_root(root) {
-                Ok(some_windows) => {
-                    for w in some_windows {
-                        all.push(*w);
-                    }
+            {
+                let some_windows = self.get_windows_for_root(root)?;
+                for w in some_windows {
+                    all.push(*w);
                 }
-                Err(err) => return Err(err),
             }
         }
         Ok(all)

--- a/leftwm-core/Cargo.toml
+++ b/leftwm-core/Cargo.toml
@@ -12,14 +12,14 @@ repository = "https://github.com/leftwm/leftwm"
 description = "A window manager for Adventurers"
 
 [dependencies]
-dirs = "6.0.0"
-futures = "0.3.21"
-tracing = "0.1.37"
-nix = {version = "0.31.1", features = ["fs", "signal"]}
-serde = { version = "1.0.104", features = ["derive", "rc"] }
-serde_json = "1.0.44"
-signal-hook = "0.4.1"
-thiserror = "2.0.9"
+dirs = { version = "6.0.0", default-features = false }
+futures = { version = "0.3.21", default-features = false }
+tracing = { version = "0.1.37", default-features = false }
+nix = { version = "0.31.1", features = ["fs", "signal"], default-features = false }
+serde = { version = "1.0.104", features = ["derive", "rc", "std"], default-features = false }
+serde_json = { version = "1.0.44", features = ["std"], default-features = false }
+signal-hook = { version = "0.4.1", default-features = false }
+thiserror = { version = "2.0.9", default-features = false }
 tokio = { version = "1.43.1", features = [
   "fs",
   "io-util",
@@ -28,10 +28,11 @@ tokio = { version = "1.43.1", features = [
   "rt-multi-thread",
   "sync",
   "time",
-] }
-leftwm-layouts = "0.9.1"
-xdg = "3.0.0"
-bitflags = "2.4.2"
+], default-features = false }
+leftwm-layouts = { version = "0.9.1" }
+xdg = { version = "3.0.0", default-features = false }
+bitflags = { version = "2.4.2", default-features = false }
+
 
 [dev-dependencies]
 tempfile = {version = "3.2.0", default-features=false}

--- a/leftwm-core/src/handlers/focus_handler.rs
+++ b/leftwm-core/src/handlers/focus_handler.rs
@@ -163,7 +163,7 @@ impl<H: Handle> State<H> {
             .filter(|x| ws.is_managed(x) && x.can_focus())
             .map(|w| (distance(w, x, y), w))
             .collect();
-        dists.sort_by(|a, b| (a.0).cmp(&b.0));
+        dists.sort_by_key(|a| a.0);
         if let Some(first) = dists.first() {
             let handle = first.1.handle;
             self.focus_window(&handle);

--- a/leftwm-core/src/utils/command_pipe.rs
+++ b/leftwm-core/src/utils/command_pipe.rs
@@ -487,14 +487,14 @@ impl<H: Handle> fmt::Display for InvalidFocusDeltaBehaviorError<H> {
             Command::FocusNextTag { .. } => write!(
                 f,
                 "Invalid behavior for FocusNextTag: {}",
-                &self.attempted_value
+                self.attempted_value
             ),
             Command::FocusPreviousTag { .. } => write!(
                 f,
                 "Invalid behavior for FocusPreviousTag: {}",
-                &self.attempted_value
+                self.attempted_value
             ),
-            _ => write!(f, "Invalid behavior: {}", &self.attempted_value),
+            _ => write!(f, "Invalid behavior: {}", self.attempted_value),
         }
     }
 }

--- a/leftwm-macros/Cargo.toml
+++ b/leftwm-macros/Cargo.toml
@@ -15,6 +15,6 @@ description = "A window manager for Adventurers"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = {version = "1", features = ["nightly"]}
-quote = "1"
-syn = {version = "2.0.17", features = ["full", "parsing", "fold"]}
+proc-macro2 = {version = "1", features = ["nightly"], default-features=false}
+quote = {version = "1", default-features = false}
+syn = {version = "2.0.17", features = ["full", "parsing", "fold"], default-features = false}

--- a/leftwm/Cargo.toml
+++ b/leftwm/Cargo.toml
@@ -20,21 +20,21 @@ name = "leftwm"
 required-features = ["leftwm-watchdog"]
 
 [dependencies]
-anyhow = "1.0.48"
-clap = { version = "4.5.0", features = ["cargo"] }
-git-version = "0.3.5"
+anyhow = { version = "1.0.48", default-features = false }
+clap = { version = "4.5.0", features = ["cargo", "std", "help"], default-features = false }
+git-version = { version = "0.3.5", default-features = false }
 lefthk-core = { version = '0.3', optional = true }
-leftwm-core = { path = "../leftwm-core", version = '0.5.4' }
-leftwm-macros = {path = "../leftwm-macros", version = '0.5.4'}
-leftwm-layouts = "0.9.1"
-liquid = "0.26.9"
-nix = { version = "0.31.1", features = ["fs", "signal"] }
-regex = "1"
-ron = "0.12.0"
-serde = { version = "1.0.104", features = ["derive", "rc"] }
-serde_json = "1.0.44"
-shellexpand = "3.0.0"
-thiserror = "2.0.9"
+leftwm-core = { path = "../leftwm-core", version = '0.5.4'}
+leftwm-macros = { path = "../leftwm-macros", version = '0.5.4' }
+leftwm-layouts = { version = "0.9.1" }
+liquid = { version = "0.26.9", features = ["stdlib"], default-features = false }
+nix = { version = "0.31.1", features = ["fs", "signal"], default-features = false }
+regex = { version = "1", features = ["perf"], default-features = false }
+ron = { version = "0.12.0", default-features = false }
+serde = { version = "1.0.104", features = ["derive", "rc"], default-features = false }
+serde_json = { version = "1.0.44", default-features = false }
+shellexpand = { version = "3.0.0", features = ["base-0", "full"], default-features = false }
+thiserror = { version = "2.0.9", default-features = false }
 tokio = { version = "1.43.1", features = [
   "fs",
   "io-util",
@@ -43,19 +43,19 @@ tokio = { version = "1.43.1", features = [
   "rt-multi-thread",
   "sync",
   "time",
-] }
-xdg = "3.0.0"
+], default-features = false }
+xdg = { version = "3.0.0", default-features = false }
 
 # logging
-tracing = "0.1.36"
-tracing-subscriber = {version = "0.3.20", features = ["env-filter"]}
-tracing-journald = {version = "0.3.0", optional = true}
-tracing-appender = {version = "0.2.2", optional = true}
-syslog-tracing = {version = "0.3.0", optional = true}
+tracing = { version = "0.1.36", default-features = false }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"], default-features = false }
+tracing-journald = { version = "0.3.0", optional = true, default-features = false }
+tracing-appender = { version = "0.2.2", optional = true, default-features = false }
+syslog-tracing = { version = "0.3.0", optional = true, default-features = false }
 
 # display_servers
-xlib-display-server = { path = "../display-servers/xlib-display-server", version = "0.1.4", optional = true }
-x11rb-display-server = { path = "../display-servers/x11rb-display-server", version = "0.1.4", optional = true }
+xlib-display-server = { path = "../display-servers/xlib-display-server", version = "0.1.4", optional = true}
+x11rb-display-server = { path = "../display-servers/x11rb-display-server", version = "0.1.4", optional = true}
 
 [dev-dependencies]
 tempfile = {version = "3.2.0", default-features=false}

--- a/leftwm/src/bin/leftwm-check.rs
+++ b/leftwm/src/bin/leftwm-check.rs
@@ -444,7 +444,7 @@ fn check_binary(binary: &str, verbose: bool) -> Result<()> {
             let path = format!("{p}/{binary}");
             if Path::new(&path).exists() {
                 if verbose {
-                    println!("In search for binaries, found {}", &path);
+                    println!("In search for binaries, found {path}");
                 }
                 return Ok(());
             }

--- a/leftwm/src/bin/leftwm.rs
+++ b/leftwm/src/bin/leftwm.rs
@@ -195,7 +195,7 @@ fn start_leftwm() {
         // wait to give the login manager a second to boot.
         #[cfg(feature = "slow-dm-fix")]
         {
-            let delay = std::time::Duration::from_millis(2000);
+            let delay = std::time::Duration::from_secs(2);
             std::thread::sleep(delay);
         }
     }


### PR DESCRIPTION
# Description

New rust version dropped so pipelines may begin failing without doing the clippies. Also took the time to purge some unneeded dependencies, resulting in a few seconds' time-savings on build on my machine.

Fixes N/A

## Type of change

- [x] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

N/A

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
