### PR TITLE
fix: preserve geometry for dialog-like windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(MSRV): update edition to 2024, MSRV to 1.85.0 (via #1338 by @mautamu and @VuiMuich)
 - feat(config.toml): remove TOML support entirely from leftwm, leftwm-check (via #1339 by @mautamu).
 
+### Added
+
+- Add `disable_mouse_grab` to window rules and suppress creation-time mouse warping for utility windows by default (via #1366).
+
 ### Fixes
 
 - Sloppy focus when switching tags with mouse over margins is now fixed (via #1311 by @fransklaver)

--- a/display-servers/x11rb-display-server/src/event_translate.rs
+++ b/display-servers/x11rb-display-server/src/event_translate.rs
@@ -97,6 +97,18 @@ fn from_focus_in(
     Ok(None)
 }
 
+fn requested_geometry(event: &xproto::ConfigureRequestEvent) -> XyhwChange {
+    let value_mask = u16::from(event.value_mask);
+    XyhwChange {
+        x: (value_mask & u16::from(xproto::ConfigWindow::X) != 0).then_some(event.x.into()),
+        y: (value_mask & u16::from(xproto::ConfigWindow::Y) != 0).then_some(event.y.into()),
+        w: (value_mask & u16::from(xproto::ConfigWindow::WIDTH) != 0).then_some(event.width.into()),
+        h: (value_mask & u16::from(xproto::ConfigWindow::HEIGHT) != 0)
+            .then_some(event.height.into()),
+        ..XyhwChange::default()
+    }
+}
+
 fn from_configure_request(
     event: &xproto::ConfigureRequestEvent,
     xw: &mut XWrap,
@@ -129,22 +141,13 @@ fn from_configure_request(
         return Ok(Some(DisplayEvent::ConfigureXlibWindow(handle)));
     }
     let mut change = WindowChange::new(handle);
-    let xyhw = match window_type {
-        // We want to handle the window positioning when it is a dialog or a normal window with a
-        // parent.
-        WindowType::Dialog | WindowType::Normal => XyhwChange {
-            w: Some(event.width.into()),
-            h: Some(event.height.into()),
-            ..XyhwChange::default()
-        },
-        _ => XyhwChange {
-            w: Some(event.width.into()),
-            h: Some(event.height.into()),
-            x: Some(event.x.into()),
-            y: Some(event.y.into()),
-            ..XyhwChange::default()
-        },
-    };
+    let mut xyhw = requested_geometry(event);
+    // Normal transient windows retain LeftWM's parent-relative placement. Dialog-like windows keep
+    // every geometry field explicitly selected by their client.
+    if window_type == WindowType::Normal {
+        xyhw.x = None;
+        xyhw.y = None;
+    }
     change.floating = Some(xyhw);
     Ok(Some(DisplayEvent::WindowChange(change)))
 }
@@ -219,4 +222,31 @@ fn from_button_release(
 ) -> Result<Option<DisplayEvent<X11rbWindowHandle>>> {
     xw.set_mode(Mode::Normal)?;
     Ok(Some(DisplayEvent::ChangeToNormalMode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configure_geometry_uses_the_x11_value_mask() {
+        let event = xproto::ConfigureRequestEvent {
+            window: 1,
+            x: -40,
+            y: 210,
+            width: 300,
+            height: 190,
+            value_mask: xproto::ConfigWindow::X | xproto::ConfigWindow::HEIGHT,
+            ..xproto::ConfigureRequestEvent::default()
+        };
+
+        assert_eq!(
+            requested_geometry(&event),
+            XyhwChange {
+                x: Some(-40),
+                h: Some(190),
+                ..XyhwChange::default()
+            }
+        );
+    }
 }

--- a/display-servers/x11rb-display-server/src/xwrap/window.rs
+++ b/display-servers/x11rb-display-server/src/xwrap/window.rs
@@ -34,6 +34,7 @@ impl XWrap {
         let actions = self.get_window_actions_atoms(window)?;
         let mut can_resize = actions.contains(&self.atoms.NetWMActionResize);
         let trans = self.get_transient_for(window)?;
+        let geometry = self.get_window_geometry(window)?;
         let sizing_hint = self.get_hint_sizing_as_xyhw(window)?;
         let wm_hint = self.get_wmhints(window)?;
 
@@ -48,14 +49,12 @@ impl XWrap {
         w.states = states;
         w.transient = trans.map(|h| WindowHandle(X11rbWindowHandle(h)));
 
-        // Initialise the windows floating with the pre-mapped settings.
-        sizing_hint
-            .unwrap_or_default()
-            .update_window_floating(&mut w);
+        // Initialise the window's floating geometry with its pre-map rectangle.
+        geometry.update_window_floating(&mut w);
         let mut requested = Xyhw::default();
-        sizing_hint.unwrap_or_default().update(&mut requested);
+        geometry.update(&mut requested);
 
-        if let Some(hint) = sizing_hint {
+        if let Some(mut hint) = sizing_hint {
             // Ignore this for now for non-splashes as it causes issues, e.g. mintstick is non-resizable but is too
             // small, issue #614: https://github.com/leftwm/leftwm/issues/614.
             can_resize = match (r#type, hint.minw, hint.minh, hint.maxw, hint.maxh) {
@@ -69,8 +68,8 @@ impl XWrap {
                 _ => true,
             };
             // Use the pre-mapped sizes if they are bigger.
-            // hint.w = std::cmp::max(xyhw.w, hint.w);
-            // hint.h = std::cmp::max(xyhw.h, hint.h);
+            hint.w = std::cmp::max(geometry.w, hint.w);
+            hint.h = std::cmp::max(geometry.h, hint.h);
             hint.update_window_floating(&mut w);
             hint.update(&mut requested);
         }
@@ -81,12 +80,6 @@ impl XWrap {
             w.never_focus = !hint.input.unwrap_or(true);
             w.urgent = hint.urgent;
         }
-        // Is this needed? Made it so it doens't overwrite prior sizing.
-        if w.floating() && sizing_hint.is_none() {
-            let geo = self.get_window_geometry(window)?;
-            geo.update_window_floating(&mut w);
-        }
-
         let cursor = self.get_cursor_point()?;
         Ok(Some(DisplayEvent::WindowCreate(w, cursor.0, cursor.1)))
     }

--- a/display-servers/xlib-display-server/src/event_translate.rs
+++ b/display-servers/xlib-display-server/src/event_translate.rs
@@ -109,6 +109,17 @@ fn from_property_notify(x_event: &XEvent) -> Option<DisplayEvent<XlibWindowHandl
     event_translate_property_notify::from_event(x_event.0, event)
 }
 
+fn requested_geometry(event: &xlib::XConfigureRequestEvent) -> XyhwChange {
+    let value_mask = event.value_mask;
+    XyhwChange {
+        x: (value_mask & c_ulong::from(xlib::CWX) != 0).then_some(event.x),
+        y: (value_mask & c_ulong::from(xlib::CWY) != 0).then_some(event.y),
+        w: (value_mask & c_ulong::from(xlib::CWWidth) != 0).then_some(event.width),
+        h: (value_mask & c_ulong::from(xlib::CWHeight) != 0).then_some(event.height),
+        ..XyhwChange::default()
+    }
+}
+
 fn from_configure_request(x_event: XEvent) -> Option<DisplayEvent<XlibWindowHandle>> {
     let xw = x_event.0;
     let event = xlib::XConfigureRequestEvent::from(x_event.1);
@@ -147,22 +158,13 @@ fn from_configure_request(x_event: XEvent) -> Option<DisplayEvent<XlibWindowHand
         return Some(DisplayEvent::ConfigureXlibWindow(handle));
     }
     let mut change = WindowChange::new(handle);
-    let xyhw = match window_type {
-        // We want to handle the window positioning when it is a dialog or a normal window with a
-        // parent.
-        WindowType::Dialog | WindowType::Normal => XyhwChange {
-            w: Some(event.width),
-            h: Some(event.height),
-            ..XyhwChange::default()
-        },
-        _ => XyhwChange {
-            w: Some(event.width),
-            h: Some(event.height),
-            x: Some(event.x),
-            y: Some(event.y),
-            ..XyhwChange::default()
-        },
-    };
+    let mut xyhw = requested_geometry(&event);
+    // Normal transient windows retain LeftWM's parent-relative placement. Dialog-like windows keep
+    // every geometry field explicitly selected by their client.
+    if window_type == WindowType::Normal {
+        xyhw.x = None;
+        xyhw.y = None;
+    }
     change.floating = Some(xyhw);
     Some(DisplayEvent::WindowChange(change))
 }
@@ -232,4 +234,38 @@ fn from_button_release(x_event: XEvent) -> DisplayEvent<XlibWindowHandle> {
     let xw = x_event.0;
     xw.set_mode(Mode::Normal);
     DisplayEvent::ChangeToNormalMode
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configure_geometry_uses_the_x11_value_mask() {
+        let event = xlib::XConfigureRequestEvent {
+            type_: xlib::ConfigureRequest,
+            serial: 0,
+            send_event: xlib::False,
+            display: std::ptr::null_mut(),
+            parent: 0,
+            window: 1,
+            x: -40,
+            y: 210,
+            width: 300,
+            height: 190,
+            border_width: 0,
+            above: 0,
+            detail: 0,
+            value_mask: c_ulong::from(xlib::CWX | xlib::CWHeight),
+        };
+
+        assert_eq!(
+            requested_geometry(&event),
+            XyhwChange {
+                x: Some(-40),
+                h: Some(190),
+                ..XyhwChange::default()
+            }
+        );
+    }
 }

--- a/examples/config-with-comments.ron
+++ b/examples/config-with-comments.ron
@@ -59,7 +59,12 @@
     scratchpad: [
         (name: "Alacritty", value: "alacritty", x: 860, y: 390, height: 300, width: 200),
     ],
-    window_rules: [],
+    window_rules: [
+        // Utility windows disable the creation-time mouse warp by default.
+        // Disable it for another window by matching its class or title:
+        // (window_class: "^pavucontrol$", disable_mouse_grab: true),
+        // Use `disable_mouse_grab: false` to re-enable it for a matching utility window.
+    ],
     disable_current_tag_swap: false,
     disable_tile_drag: false,
     disable_window_snap: true,

--- a/leftwm-core/src/config.rs
+++ b/leftwm-core/src/config.rs
@@ -64,6 +64,9 @@ pub trait Config {
     fn disable_window_snap(&self) -> bool;
     fn sloppy_mouse_follows_focus(&self) -> bool;
     fn create_follows_cursor(&self) -> bool;
+    fn respect_dialog_position(&self) -> bool {
+        false
+    }
     fn reposition_cursor_on_resize(&self) -> bool;
     fn window_hiding_strategy(&self) -> WindowHidingStrategy;
 
@@ -114,6 +117,7 @@ pub(crate) mod tests {
         pub insert_behavior: InsertBehavior,
         pub border_width: i32,
         pub single_window_border: bool,
+        pub respect_dialog_position: bool,
     }
 
     impl Config for TestConfig {
@@ -248,6 +252,10 @@ pub(crate) mod tests {
 
         fn create_follows_cursor(&self) -> bool {
             false
+        }
+
+        fn respect_dialog_position(&self) -> bool {
+            self.respect_dialog_position
         }
 
         fn window_hiding_strategy(&self) -> WindowHidingStrategy {

--- a/leftwm-core/src/event_loop.rs
+++ b/leftwm-core/src/event_loop.rs
@@ -9,10 +9,10 @@ use std::sync::{Once, atomic::Ordering};
 /// Errors which can appear while running the event loop.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Error {
-    #[error("Couldn't create the file: '{0}'")]
+    #[error("Couldn't create the file: '{}'", .0.display())]
     CreateFile(PathBuf),
 
-    #[error("Couldn't connect to file: '{0}'")]
+    #[error("Couldn't connect to file: '{}'", .0.display())]
     ConnectToFile(PathBuf),
 }
 

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -174,15 +174,10 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
                 above_changed = states.contains(&WindowState::Above)
                     != window.states.contains(&WindowState::Above);
             }
-            let container = match find_transient_parent(&windows, window.transient) {
-                Some(parent) => Some(parent.exact_xyhw()),
-                None if window.r#type == WindowType::Dialog => self
-                    .state
-                    .workspaces
-                    .iter()
-                    .find(|ws| ws.tag == window.tag)
-                    .map(|ws| ws.xyhw),
-                _ => None,
+            let container = if window.r#type.is_dialog_like() {
+                None
+            } else {
+                find_transient_parent(&windows, window.transient).map(Window::exact_xyhw)
             };
 
             changed = change.update(window, container);
@@ -396,6 +391,15 @@ fn set_relative_floating<H: Handle>(window: &mut Window<H>, ws: &Workspace, oute
     window.set_floating_exact(xyhw);
 }
 
+// Dialog-like windows already carry the geometry selected by their client. Keep that geometry
+// instead of replacing its position with LeftWM's centering policy.
+fn set_requested_floating<H: Handle>(window: &mut Window<H>, ws: &Workspace) {
+    window.set_floating(true);
+    window.normal = ws.xyhw;
+    let xyhw = window.requested.unwrap_or_else(|| ws.center_halfed());
+    window.set_floating_exact(xyhw);
+}
+
 fn setup_window<H: Handle>(
     state: &mut State<H>,
     window: &mut Window<H>,
@@ -461,6 +465,13 @@ fn setup_window<H: Handle>(
         }
     }
 
+    // Dialog-like clients are responsible for their own geometry. This must run before transient
+    // handling, which intentionally centers normal child windows relative to their parent.
+    if window.r#type.is_dialog_like() {
+        set_requested_floating(window, ws);
+        return;
+    }
+
     // Setup a child window.
     if let Some(parent) = find_transient_parent(&state.windows, window.transient) {
         // This is currently for vlc, this probably will need to be more general if another
@@ -472,17 +483,11 @@ fn setup_window<H: Handle>(
     }
 
     // Setup window based on type.
-    match window.r#type {
-        WindowType::Normal => {
-            window.apply_margin_multiplier(ws.margin_multiplier);
-            if window.floating() {
-                set_relative_floating(window, ws, ws.xyhw_avoided);
-            }
-        }
-        WindowType::Dialog | WindowType::Splash => {
+    if window.r#type == WindowType::Normal {
+        window.apply_margin_multiplier(ws.margin_multiplier);
+        if window.floating() {
             set_relative_floating(window, ws, ws.xyhw_avoided);
         }
-        _ => {}
     }
 }
 
@@ -516,7 +521,7 @@ mod tests {
     use super::*;
     use crate::Manager;
     use crate::layouts::MONOCLE;
-    use crate::models::{MockHandle, Screen};
+    use crate::models::{MockHandle, Screen, XyhwBuilder, XyhwChange};
 
     fn last_window_order(state: &State<MockHandle>) -> Vec<WindowHandle<MockHandle>> {
         state
@@ -528,6 +533,139 @@ mod tests {
                 _ => None,
             })
             .expect("expected a window order action")
+    }
+
+    fn dialog_like_types() -> [WindowType; 10] {
+        [
+            WindowType::Dialog,
+            WindowType::Splash,
+            WindowType::Utility,
+            WindowType::Menu,
+            WindowType::DropdownMenu,
+            WindowType::PopupMenu,
+            WindowType::Tooltip,
+            WindowType::Notification,
+            WindowType::Combo,
+            WindowType::Dnd,
+        ]
+    }
+
+    #[test]
+    fn dialog_like_windows_keep_their_requested_geometry() {
+        let requested: Xyhw = XyhwBuilder {
+            x: 120,
+            y: 80,
+            w: 240,
+            h: 160,
+            ..XyhwBuilder::default()
+        }
+        .into();
+
+        for (handle, window_type) in dialog_like_types().into_iter().enumerate() {
+            let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.screen_create_handler(Screen::default());
+
+            let handle = WindowHandle::<MockHandle>(handle as i32 + 1);
+            let mut window = Window::new(handle, None, None);
+            window.r#type = window_type;
+            window.requested = Some(requested);
+            manager.window_created_handler(window, -1, -1);
+
+            let actual = manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == handle)
+                .expect("expected the dialog-like window")
+                .exact_xyhw();
+            assert_eq!(actual, requested);
+        }
+    }
+
+    #[test]
+    fn dialog_like_windows_without_geometry_keep_the_centered_fallback() {
+        for (handle, window_type) in dialog_like_types().into_iter().enumerate() {
+            let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.screen_create_handler(Screen::default());
+            let expected = manager.state.workspaces[0].center_halfed();
+
+            let handle = WindowHandle::<MockHandle>(handle as i32 + 1);
+            let mut window = Window::new(handle, None, None);
+            window.r#type = window_type;
+            manager.window_created_handler(window, -1, -1);
+
+            let actual = manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == handle)
+                .expect("expected the dialog-like window")
+                .exact_xyhw();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn dialog_like_configure_changes_only_update_requested_fields() {
+        for (index, window_type) in dialog_like_types().into_iter().enumerate() {
+            let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.screen_create_handler(Screen::default());
+
+            let parent_handle = WindowHandle::<MockHandle>(1);
+            manager.window_created_handler(Window::new(parent_handle, None, None), -1, -1);
+
+            let requested: Xyhw = XyhwBuilder {
+                x: 120,
+                y: 80,
+                w: 240,
+                h: 160,
+                ..XyhwBuilder::default()
+            }
+            .into();
+            let handle = WindowHandle::<MockHandle>(index as i32 + 2);
+            let mut window = Window::new(handle, None, None);
+            window.r#type = window_type;
+            window.transient = Some(parent_handle);
+            window.border = 0;
+            window.requested = Some(requested);
+            manager.window_created_handler(window, -1, -1);
+
+            let mut resize = WindowChange::new(handle);
+            resize.floating = Some(XyhwChange {
+                w: Some(300),
+                h: Some(190),
+                ..XyhwChange::default()
+            });
+            manager.window_changed_handler(resize);
+
+            let resized = manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == handle)
+                .expect("expected the resized dialog-like window")
+                .exact_xyhw();
+            assert_eq!((resized.x(), resized.y()), (120, 80));
+            assert_eq!((resized.w(), resized.h()), (300, 190));
+
+            let mut movement = WindowChange::new(handle);
+            movement.floating = Some(XyhwChange {
+                x: Some(-40),
+                y: Some(210),
+                ..XyhwChange::default()
+            });
+            manager.window_changed_handler(movement);
+
+            let moved = manager
+                .state
+                .windows
+                .iter()
+                .find(|window| window.handle == handle)
+                .expect("expected the moved dialog-like window")
+                .exact_xyhw();
+            assert_eq!((moved.x(), moved.y()), (-40, 210));
+            assert_eq!((moved.w(), moved.h()), (300, 190));
+        }
     }
 
     #[test]

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -30,10 +30,12 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
         let mut on_same_tag = true;
         // Random value
         let mut layout = MAIN_AND_VERT_STACK.to_string();
+        let respect_dialog_position = self.config.respect_dialog_position();
         setup_window(
             &mut self.state,
             &mut window,
             (x, y),
+            respect_dialog_position,
             &mut layout,
             &mut is_first,
             &mut on_same_tag,
@@ -159,6 +161,7 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
         let mut transient_changed = false;
         let strut_changed = change.strut.is_some();
         let windows = self.state.windows.clone();
+        let respect_dialog_position = self.config.respect_dialog_position();
         if let Some(window) = self
             .state
             .windows
@@ -175,10 +178,19 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
                 above_changed = states.contains(&WindowState::Above)
                     != window.states.contains(&WindowState::Above);
             }
-            let container = if window.r#type.is_dialog_like() {
+            let container = if respect_dialog_position && window.r#type.is_dialog_like() {
                 None
             } else {
-                find_transient_parent(&windows, window.transient).map(Window::exact_xyhw)
+                match find_transient_parent(&windows, window.transient) {
+                    Some(parent) => Some(parent.exact_xyhw()),
+                    None if window.r#type == WindowType::Dialog => self
+                        .state
+                        .workspaces
+                        .iter()
+                        .find(|ws| ws.tag == window.tag)
+                        .map(|ws| ws.xyhw),
+                    _ => None,
+                }
             };
 
             changed = change.update(window, container);
@@ -405,6 +417,7 @@ fn setup_window<H: Handle>(
     state: &mut State<H>,
     window: &mut Window<H>,
     xy: (i32, i32),
+    respect_dialog_position: bool,
     layout: &mut String,
     is_first: &mut bool,
     on_same_tag: &mut bool,
@@ -468,7 +481,7 @@ fn setup_window<H: Handle>(
 
     // Dialog-like clients are responsible for their own geometry. This must run before transient
     // handling, which intentionally centers normal child windows relative to their parent.
-    if window.r#type.is_dialog_like() {
+    if respect_dialog_position && window.r#type.is_dialog_like() {
         set_requested_floating(window, ws);
         return;
     }
@@ -484,11 +497,17 @@ fn setup_window<H: Handle>(
     }
 
     // Setup window based on type.
-    if window.r#type == WindowType::Normal {
-        window.apply_margin_multiplier(ws.margin_multiplier);
-        if window.floating() {
+    match window.r#type {
+        WindowType::Normal => {
+            window.apply_margin_multiplier(ws.margin_multiplier);
+            if window.floating() {
+                set_relative_floating(window, ws, ws.xyhw_avoided);
+            }
+        }
+        WindowType::Dialog | WindowType::Splash => {
             set_relative_floating(window, ws, ws.xyhw_avoided);
         }
+        _ => {}
     }
 }
 
@@ -600,7 +619,7 @@ mod tests {
     }
 
     #[test]
-    fn dialog_like_windows_keep_their_requested_geometry() {
+    fn dialog_like_windows_keep_their_requested_geometry_when_enabled() {
         let requested: Xyhw = XyhwBuilder {
             x: 120,
             y: 80,
@@ -612,6 +631,7 @@ mod tests {
 
         for (handle, window_type) in dialog_like_types().into_iter().enumerate() {
             let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.config.respect_dialog_position = true;
             manager.screen_create_handler(Screen::default());
 
             let handle = WindowHandle::<MockHandle>(handle as i32 + 1);
@@ -629,6 +649,39 @@ mod tests {
                 .exact_xyhw();
             assert_eq!(actual, requested);
         }
+    }
+
+    #[test]
+    fn dialog_windows_center_by_default_but_keep_their_requested_size() {
+        let mut manager = Manager::new_test(vec!["1".to_owned()]);
+        manager.screen_create_handler(Screen::default());
+
+        let requested: Xyhw = XyhwBuilder {
+            x: 120,
+            y: 80,
+            w: 240,
+            h: 160,
+            ..XyhwBuilder::default()
+        }
+        .into();
+        let handle = WindowHandle::<MockHandle>(1);
+        let mut window = Window::new(handle, None, None);
+        window.r#type = WindowType::Dialog;
+        window.requested = Some(requested);
+        let mut expected = requested;
+        expected.center_relative(manager.state.workspaces[0].xyhw_avoided, window.border);
+        manager.window_created_handler(window, -1, -1);
+
+        let actual = manager
+            .state
+            .windows
+            .iter()
+            .find(|window| window.handle == handle)
+            .expect("expected the dialog window")
+            .exact_xyhw();
+        assert_eq!(actual, expected);
+        assert_eq!((actual.w(), actual.h()), (requested.w(), requested.h()));
+        assert_ne!((actual.x(), actual.y()), (requested.x(), requested.y()));
     }
 
     #[test]
@@ -655,6 +708,7 @@ mod tests {
     fn dialog_like_windows_without_geometry_keep_the_centered_fallback() {
         for (handle, window_type) in dialog_like_types().into_iter().enumerate() {
             let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.config.respect_dialog_position = true;
             manager.screen_create_handler(Screen::default());
             let expected = manager.state.workspaces[0].center_halfed();
 
@@ -675,9 +729,10 @@ mod tests {
     }
 
     #[test]
-    fn dialog_like_configure_changes_only_update_requested_fields() {
+    fn dialog_like_configure_changes_only_update_requested_fields_when_enabled() {
         for (index, window_type) in dialog_like_types().into_iter().enumerate() {
             let mut manager = Manager::new_test(vec!["1".to_owned()]);
+            manager.config.respect_dialog_position = true;
             manager.screen_create_handler(Screen::default());
 
             let parent_handle = WindowHandle::<MockHandle>(1);
@@ -735,6 +790,69 @@ mod tests {
             assert_eq!((moved.x(), moved.y()), (-40, 210));
             assert_eq!((moved.w(), moved.h()), (300, 190));
         }
+    }
+
+    #[test]
+    fn dialog_configure_centers_by_default_but_keeps_the_requested_size() {
+        let mut manager = Manager::new_test(vec!["1".to_owned()]);
+        manager.screen_create_handler(Screen::default());
+
+        let parent_handle = WindowHandle::<MockHandle>(1);
+        manager.window_created_handler(Window::new(parent_handle, None, None), -1, -1);
+        let parent = manager
+            .state
+            .windows
+            .iter()
+            .find(|window| window.handle == parent_handle)
+            .expect("expected the parent window")
+            .exact_xyhw();
+
+        let handle = WindowHandle::<MockHandle>(2);
+        let mut window = Window::new(handle, None, None);
+        window.r#type = WindowType::Dialog;
+        window.transient = Some(parent_handle);
+        window.border = 0;
+        window.requested = Some(
+            XyhwBuilder {
+                x: 120,
+                y: 80,
+                w: 240,
+                h: 160,
+                ..XyhwBuilder::default()
+            }
+            .into(),
+        );
+        manager.window_created_handler(window, -1, -1);
+
+        let mut requested: Xyhw = XyhwBuilder {
+            x: -40,
+            y: 210,
+            w: 300,
+            h: 190,
+            ..XyhwBuilder::default()
+        }
+        .into();
+        let mut change = WindowChange::new(handle);
+        change.floating = Some(XyhwChange {
+            x: Some(requested.x()),
+            y: Some(requested.y()),
+            w: Some(requested.w()),
+            h: Some(requested.h()),
+            ..XyhwChange::default()
+        });
+        manager.window_changed_handler(change);
+
+        requested.center_relative(parent, 0);
+        let actual = manager
+            .state
+            .windows
+            .iter()
+            .find(|window| window.handle == handle)
+            .expect("expected the dialog window")
+            .exact_xyhw();
+        assert_eq!(actual, requested);
+        assert_eq!((actual.w(), actual.h()), (300, 190));
+        assert_ne!((actual.x(), actual.y()), (-40, 210));
     }
 
     #[test]

--- a/leftwm-core/src/handlers/window_handler.rs
+++ b/leftwm-core/src/handlers/window_handler.rs
@@ -45,7 +45,8 @@ impl<H: Handle, C: Config, SERVER: DisplayServer<H>> Manager<H, C, SERVER> {
             && self.state.focus_manager.behaviour.is_sloppy()
             && self.state.focus_manager.sloppy_mouse_follows_focus
             && window.is_managed()
-            && on_same_tag;
+            && on_same_tag
+            && window.allows_mouse_warp();
 
         // Let the DS know we are managing this window.
         let act = DisplayAction::AddedWindow(window.handle, window.floating(), follow_mouse);
@@ -516,7 +517,7 @@ mod tests {
     use super::*;
     use crate::Manager;
     use crate::layouts::MONOCLE;
-    use crate::models::{MockHandle, Screen};
+    use crate::models::{FocusBehaviour, MockHandle, Screen};
 
     fn last_window_order(state: &State<MockHandle>) -> Vec<WindowHandle<MockHandle>> {
         state
@@ -528,6 +529,74 @@ mod tests {
                 _ => None,
             })
             .expect("expected a window order action")
+    }
+
+    fn follows_mouse_on_creation(
+        window: Window<MockHandle>,
+        focus_new_windows: bool,
+        focus_behaviour: FocusBehaviour,
+        sloppy_mouse_follows_focus: bool,
+    ) -> bool {
+        let mut manager = Manager::new_test(vec!["1".to_owned()]);
+        manager.screen_create_handler(Screen::default());
+        manager.state.actions.clear();
+        manager.state.focus_manager.focus_new_windows = focus_new_windows;
+        manager.state.focus_manager.behaviour = focus_behaviour;
+        manager.state.focus_manager.sloppy_mouse_follows_focus = sloppy_mouse_follows_focus;
+
+        manager.window_created_handler(window, -1, -1);
+
+        manager
+            .state
+            .actions
+            .iter()
+            .find_map(|action| match action {
+                DisplayAction::AddedWindow(_, _, follow_mouse) => Some(*follow_mouse),
+                _ => None,
+            })
+            .expect("expected an AddedWindow action")
+    }
+
+    #[test]
+    fn new_window_mouse_warp_uses_type_default_and_window_override() {
+        let cases = [
+            (1, WindowType::Normal, None, true),
+            (2, WindowType::Utility, None, false),
+            (3, WindowType::Normal, Some(true), false),
+            (4, WindowType::Utility, Some(false), true),
+        ];
+
+        for (handle, window_type, disable_mouse_grab, expected) in cases {
+            let mut window = Window::new(WindowHandle(handle), None, None);
+            window.r#type = window_type;
+            window.set_disable_mouse_grab(disable_mouse_grab);
+
+            assert_eq!(
+                follows_mouse_on_creation(window, true, FocusBehaviour::Sloppy, true),
+                expected,
+                "unexpected follow_mouse for disable_mouse_grab={disable_mouse_grab:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn mouse_warp_permission_does_not_bypass_global_focus_settings() {
+        let cases = [
+            (false, FocusBehaviour::Sloppy, true),
+            (true, FocusBehaviour::ClickTo, true),
+            (true, FocusBehaviour::Sloppy, false),
+        ];
+
+        for (focus_new_windows, focus_behaviour, sloppy_mouse_follows_focus) in cases {
+            let window = Window::new(WindowHandle(1), None, None);
+
+            assert!(!follows_mouse_on_creation(
+                window,
+                focus_new_windows,
+                focus_behaviour,
+                sloppy_mouse_follows_focus,
+            ));
+        }
     }
 
     #[test]

--- a/leftwm-core/src/models/window.rs
+++ b/leftwm-core/src/models/window.rs
@@ -55,6 +55,9 @@ pub struct Window<H: Handle> {
     pub(crate) must_float: bool,
     floating: Option<Xyhw>,
     pub never_focus: bool,
+    /// Per-window override for the creation-time pointer warp.
+    #[serde(default)]
+    disable_mouse_grab: Option<bool>,
     pub urgent: bool,
     pub debugging: bool,
     pub name: Option<String>,
@@ -89,6 +92,7 @@ impl<H: Handle> Window<H> {
             must_float: false,
             debugging: false,
             never_focus: false,
+            disable_mouse_grab: None,
             urgent: false,
             name,
             pid,
@@ -122,6 +126,20 @@ impl<H: Handle> Window<H> {
             || self.r#type == WindowType::Splash
             || self.r#type == WindowType::Toolbar
             || self.r#type == WindowType::Notification
+    }
+
+    /// Set a per-window override for the creation-time pointer warp.
+    pub fn set_disable_mouse_grab(&mut self, value: Option<bool>) {
+        self.disable_mouse_grab = value;
+    }
+
+    /// Whether the new-window path may move the pointer into this window.
+    #[must_use]
+    pub fn allows_mouse_warp(&self) -> bool {
+        match self.disable_mouse_grab {
+            Some(disabled) => !disabled,
+            None => self.r#type != WindowType::Utility,
+        }
     }
 
     pub fn set_floating(&mut self, value: bool) {
@@ -399,5 +417,48 @@ mod tests {
         subject.tag(&1);
         subject.untag();
         assert!(!subject.has_tag(&1), "was unable to untag the window");
+    }
+
+    #[test]
+    fn mouse_warp_policy_honors_type_defaults_and_explicit_overrides() {
+        let cases = [
+            (1, WindowType::Normal, None, true),
+            (2, WindowType::Utility, None, false),
+            (3, WindowType::Normal, Some(true), false),
+            (4, WindowType::Utility, Some(false), true),
+        ];
+
+        for (handle, window_type, disable_mouse_grab, expected) in cases {
+            let mut subject = Window::new(WindowHandle::<MockHandle>(handle), None, None);
+            subject.r#type = window_type;
+            subject.set_disable_mouse_grab(disable_mouse_grab);
+
+            assert_eq!(
+                subject.allows_mouse_warp(),
+                expected,
+                "unexpected mouse-warp policy for {:?} with disable_mouse_grab={:?}",
+                subject.r#type,
+                disable_mouse_grab,
+            );
+        }
+    }
+
+    #[test]
+    fn missing_mouse_grab_policy_deserializes_as_the_type_default() {
+        let mut subject = Window::new(WindowHandle::<MockHandle>(1), None, None);
+        subject.r#type = WindowType::Utility;
+        subject.set_disable_mouse_grab(Some(false));
+
+        let mut serialized = serde_json::to_value(subject).expect("window should serialize");
+        let fields = serialized
+            .as_object_mut()
+            .expect("a serialized window should be a map");
+        assert!(fields.remove("disable_mouse_grab").is_some());
+
+        let restored: Window<MockHandle> =
+            serde_json::from_value(serialized).expect("legacy window state should deserialize");
+
+        assert_eq!(restored.disable_mouse_grab, None);
+        assert!(!restored.allows_mouse_warp());
     }
 }

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -211,6 +211,13 @@ the cursor will be snapped to the lower right corner of the window which is
 being resized.
 .PP
 Default: \f[C]disable_cursor_reposition_on_resize = false\f[R]
+.SS Dialog Position
+.PP
+LeftWM centers dialog windows by default while retaining the dimensions requested
+by the client. Set \f[C]respect_dialog_position\f[R] to true to also retain the
+position requested by dialog-like windows.
+.PP
+Default: \f[C]respect_dialog_position = false\f[R]
 .SS Window Creation and Cursor Focus
 .PP
 In multi-workspace layouts (such as with multiple monitors), LeftWM

--- a/leftwm/doc/leftwm.1
+++ b/leftwm/doc/leftwm.1
@@ -228,6 +228,26 @@ when unset (\f[C]None\f[R]), \f[C]Some(true)\f[R], or when the cursor is in \f[C
 when set to \f[C]Some(false)\f[R]
 .PP
 Default: \f[C]create_follows_cursor = None\f[R]
+.SS Per-window New-window Mouse Warping
+.PP
+When Sloppy focus, focus_new_windows, and sloppy_mouse_follows_focus would normally
+move the pointer into a new window, a window rule can suppress that creation-time
+movement with \f[C]disable_mouse_grab\f[R]. This option controls pointer movement;
+it does not disable keyboard focus or mouse-button handling.
+.PP
+Example:
+.IP
+.nf
+\f[C]
+window_rules: [
+    (window_class: "^pavucontrol$", disable_mouse_grab: true),
+]
+\f[R]
+.fi
+.PP
+Windows of type \f[C]_NET_WM_WINDOW_TYPE_UTILITY\f[R] suppress the movement by
+default. A matching rule with \f[C]disable_mouse_grab: false\f[R] explicitly
+restores the normal behavior for a utility window.
 .SS Layouts
 .PP
 Leftwm supports a variety of user definable layouts. Layouts define the way that windows are tiled in the workspace.

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -269,6 +269,7 @@ pub struct Config {
     pub create_follows_cursor: Option<bool>,
     pub auto_derive_workspaces: bool,
     pub disable_cursor_reposition_on_resize: bool,
+    pub respect_dialog_position: bool,
     pub focus_on_activation: FocusOnActivationBehaviour,
     pub window_hiding_strategy: WindowHidingStrategy,
     #[cfg(feature = "lefthk")]
@@ -728,6 +729,10 @@ impl leftwm_core::Config for Config {
 
     fn reposition_cursor_on_resize(&self) -> bool {
         !self.disable_cursor_reposition_on_resize
+    }
+
+    fn respect_dialog_position(&self) -> bool {
+        self.respect_dialog_position
     }
 
     // Determines if a new window should be created under the cursor or on the workspace which has the focus

--- a/leftwm/src/config.rs
+++ b/leftwm/src/config.rs
@@ -74,6 +74,9 @@ pub struct WindowHook {
     pub spawn_fullscreen: Option<bool>,
     /// Handle the window as if it was of this `_NET_WM_WINDOW_TYPE`
     pub spawn_as_type: Option<WindowType>,
+    /// Suppress the creation-time pointer warp for matching windows.
+    #[serde(default)]
+    pub disable_mouse_grab: Option<bool>,
     pub hiding_strategy: Option<WindowHidingStrategy>,
 }
 
@@ -194,18 +197,28 @@ impl WindowHook {
         if let Some(should_float) = self.spawn_floating {
             window.set_floating(should_float);
         }
+        if let Some(window_type) = &self.spawn_as_type {
+            window.r#type.clone_from(window_type);
+        }
+        window.set_disable_mouse_grab(self.disable_mouse_grab);
+
+        let refocus_after_state_change = |state: &mut State<H>, window: &Window<H>| {
+            if window.allows_mouse_warp() {
+                state.handle_window_focus(&window.handle);
+            } else {
+                state.focus_window(&window.handle);
+            }
+        };
+
         if let Some(fullscreen) = self.spawn_fullscreen {
             let act = DisplayAction::SetState(window.handle, fullscreen, WindowState::Fullscreen);
             state.actions.push_back(act);
-            state.handle_window_focus(&window.handle);
+            refocus_after_state_change(state, window);
         }
         if let Some(sticky) = self.spawn_sticky {
             let act = DisplayAction::SetState(window.handle, sticky, WindowState::Sticky);
             state.actions.push_back(act);
-            state.handle_window_focus(&window.handle);
-        }
-        if let Some(w_type) = self.spawn_as_type.clone() {
-            window.r#type = w_type;
+            refocus_after_state_change(state, window);
         }
         window.hiding_strategy = self.hiding_strategy;
     }
@@ -763,6 +776,78 @@ fn write_to_pipe(return_pipe: &mut Result<File, Box<dyn Error>>, msg: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leftwm_core::models::WindowHandle;
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+    struct TestHandle(i32);
+
+    impl Handle for TestHandle {}
+
+    struct TestDisplayServer;
+
+    impl DisplayServer<TestHandle> for TestDisplayServer {
+        fn new(_: &impl leftwm_core::Config) -> Self {
+            Self
+        }
+
+        fn get_next_events(&mut self) -> Vec<leftwm_core::DisplayEvent<TestHandle>> {
+            vec![]
+        }
+
+        fn reload_config(
+            &mut self,
+            _: &impl leftwm_core::Config,
+            _: Option<WindowHandle<TestHandle>>,
+            _: &[Window<TestHandle>],
+        ) {
+        }
+
+        fn wait_readable(&self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> {
+            Box::pin(std::future::pending())
+        }
+
+        fn flush(&self) {}
+
+        fn generate_verify_focus_event(&self) -> Option<leftwm_core::DisplayEvent<TestHandle>> {
+            None
+        }
+    }
+
+    fn parse_ron_config(input: &str) -> Config {
+        Options::default()
+            .with_default_extension(Extensions::IMPLICIT_SOME | Extensions::UNWRAP_NEWTYPES)
+            .from_str(input)
+            .expect("test config should deserialize")
+    }
+
+    fn apply_window_rule(
+        config: Config,
+        class: &str,
+        window_type: WindowType,
+    ) -> (Window<TestHandle>, bool) {
+        let mut manager: Manager<TestHandle, Config, TestDisplayServer> = Manager::new(config);
+        manager.state.focus_manager.behaviour = FocusBehaviour::Sloppy;
+        manager.state.focus_manager.sloppy_mouse_follows_focus = true;
+        manager.state.actions.clear();
+
+        let mut window = Window::new(WindowHandle(TestHandle(1)), None, None);
+        window.res_class = Some(class.to_owned());
+        window.r#type = window_type;
+
+        assert!(<Config as leftwm_core::Config>::setup_predefined_window(
+            &manager.config,
+            &mut manager.state,
+            &mut window,
+        ));
+
+        let queued_mouse_warp = manager
+            .state
+            .actions
+            .iter()
+            .any(|action| matches!(action, DisplayAction::MoveMouseOver(..)));
+
+        (window, queued_mouse_warp)
+    }
 
     #[test]
     fn config_serializes_to_valid_ron_test() {
@@ -777,6 +862,116 @@ mod tests {
 
         let ron_config = ron::from_str::<'_, Config>(ron.unwrap().as_str());
         assert!(ron_config.is_ok(), "Could not deserialize default config");
+    }
+
+    #[test]
+    fn documented_mouse_grab_rule_example_deserializes() {
+        let config = parse_ron_config(
+            r#"(
+                window_rules: [
+                    // Disable the creation-time pointer warp for this application.
+                    (window_class: "^pavucontrol$", disable_mouse_grab: true),
+                ],
+            )"#,
+        );
+
+        assert_eq!(
+            config.window_rules.as_ref().unwrap()[0].disable_mouse_grab,
+            Some(true),
+        );
+    }
+
+    #[test]
+    fn window_rule_without_mouse_grab_setting_uses_window_type_default() {
+        let config = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$"),
+                ],
+            )"#,
+        );
+
+        assert_eq!(
+            config.window_rules.as_ref().unwrap()[0].disable_mouse_grab,
+            None,
+        );
+
+        let (normal, queued_mouse_warp) = apply_window_rule(config, "target", WindowType::Normal);
+        assert!(normal.allows_mouse_warp());
+        assert!(!queued_mouse_warp);
+    }
+
+    #[test]
+    fn window_rule_mouse_grab_setting_accepts_both_boolean_overrides() {
+        let disabled = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$", disable_mouse_grab: true),
+                ],
+            )"#,
+        );
+        let enabled = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (window_class: "^target$", disable_mouse_grab: false),
+                ],
+            )"#,
+        );
+
+        let (normal, _) = apply_window_rule(disabled, "target", WindowType::Normal);
+        let (utility, _) = apply_window_rule(enabled, "target", WindowType::Utility);
+
+        assert!(!normal.allows_mouse_warp());
+        assert!(utility.allows_mouse_warp());
+    }
+
+    #[test]
+    fn rule_state_change_focus_respects_mouse_warp_policy() {
+        let disabled_fullscreen = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_fullscreen: false,
+                        disable_mouse_grab: true,
+                    ),
+                ],
+            )"#,
+        );
+        let utility_sticky = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_sticky: false,
+                        spawn_as_type: Utility,
+                    ),
+                ],
+            )"#,
+        );
+        let enabled_utility = parse_ron_config(
+            r#"(
+                window_rules: [
+                    (
+                        window_class: "^target$",
+                        spawn_fullscreen: false,
+                        disable_mouse_grab: false,
+                    ),
+                ],
+            )"#,
+        );
+
+        let (_, disabled_fullscreen_warp) =
+            apply_window_rule(disabled_fullscreen, "target", WindowType::Normal);
+        let (utility, utility_sticky_warp) =
+            apply_window_rule(utility_sticky, "target", WindowType::Normal);
+        let (_, enabled_utility_warp) =
+            apply_window_rule(enabled_utility, "target", WindowType::Utility);
+
+        assert!(!disabled_fullscreen_warp);
+        assert_eq!(utility.r#type, WindowType::Utility);
+        assert!(!utility_sticky_warp);
+        assert!(enabled_utility_warp);
     }
 
     #[test]

--- a/leftwm/src/config/default.rs
+++ b/leftwm/src/config/default.rs
@@ -249,6 +249,7 @@ impl Default for Config {
             sloppy_mouse_follows_focus: true,
             create_follows_cursor: None,
             disable_cursor_reposition_on_resize: false,
+            respect_dialog_position: false,
             auto_derive_workspaces: true,
         }
     }
@@ -262,5 +263,10 @@ mod tests {
     fn serialize_default_config() {
         let config = Config::default();
         assert!(ron::to_string(&config).is_ok());
+    }
+
+    #[test]
+    fn dialog_position_is_not_respected_by_default() {
+        assert!(!Config::default().respect_dialog_position);
     }
 }


### PR DESCRIPTION
Use client-requested position and dimensions instead of unconditionally centering dialog-like windows.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

- [ ] Development change (no change visible to user)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation only update (no change to the factual codebase)
- [ ] This change requires a documentation update

## Updated user documentation:

Please insert user documentation that should be updated (as in the wiki).

See [CONTRIBUTING.md User Documentation section](../CONTRIBUTING.md#user-documentation) for further details.

**Note: Manual page changes must be performed in a commit, not in this PR section.**

# Checklist:

- [x] Ran `make test` locally with no errors or warnings reported
  Note: To fully reproduce CI checks, you will need to run `make test-full-nix`. Usually, this is not necessary.
- [ ] Manual page has been updated accordingly
- [ ] Wiki pages have been updated accordingly (to perform **after** merge)
