### PR TITLE
dont grab mouse for "dialogue like" windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(MSRV): update edition to 2024, MSRV to 1.85.0 (via #1338 by @mautamu and @VuiMuich)
 - feat(config.toml): remove TOML support entirely from leftwm, leftwm-check (via #1339 by @mautamu).
 
+### Added
+
+- Add `disable_mouse_grab` to window rules and suppress creation-time mouse warping for utility windows by default (via #1366).
+
 ### Fixes
 
 - Sloppy focus when switching tags with mouse over margins is now fixed (via #1311 by @fransklaver)

--- a/examples/config-with-comments.ron
+++ b/examples/config-with-comments.ron
@@ -59,7 +59,12 @@
     scratchpad: [
         (name: "Alacritty", value: "alacritty", x: 860, y: 390, height: 300, width: 200),
     ],
-    window_rules: [],
+    window_rules: [
+        // Utility windows disable the creation-time mouse warp by default.
+        // Disable it for another window by matching its class or title:
+        // (window_class: "^pavucontrol$", disable_mouse_grab: true),
+        // Use `disable_mouse_grab: false` to re-enable it for a matching utility window.
+    ],
     disable_current_tag_swap: false,
     disable_tile_drag: false,
     disable_window_snap: true,

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -45,7 +45,8 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             && self.state.focus_manager.behaviour.is_sloppy()
             && self.state.focus_manager.sloppy_mouse_follows_focus
             && window.is_managed()
-            && on_same_tag;
+            && on_same_tag
+            && window.allows_mouse_warp();
 
         // Let the DS know we are managing this window.
         let act = DisplayAction::AddedWindow(window.handle, window.floating(), follow_mouse);
@@ -516,7 +517,7 @@ mod tests {
     use super::*;
     use crate::Manager;
     use crate::layouts::MONOCLE;
-    use crate::models::{MockHandle, Screen};
+    use crate::models::{FocusBehaviour, MockHandle, Screen};
 
     fn last_window_order(state: &State<MockHandle>) -> Vec<WindowHandle<MockHandle>> {
         state
@@ -528,6 +529,74 @@ mod tests {
                 _ => None,
             })
             .expect("expected a window order action")
+    }
+
+    fn follows_mouse_on_creation(
+        window: Window<MockHandle>,
+        focus_new_windows: bool,
+        focus_behaviour: FocusBehaviour,
+        sloppy_mouse_follows_focus: bool,
+    ) -> bool {
+        let mut manager = Manager::new_test(vec!["1".to_owned()]);
+        manager.screen_create_handler(Screen::default());
+        manager.state.actions.clear();
+        manager.state.focus_manager.focus_new_windows = focus_new_windows;
+        manager.state.focus_manager.behaviour = focus_behaviour;
+        manager.state.focus_manager.sloppy_mouse_follows_focus = sloppy_mouse_follows_focus;
+
+        manager.window_created_handler(window, -1, -1);
+
+        manager
+            .state
+            .actions
+            .iter()
+            .find_map(|action| match action {
+                DisplayAction::AddedWindow(_, _, follow_mouse) => Some(*follow_mouse),
+                _ => None,
+            })
+            .expect("expected an AddedWindow action")
+    }
+
+    #[test]
+    fn new_window_mouse_warp_uses_type_default_and_window_override() {
+        let cases = [
+            (1, WindowType::Normal, None, true),
+            (2, WindowType::Utility, None, false),
+            (3, WindowType::Normal, Some(true), false),
+            (4, WindowType::Utility, Some(false), true),
+        ];
+
+        for (handle, window_type, disable_mouse_grab, expected) in cases {
+            let mut window = Window::new(WindowHandle(handle), None, None);
+            window.r#type = window_type;
+            window.set_disable_mouse_grab(disable_mouse_grab);
+
+            assert_eq!(
+                follows_mouse_on_creation(window, true, FocusBehaviour::Sloppy, true),
+                expected,
+                "unexpected follow_mouse for disable_mouse_grab={disable_mouse_grab:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn mouse_warp_permission_does_not_bypass_global_focus_settings() {
+        let cases = [
+            (false, FocusBehaviour::Sloppy, true),
+            (true, FocusBehaviour::ClickTo, true),
+            (true, FocusBehaviour::Sloppy, false),
+        ];
+
+        for (focus_new_windows, focus_behaviour, sloppy_mouse_follows_focus) in cases {
+            let window = Window::new(WindowHandle(1), None, None);
+
+            assert!(!follows_mouse_on_creation(
+                window,
+                focus_new_windows,
+                focus_behaviour,
+                sloppy_mouse_follows_focus,
+            ));
+        }
     }
 
     #[test]

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -55,6 +55,9 @@ pub struct Window<H: Handle> {
     pub(crate) must_float: bool,
     floating: Option<Xyhw>,
     pub never_focus: bool,
+    /// Per-window override for the creation-time pointer warp.
+    #[serde(default)]
+    disable_mouse_grab: Option<bool>,
     pub urgent: bool,
     pub debugging: bool,
     pub name: Option<String>,
@@ -89,6 +92,7 @@ impl<H: Handle> Window<H> {
             must_float: false,
             debugging: false,
             never_focus: false,
+            disable_mouse_grab: None,
             urgent: false,
             name,
             pid,
@@ -122,6 +126,20 @@ impl<H: Handle> Window<H> {
             || self.r#type == WindowType::Splash
             || self.r#type == WindowType::Toolbar
             || self.r#type == WindowType::Notification
+    }
+
+    /// Set a per-window override for the creation-time pointer warp.
+    pub fn set_disable_mouse_grab(&mut self, value: Option<bool>) {
+        self.disable_mouse_grab = value;
+    }
+
+    /// Whether the new-window path may move the pointer into this window.
+    #[must_use]
+    pub fn allows_mouse_warp(&self) -> bool {
+        match self.disable_mouse_grab {
+            Some(disabled) => !disabled,
+            None => self.r#type != WindowType::Utility,
+        }
     }
 
     pub fn set_floating(&mut self, value: bool) {
@@ -399,5 +417,48 @@ mod tests {
         subject.tag(&1);
         subject.untag();
         assert!(!subject.has_tag(&1), "was unable to untag the window");
+    }
+
+    #[test]
+    fn mouse_warp_policy_honors_type_defaults_and_explicit_overrides() {
+        let cases = [
+            (1, WindowType::Normal, None, true),
+            (2, WindowType::Utility, None, false),
+            (3, WindowType::Normal, Some(true), false),
+            (4, WindowType::Utility, Some(false), true),
+        ];
+
+        for (handle, window_type, disable_mouse_grab, expected) in cases {
+            let mut subject = Window::new(WindowHandle::<MockHandle>(handle), None, None);
+            subject.r#type = window_type;
+            subject.set_disable_mouse_grab(disable_mouse_grab);
+
+            assert_eq!(
+                subject.allows_mouse_warp(),
+                expected,
+                "unexpected mouse-warp policy for {:?} with disable_mouse_grab={:?}",
+                subject.r#type,
+                disable_mouse_grab,
+            );
+        }
+    }
+
+    #[test]
+    fn missing_mouse_grab_policy_deserializes_as_the_type_default() {
+        let mut subject = Window::new(WindowHandle::<MockHandle>(1), None, None);
+        subject.r#type = WindowType::Utility;
+        subject.set_disable_mouse_grab(Some(false));
+
+        let mut serialized = serde_json::to_value(subject).expect("window should serialize");
+        let fields = serialized
+            .as_object_mut()
+            .expect("a serialized window should be a map");
+        assert!(fields.remove("disable_mouse_grab").is_some());
+
+        let restored: Window<MockHandle> =
+            serde_json::from_value(serialized).expect("legacy window state should deserialize");
+
+        assert_eq!(restored.disable_mouse_grab, None);
+        assert!(!restored.allows_mouse_warp());
     }
 }

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -228,6 +228,26 @@ when unset (\f[C]None\f[R]), \f[C]Some(true)\f[R], or when the cursor is in \f[C
 when set to \f[C]Some(false)\f[R]
 .PP
 Default: \f[C]create_follows_cursor = None\f[R]
+.SS Per-window New-window Mouse Warping
+.PP
+When Sloppy focus, focus_new_windows, and sloppy_mouse_follows_focus would normally
+move the pointer into a new window, a window rule can suppress that creation-time
+movement with \f[C]disable_mouse_grab\f[R]. This option controls pointer movement;
+it does not disable keyboard focus or mouse-button handling.
+.PP
+Example:
+.IP
+.nf
+\f[C]
+window_rules: [
+    (window_class: "^pavucontrol$", disable_mouse_grab: true),
+]
+\f[R]
+.fi
+.PP
+Windows of type \f[C]_NET_WM_WINDOW_TYPE_UTILITY\f[R] suppress the movement by
+default. A matching rule with \f[C]disable_mouse_grab: false\f[R] explicitly
+restores the normal behavior for a utility window.
 .SS Layouts
 .PP
 Leftwm supports a variety of user definable layouts. Layouts define the way that windows are tiled in the workspace.

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -74,6 +74,9 @@ pub struct WindowHook {
     pub spawn_fullscreen: Option<bool>,
     /// Handle the window as if it was of this `_NET_WM_WINDOW_TYPE`
     pub spawn_as_type: Option<WindowType>,
+    /// Suppress the creation-time pointer warp for matching windows.
+    #[serde(default)]
+    pub disable_mouse_grab: Option<bool>,
     pub hiding_strategy: Option<WindowHidingStrategy>,
 }
 
@@ -194,18 +197,28 @@ impl WindowHook {
         if let Some(should_float) = self.spawn_floating {
             window.set_floating(should_float);
         }
+        if let Some(window_type) = &self.spawn_as_type {
+            window.r#type.clone_from(window_type);
+        }
+        window.set_disable_mouse_grab(self.disable_mouse_grab);
+
+        let refocus_after_state_change = |state: &mut State<H>, window: &Window<H>| {
+            if window.allows_mouse_warp() {
+                state.handle_window_focus(&window.handle);
+            } else {
+                state.focus_window(&window.handle);
+            }
+        };
+
         if let Some(fullscreen) = self.spawn_fullscreen {
             let act = DisplayAction::SetState(window.handle, fullscreen, WindowState::Fullscreen);
             state.actions.push_back(act);
-            state.handle_window_focus(&window.handle);
+            refocus_after_state_change(state, window);
         }
         if let Some(sticky) = self.spawn_sticky {
             let act = DisplayAction::SetState(window.handle, sticky, WindowState::Sticky);
             state.actions.push_back(act);
-            state.handle_window_focus(&window.handle);
-        }
-        if let Some(w_type) = self.spawn_as_type.clone() {
-            window.r#type = w_type;
+            refocus_after_state_change(state, window);
         }
         window.hiding_strategy = self.hiding_strategy;
     }
@@ -763,6 +776,78 @@ fn write_to_pipe(return_pipe: &mut Result<File, Box<dyn Error>>, msg: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leftwm_core::models::WindowHandle;
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+    struct TestHandle(i32);
+
+    impl Handle for TestHandle {}
+
+    struct TestDisplayServer;
+
+    impl DisplayServer<TestHandle> for TestDisplayServer {
+        fn new(_: &impl leftwm_core::Config) -> Self {
+            Self
+        }
+
+        fn get_next_events(&mut self) -> Vec<leftwm_core::DisplayEvent<TestHandle>> {
+            vec![]
+        }
+
+        fn reload_config(
+            &mut self,
+            _: &impl leftwm_core::Config,
+            _: Option<WindowHandle<TestHandle>>,
+            _: &[Window<TestHandle>],
+        ) {
+        }
+
+        fn wait_readable(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> {
+            Box::pin(std::future::pending())
+        }
+
+        fn flush(&self) {}
+
+        fn generate_verify_focus_event(&self) -> Option<leftwm_core::DisplayEvent<TestHandle>> {
+            None
+        }
+    }
+
+    fn parse_ron_config(input: &str) -> Config {
+        Options::default()
+            .with_default_extension(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES)
+            .from_str(input)
+            .expect("test config should deserialize")
+    }
+
+    fn apply_window_rule(
+        config: Config,
+        class: &str,
+        window_type: WindowType,
+    ) -> (Window<TestHandle>, bool) {
+        let mut manager: Manager<TestHandle, Config, TestDisplayServer> = Manager::new(config);
+        manager.state.focus_manager.behaviour = FocusBehaviour::Sloppy;
+        manager.state.focus_manager.sloppy_mouse_follows_focus = true;
+        manager.state.actions.clear();
+
+        let mut window = Window::new(WindowHandle(TestHandle(1)), None, None);
+        window.res_class = Some(class.to_owned());
+        window.r#type = window_type;
+
+        assert!(<Config as leftwm_core::Config>::setup_predefined_window(
+            &manager.config,
+            &mut manager.state,
+            &mut window,
+        ));
+
+        let queued_mouse_warp = manager
+            .state
+            .actions
+            .iter()
+            .any(|action| matches!(action, DisplayAction::MoveMouseOver(..)));
+
+        (window, queued_mouse_warp)
+    }
 
     #[test]
     fn config_serializes_to_valid_ron_test() {
@@ -777,6 +862,116 @@ mod tests {
 
         let ron_config = ron::from_str::<'_, Config>(ron.unwrap().as_str());
         assert!(ron_config.is_ok(), "Could not deserialize default config");
+    }
+
+    #[test]
+    fn documented_mouse_grab_rule_example_deserializes() {
+        let config = parse_ron_config(
+            r#"(
+                window_rules: [
+                    // Disable the creation-time pointer warp for this application.
+                    (window_class: "^pavucontrol$", disable_mouse_grab: true),
+                ],
+            )"#,
+        );
+
+        assert_eq!(
+            config.window_rules.as_ref().unwrap()[0].disable_mouse_grab,
+            Some(true),
+        );
+    }
+
+    #[test]
+    fn window_rule_without_mouse_grab_setting_uses_window_type_default() {
+        let config = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$"),
+                ],
+            )"#,
+        );
+
+        assert_eq!(
+            config.window_rules.as_ref().unwrap()[0].disable_mouse_grab,
+            None,
+        );
+
+        let (normal, queued_mouse_warp) = apply_window_rule(config, "target", WindowType::Normal);
+        assert!(normal.allows_mouse_warp());
+        assert!(!queued_mouse_warp);
+    }
+
+    #[test]
+    fn window_rule_mouse_grab_setting_accepts_both_boolean_overrides() {
+        let disabled = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$", disable_mouse_grab: true),
+                ],
+            )"#,
+        );
+        let enabled = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$", disable_mouse_grab: false),
+                ],
+            )"#,
+        );
+
+        let (normal, _) = apply_window_rule(disabled, "target", WindowType::Normal);
+        let (utility, _) = apply_window_rule(enabled, "target", WindowType::Utility);
+
+        assert!(!normal.allows_mouse_warp());
+        assert!(utility.allows_mouse_warp());
+    }
+
+    #[test]
+    fn rule_state_change_focus_respects_mouse_warp_policy() {
+        let disabled_fullscreen = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_fullscreen: false,
+                        disable_mouse_grab: true,
+                    ),
+                ],
+            )"#,
+        );
+        let utility_sticky = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_sticky: false,
+                        spawn_as_type: Utility,
+                    ),
+                ],
+            )"#,
+        );
+        let enabled_utility = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_fullscreen: false,
+                        disable_mouse_grab: false,
+                    ),
+                ],
+            )"#,
+        );
+
+        let (_, disabled_fullscreen_warp) =
+            apply_window_rule(disabled_fullscreen, "target", WindowType::Normal);
+        let (utility, utility_sticky_warp) =
+            apply_window_rule(utility_sticky, "target", WindowType::Normal);
+        let (_, enabled_utility_warp) =
+            apply_window_rule(enabled_utility, "target", WindowType::Utility);
+
+        assert!(!disabled_fullscreen_warp);
+        assert_eq!(utility.r#type, WindowType::Utility);
+        assert!(!utility_sticky_warp);
+        assert!(enabled_utility_warp);
     }
 
     #[test]


### PR DESCRIPTION
# Description

Right now dialogue windows grab the mouse when spawned which is increadably annoying in most use cases.
This keeps the mouse where it is when dialogue like windows spawn.

## Type of change

- [ ] Development change (no change visible to user)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

utility / dialogue wondows no longer grab mouse

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [x] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
