### PR TITLE
feat: Update the makefile for man spec, feat spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sloppy focus when switching tags with mouse over margins is now fixed (via #1311 by @fransklaver)
 - ClickTo focus when switching tags is now fixed (via #1312 by @fransklaver)
+- feat: Update the makefile for man spec, and allow specifying features (via #1368 by @evanescente-ondine, @mautamu)
 
 ## [0.5.4]
 

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ install: build
 	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 $(MAN_DIR)/man1/leftwm.1
 	[ -d '/usr/share/leftwm' ] || sudo mkdir $(SHARE_DIR)/leftwm
 	sudo cp -rL $(ROOT_DIR)/examples $(SHARE_DIR)/leftwm
-	-sudo install -s -Dm755 $(ROOT_DIR)/target/$(folder)/lefthk-worker  -t $(TARGET_DIR)
-	sudo install -m755 -s \
-		$(ROOT_DIR)/target/$(folder)/leftwm \
+	-sudo install -s -Dm755 $(ROOT_DIR)/target/$(folder)/lefthk-worker -t $(TARGET_DIR)
+	-sudo install -s -Dm755 $(ROOT_DIR)/target/$(folder)/leftwm -t $(TARGET_DIR) 
+	sudo install -s -Dm755 \
 		$(ROOT_DIR)/target/$(folder)/leftwm-log \
 		$(ROOT_DIR)/target/$(folder)/leftwm-worker\
 		$(ROOT_DIR)/target/$(folder)/leftwm-state \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # or when 'make' is run from another directory.
 # - credit: https://stackoverflow.com/a/23324703/2726733
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-
 SHARE_DIR := /usr/share
 TARGET_DIR := /usr/local/bin
+MAN_DIR := /usr/local/share/man
 
 # Set default profile if unset
 ifndef profile
@@ -41,7 +41,7 @@ test-full-nix: test test-nix
 build:
 	@echo "Building with $(profile) profile"
 	@echo "Change the profile by adding profile=release or profile=dev to the command"
-	cd $(ROOT_DIR) && cargo build --profile $(profile)
+	cd $(ROOT_DIR) && cargo build --profile $(profile) $(if $(FEATURES),--features=$(FEATURES)) $(if $(filter-out undefined,$(origin NO_DEFAULT_FEATURES)),--no-default-features)
 
 # removes the generated binaries
 clean:
@@ -52,17 +52,17 @@ clean:
 # builds the project and installs the binaries (and .desktop)
 install: build
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/xsessions/
-	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
+	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 $(MAN_DIR)/man1/leftwm.1
 	[ -d '/usr/share/leftwm' ] || sudo mkdir $(SHARE_DIR)/leftwm
 	sudo cp -rL $(ROOT_DIR)/examples $(SHARE_DIR)/leftwm
-	sudo install -s -Dm755\
-		$(ROOT_DIR)/target/$(folder)/leftwm\
-		$(ROOT_DIR)/target/$(folder)/leftwm-log\
+	-sudo install -s -Dm755 $(ROOT_DIR)/target/$(folder)/lefthk-worker  -t $(TARGET_DIR)
+	sudo install -m755 -s \
+		$(ROOT_DIR)/target/$(folder)/leftwm \
+		$(ROOT_DIR)/target/$(folder)/leftwm-log \
 		$(ROOT_DIR)/target/$(folder)/leftwm-worker\
-		$(ROOT_DIR)/target/$(folder)/lefthk-worker\
-		$(ROOT_DIR)/target/$(folder)/leftwm-state\
-		$(ROOT_DIR)/target/$(folder)/leftwm-check\
-		$(ROOT_DIR)/target/$(folder)/leftwm-command\
+		$(ROOT_DIR)/target/$(folder)/leftwm-state \
+		$(ROOT_DIR)/target/$(folder)/leftwm-check \
+		$(ROOT_DIR)/target/$(folder)/leftwm-command \
 		-t $(TARGET_DIR)
 	cd $(ROOT_DIR) && cargo clean
 	@echo "Binaries, '.desktop' file, manpage, theme and config templates have been installed"
@@ -70,29 +70,29 @@ install: build
 # Function to build and link a specific profile
 install-linked: build
 	sudo cp $(ROOT_DIR)/leftwm.desktop $(SHARE_DIR)/
-	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 /usr/local/share/man/man1/leftwm.1
+	sudo cp $(ROOT_DIR)/leftwm/doc/leftwm.1 $(MAN_DIR)/man1/leftwm.1
 	[ -d '/usr/share/leftwm' ] || sudo mkdir $(SHARE_DIR)/leftwm
 	sudo cp -rL $(ROOT_DIR)/examples $(SHARE_DIR)/leftwm
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm $(TARGET_DIR)/leftwm
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-log $(TARGET_DIR)/leftwm-log
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-worker $(TARGET_DIR)/leftwm-worker
-	sudo ln -sf $(ROOT_DIR)/target/$(folder)/lefthk-worker $(TARGET_DIR)/lefthk-worker
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-state $(TARGET_DIR)/leftwm-state
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-check $(TARGET_DIR)/leftwm-check
 	sudo ln -sf $(ROOT_DIR)/target/$(folder)/leftwm-command $(TARGET_DIR)/leftwm-command
+	-sudo ln -sf $(ROOT_DIR)/target/$(folder)/lefthk-worker $(TARGET_DIR)/lefthk-worker
 	@echo "binaries have been linked, '.desktop' file, manpage, theme and config templates have been installed"
 
 # Uninstalls leftwm from the system.
 uninstall:
 	sudo rm -f $(SHARE_DIR)/leftwm.desktop
-	sudo rm /usr/local/share/man/man1/leftwm.1
+	sudo rm $(MAN_DIR)/man1/leftwm.1
 	sudo rm -rf $(SHARE_DIR)/leftwm
-	sudo rm -f\
-		$(TARGET_DIR)/leftwm\
-		$(TARGET_DIR)/leftwm-log\
-		$(TARGET_DIR)/leftwm-worker\
-		$(TARGET_DIR)/lefthk-worker\
-		$(TARGET_DIR)/leftwm-state\
-		$(TARGET_DIR)/leftwm-check\
+	sudo rm -f \
+		$(TARGET_DIR)/leftwm \
+		$(TARGET_DIR)/leftwm-log \
+		$(TARGET_DIR)/leftwm-worker $(if $(findstring lefthk-worker,$(FEATURES)),,$(TARGET_DIR)/lefthk-worker) \
+		$(TARGET_DIR)/leftwm-state \
+		$(TARGET_DIR)/leftwm-check \
 		$(TARGET_DIR)/leftwm-command
 	@echo "Binaries and manpage have been uninstalled and '.desktop' file, theme and config templates have been removed"
+

--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ List of LeftWM dependencies:
 List of common dependencies for themes:
 
 | Dependency<br>(git)      | Ubuntu 24.04<br> _sudo apt install {}_ | Arch<br> _sudo pacman -S {}_ | Fedora 42<br> _sudo dnf install {}_ | PKGS                     |
-| ------------------------ | --------------------------------------- | ---------------------------- | ----------------------------------- | ------------------------ |
-| [feh][feh-git]           | feh                                     | feh                          | feh                                 | [feh][feh-pkg]           |
-| [compton][compton-git]   | compton                                 | picom                        | compton                             | [compton][compton-pkg]   |
+| ------------------------ | -------------------------------------- | ---------------------------- | ----------------------------------- | ------------------------ |
+| [feh][feh-git]           | feh                                    | feh                          | feh                                 | [feh][feh-pkg]           |
+| [compton][compton-git]   | compton                                | picom                        | compton                             | [compton][compton-pkg]   |
 | [picom][picom-git]       | picom \*\*                             | picom                        | picom                               | [picom][picom-pkg]       |
-| [polybar][polybar-git]   | polybar \*\*                             | polybar                      | polybar                             | [polybar][polybar-pkg]   |
-| [xmobar][xmobar-git]     | xmobar                                  | xmobar                       | xmobar                              | [xmobar][xmobar-pkg]     |
-| [lemonbar][lemonbar-git] | lemonbar                                | paru -S lemonbar\*           | manual \*\*                         | [lemonbar][lemonbar-pkg] |
-| [conky][conky-git]       | conky                                   | conky                        | conky                               | [conky][conky-pkg]       |
-| [dmenu][dmenu-git]       | dmenu                                   | dmenu                        | dmenu                               | [dmenu][dmenu-pkg]       |
+| [polybar][polybar-git]   | polybar \*\*                           | polybar                      | polybar                             | [polybar][polybar-pkg]   |
+| [xmobar][xmobar-git]     | xmobar                                 | xmobar                       | xmobar                              | [xmobar][xmobar-pkg]     |
+| [lemonbar][lemonbar-git] | lemonbar                               | paru -S lemonbar\*           | manual \*\*                         | [lemonbar][lemonbar-pkg] |
+| [conky][conky-git]       | conky                                  | conky                        | conky                               | [conky][conky-pkg]       |
+| [dmenu][dmenu-git]       | dmenu                                  | dmenu                        | dmenu                               | [dmenu][dmenu-pkg]       |
 
 [feh-git]: https://github.com/derf/feh
 [feh-pkg]: https://pkgs.org/search/?q=feh&on=provides
@@ -343,9 +343,9 @@ Use `cargo` with the added flags `--no-default-features --features=` and then co
 | journald-log | logging to `journald`, depends on `systemd`                                                                                                                                                    | ✔      |
 | sys-log      | use standard system logging                                                                                                                                                                    | ✘       |
 | file-log     | log to `/tmp/leftwm/<log-file-by-datetime-of-launch>`                                                                                                                                          | ✘       |
-| xlib (\*)    | legacy backend linking to `libX11`                                                                                                                                                             | ✔       |
-| x11rb (\*)   | rust based backend using [`x11rb`](https://github.com/psychon/x11rb)                                                                                                                           | ✔       |
-| leftwm (\*)  | whether to build the `leftwm` binary                                                                                                                                                           | ✔       | 
+| xlib (\*)    | legacy backend linking to `libX11`                                                                                                                                                             | ✔      |
+| x11rb (\*)   | rust based backend using [`x11rb`](https://github.com/psychon/x11rb)                                                                                                                           | ✔      |
+| leftwm (\*)  | whether to build the `leftwm` binary                                                                                                                                                           | ✔      |
 
 ⚠️ You need to select **at least one** backend feature (\*) for leftwm to build, and leftwm-watchdog in order to get the `leftwm` binary ⚠️
 
@@ -386,6 +386,12 @@ For conveniece we also have a Makefile with the following rules:
 | install        | install by copying binaries to `/usr/bin`, also places `leftwm.desktop` file to `/usr/share/xsession` and cleans build files |
 | install-linked | installs by symlinking, copies `leftwm.desktop`, no clean                                                                    |
 | uninstall      | removes `leftwm-*` files from `/usr/bin` and `leftwm.desktop` file                                                           |
+
+Additionally, the `build` and `install` portions of the makefile take an optional argument `FEATURES` which can be used to specify which feature(s) to build, for example:
+
+```
+make install FEATURES=lefthk,xlib
+```
 
 Note that for `build`, `install` and `install-linked`, you can specify the build profile to use by adding the `profile=<profile-name>` argument. Currently available are `dev`, `release` and `release-optimized`.
 


### PR DESCRIPTION
# Description
Updates the Makefile, as per #1363, to allow for the man pages folder to be specified in $MAN_DIR and the features to be specified in $FEATURES.

Co-authored-by: @evanescente-ondine

Fixes #1363

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [x] This change requires a documentation update

## Updated user documentation:
- [ ] README.md: update makefile usage to show this workflow

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
