### PR TITLE
fix: keep dialogs above  windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sloppy focus when switching tags with mouse over margins is now fixed (via #1311 by @fransklaver)
 - ClickTo focus when switching tags is now fixed (via #1312 by @fransklaver)
+- Keep dialogs above fullscreen windows without relying on focus (via #1364 by @NicTanghe)
 
 ## [0.5.4]
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -341,13 +341,8 @@ fn insert_window<H: Handle>(state: &mut State<H>, window: &mut Window<H>, layout
         }
     }
 
-    // If a window is a dialog, splash, utility, floating or scractchpad we want it to be at the top.
-    if window.r#type == WindowType::Dialog
-        || window.r#type == WindowType::Splash
-        || window.r#type == WindowType::Utility
-        || window.floating()
-        || is_scratchpad(state, window)
-    {
+    // Keep dialog-like, floating, and scratchpad windows at the top.
+    if window.r#type.is_dialog_like() || window.floating() || is_scratchpad(state, window) {
         state.windows.insert(0, window.clone());
         return;
     }

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -155,6 +155,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
         let mut changed = false;
         let mut fullscreen_changed = false;
         let mut above_changed = false;
+        let mut transient_changed = false;
         let strut_changed = change.strut.is_some();
         let windows = self.state.windows.clone();
         if let Some(window) = self
@@ -163,6 +164,10 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             .iter_mut()
             .find(|w| w.handle == change.handle)
         {
+            transient_changed = change
+                .transient
+                .as_ref()
+                .is_some_and(|transient| transient != &window.transient);
             if let Some(states) = &change.states {
                 fullscreen_changed =
                     states.contains(&WindowState::Fullscreen) != window.is_fullscreen();
@@ -200,7 +205,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             }
         }
 
-        if fullscreen_changed || above_changed {
+        if fullscreen_changed || above_changed || transient_changed {
             // Reorder windows.
             self.state.sort_windows();
         }
@@ -517,6 +522,89 @@ mod tests {
     use crate::Manager;
     use crate::layouts::MONOCLE;
     use crate::models::{MockHandle, Screen};
+
+    fn last_window_order(state: &State<MockHandle>) -> Vec<WindowHandle<MockHandle>> {
+        state
+            .actions
+            .iter()
+            .rev()
+            .find_map(|action| match action {
+                DisplayAction::SetWindowOrder(order) => Some(order.clone()),
+                _ => None,
+            })
+            .expect("expected a window order action")
+    }
+
+    #[test]
+    fn dialog_is_visible_and_stacked_above_fullscreen_without_focus() {
+        let mut manager = Manager::new_test(vec!["1".to_string()]);
+        manager.screen_create_handler(Screen::default());
+
+        let mut fullscreen = Window::new(WindowHandle::<MockHandle>(1), None, None);
+        fullscreen.states.push(WindowState::Fullscreen);
+        manager.window_created_handler(fullscreen, -1, -1);
+
+        let mut dialog = Window::new(WindowHandle::<MockHandle>(2), None, None);
+        dialog.r#type = WindowType::Dialog;
+        manager.window_created_handler(dialog, -1, -1);
+
+        assert_eq!(
+            manager
+                .state
+                .focus_manager
+                .window(&manager.state.windows)
+                .map(|window| window.handle),
+            Some(WindowHandle(1))
+        );
+        assert_eq!(
+            last_window_order(&manager.state),
+            vec![WindowHandle(2), WindowHandle(1)]
+        );
+
+        manager.update_windows();
+        assert!(
+            manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == WindowHandle(2))
+                .is_some_and(Window::visible)
+        );
+    }
+
+    #[test]
+    fn late_transient_hint_restacks_dialog_above_fullscreen_parent() {
+        let mut manager = Manager::new_test(vec!["1".to_string()]);
+        manager.screen_create_handler(Screen::default());
+
+        let mut fullscreen = Window::new(WindowHandle::<MockHandle>(1), None, None);
+        fullscreen.states.push(WindowState::Fullscreen);
+        manager.window_created_handler(fullscreen, -1, -1);
+
+        let mut dialog = Window::new(WindowHandle::<MockHandle>(2), None, None);
+        dialog.r#type = WindowType::Dialog;
+        manager.window_created_handler(dialog, -1, -1);
+
+        manager.state.actions.clear();
+        let mut change = WindowChange::new(WindowHandle(2));
+        change.transient = Some(Some(WindowHandle(1)));
+
+        assert!(manager.window_changed_handler(change));
+        assert_eq!(
+            last_window_order(&manager.state),
+            vec![WindowHandle(2), WindowHandle(1)]
+        );
+
+        manager.update_windows();
+        assert!(
+            manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == WindowHandle(2))
+                .is_some_and(Window::visible)
+        );
+    }
 
     #[test]
     fn insert_behavior_bottom_add_window_at_the_end_of_the_stack() {

--- a/leftwm-core/src/models/tag.rs
+++ b/leftwm-core/src/models/tag.rs
@@ -240,6 +240,7 @@ impl Tag {
                 .filter(|w| {
                     w.has_tag(&self.id)
                         && (w.transient == Some(handle)
+                            || w.r#type.is_dialog_like()
                             || w.states.contains(&super::WindowState::Above) && w.floating())
                         && w.is_managed()
                 })

--- a/leftwm-core/src/models/window_type.rs
+++ b/leftwm-core/src/models/window_type.rs
@@ -17,3 +17,22 @@ pub enum WindowType {
     Dnd,
     Normal,
 }
+
+impl WindowType {
+    #[must_use]
+    pub fn is_dialog_like(&self) -> bool {
+        matches!(
+            self,
+            Self::Dialog
+                | Self::Splash
+                | Self::Utility
+                | Self::Menu
+                | Self::DropdownMenu
+                | Self::PopupMenu
+                | Self::Tooltip
+                | Self::Notification
+                | Self::Combo
+                | Self::Dnd
+        )
+    }
+}

--- a/leftwm-core/src/state.rs
+++ b/leftwm-core/src/state.rs
@@ -89,22 +89,11 @@ impl<H: Handle> State<H> {
             })
         });
 
+        // Dialogs and modals.
+        sorter.sort(|w| w.r#type.is_dialog_like());
+
         // Fullscreen windows
         sorter.sort(Window::is_fullscreen);
-
-        // Dialogs and modals.
-        sorter.sort(|w| {
-            w.r#type == WindowType::Dialog
-                || w.r#type == WindowType::Splash
-                || w.r#type == WindowType::Utility
-                || w.r#type == WindowType::Menu
-                || w.r#type == WindowType::DropdownMenu
-                || w.r#type == WindowType::PopupMenu
-                || w.r#type == WindowType::Tooltip
-                || w.r#type == WindowType::Notification
-                || w.r#type == WindowType::Combo
-                || w.r#type == WindowType::Dnd
-        });
 
         // Floating windows.
         sorter.sort(|w| w.r#type == WindowType::Normal && w.floating());


### PR DESCRIPTION
Keep dialog-like windows visible and stacked above fullscreen windows without relying on focus. Restack windows when transient hints change.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

I'm unfamiliar

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
